### PR TITLE
Handle NOOPing on status updates from merged PRs

### DIFF
--- a/src/compute-pr-actions.ts
+++ b/src/compute-pr-actions.ts
@@ -81,7 +81,7 @@ function createEmptyActions(prNumber: number): Actions {
         shouldUpdateLabels: false,
         shouldUpdateProjectColumn: false,
         shouldRemoveFromActiveColumns: false,
-};
+    };
 }
 
 const uriForTestingEditedPackages = "https://github.com/DefinitelyTyped/DefinitelyTyped#editing-tests-on-an-existing-package"

--- a/src/queries/status-to-PR-query.ts
+++ b/src/queries/status-to-PR-query.ts
@@ -21,6 +21,7 @@ export const GetPRForStatusQuery = gql`query GetPRForStatus($query: String!) {
       ... on PullRequest {
         title
         number
+        closed
       }
     }
   }


### PR DESCRIPTION
Travis validates that master is green, which sends status updates to the webhook - we don't need to do work there, so this doesn't raise when we don't need to do work