### PR TITLE
Adds a label for self-merging

### DIFF
--- a/src/_tests/fixtures/43136/result.json
+++ b/src/_tests/fixtures/43136/result.json
@@ -16,7 +16,8 @@
     "Critical package": true,
     "Edits Infrastructure": false,
     "Edits multiple packages": false,
-    "Author is Owner": false
+    "Author is Owner": false,
+    "Merge:Auto": false
   },
   "responseComments": [
     {

--- a/src/_tests/fixtures/43144/mutations.json
+++ b/src/_tests/fixtures/43144/mutations.json
@@ -1,5 +1,16 @@
 [
   {
+    "query": "mutation($input: AddLabelsToLabelableInput!) { addLabelsToLabelable(input: $input) { clientMutationId } }",
+    "variables": {
+      "input": {
+        "labelIds": [
+          "MDU6TGFiZWw2OTcwMTg5NzI="
+        ],
+        "labelableId": "MDExOlB1bGxSZXF1ZXN0Mzg4NDkxOTI2"
+      }
+    }
+  },
+  {
     "query": "mutation($input: AddProjectCardInput!) { addProjectCard(input: $input) { clientMutationId } }",
     "variables": {
       "input": {

--- a/src/_tests/fixtures/43144/result.json
+++ b/src/_tests/fixtures/43144/result.json
@@ -16,7 +16,8 @@
     "Critical package": false,
     "Edits Infrastructure": false,
     "Edits multiple packages": false,
-    "Author is Owner": false
+    "Author is Owner": false,
+    "Merge:Auto": true
   },
   "responseComments": [
     {

--- a/src/_tests/fixtures/43151/result.json
+++ b/src/_tests/fixtures/43151/result.json
@@ -16,7 +16,8 @@
     "Critical package": false,
     "Edits Infrastructure": false,
     "Edits multiple packages": false,
-    "Author is Owner": false
+    "Author is Owner": false,
+    "Merge:Auto": false
   },
   "responseComments": [
     {

--- a/src/_tests/fixtures/43160/result.json
+++ b/src/_tests/fixtures/43160/result.json
@@ -16,7 +16,8 @@
     "Critical package": false,
     "Edits Infrastructure": false,
     "Edits multiple packages": false,
-    "Author is Owner": false
+    "Author is Owner": false,
+    "Merge:Auto": false
   },
   "responseComments": [
     {

--- a/src/_tests/fixtures/43175/result.json
+++ b/src/_tests/fixtures/43175/result.json
@@ -16,7 +16,8 @@
     "Critical package": false,
     "Edits Infrastructure": false,
     "Edits multiple packages": false,
-    "Author is Owner": false
+    "Author is Owner": false,
+    "Merge:Auto": false
   },
   "responseComments": [
     {

--- a/src/_tests/fixtures/43235/result.json
+++ b/src/_tests/fixtures/43235/result.json
@@ -16,7 +16,8 @@
     "Critical package": false,
     "Edits Infrastructure": false,
     "Edits multiple packages": false,
-    "Author is Owner": false
+    "Author is Owner": false,
+    "Merge:Auto": false
   },
   "responseComments": [
     {

--- a/src/_tests/fixtures/43314/result.json
+++ b/src/_tests/fixtures/43314/result.json
@@ -16,7 +16,8 @@
     "Critical package": false,
     "Edits Infrastructure": false,
     "Edits multiple packages": false,
-    "Author is Owner": false
+    "Author is Owner": false,
+    "Merge:Auto": false
   },
   "responseComments": [
     {

--- a/src/_tests/fixtures/43695-duplicate-comment/result.json
+++ b/src/_tests/fixtures/43695-duplicate-comment/result.json
@@ -16,7 +16,8 @@
     "Critical package": false,
     "Edits Infrastructure": false,
     "Edits multiple packages": false,
-    "Author is Owner": false
+    "Author is Owner": false,
+    "Merge:Auto": false
   },
   "responseComments": [
     {

--- a/src/_tests/fixtures/43695-post-review/result.json
+++ b/src/_tests/fixtures/43695-post-review/result.json
@@ -16,7 +16,8 @@
     "Critical package": false,
     "Edits Infrastructure": false,
     "Edits multiple packages": false,
-    "Author is Owner": false
+    "Author is Owner": false,
+    "Merge:Auto": false
   },
   "responseComments": [
     {

--- a/src/_tests/fixtures/43695/result.json
+++ b/src/_tests/fixtures/43695/result.json
@@ -16,7 +16,8 @@
     "Critical package": false,
     "Edits Infrastructure": false,
     "Edits multiple packages": false,
-    "Author is Owner": false
+    "Author is Owner": false,
+    "Merge:Auto": false
   },
   "responseComments": [
     {

--- a/src/_tests/fixtures/43960/result.json
+++ b/src/_tests/fixtures/43960/result.json
@@ -16,7 +16,8 @@
     "Critical package": false,
     "Edits Infrastructure": false,
     "Edits multiple packages": false,
-    "Author is Owner": false
+    "Author is Owner": false,
+    "Merge:Auto": false
   },
   "responseComments": [
     {

--- a/src/_tests/fixtures/44267/result.json
+++ b/src/_tests/fixtures/44267/result.json
@@ -16,7 +16,8 @@
     "Critical package": false,
     "Edits Infrastructure": false,
     "Edits multiple packages": false,
-    "Author is Owner": false
+    "Author is Owner": false,
+    "Merge:Auto": false
   },
   "responseComments": [
     {

--- a/src/_tests/fixtures/44282/result.json
+++ b/src/_tests/fixtures/44282/result.json
@@ -16,7 +16,8 @@
     "Critical package": false,
     "Edits Infrastructure": false,
     "Edits multiple packages": false,
-    "Author is Owner": false
+    "Author is Owner": false,
+    "Merge:Auto": false
   },
   "responseComments": [
     {

--- a/src/_tests/fixtures/44288/result.json
+++ b/src/_tests/fixtures/44288/result.json
@@ -16,7 +16,8 @@
     "Critical package": false,
     "Edits Infrastructure": false,
     "Edits multiple packages": false,
-    "Author is Owner": false
+    "Author is Owner": false,
+    "Merge:Auto": false
   },
   "responseComments": [
     {

--- a/src/_tests/fixtures/44299/result.json
+++ b/src/_tests/fixtures/44299/result.json
@@ -16,7 +16,8 @@
     "Critical package": false,
     "Edits Infrastructure": false,
     "Edits multiple packages": false,
-    "Author is Owner": false
+    "Author is Owner": false,
+    "Merge:Auto": false
   },
   "responseComments": [
     {

--- a/src/_tests/fixtures/44316/result.json
+++ b/src/_tests/fixtures/44316/result.json
@@ -16,7 +16,8 @@
     "Critical package": false,
     "Edits Infrastructure": false,
     "Edits multiple packages": false,
-    "Author is Owner": true
+    "Author is Owner": true,
+    "Merge:Auto": false
   },
   "responseComments": [
     {

--- a/src/_tests/fixtures/44343-pending-travis/result.json
+++ b/src/_tests/fixtures/44343-pending-travis/result.json
@@ -16,7 +16,8 @@
     "Critical package": false,
     "Edits Infrastructure": false,
     "Edits multiple packages": false,
-    "Author is Owner": false
+    "Author is Owner": false,
+    "Merge:Auto": false
   },
   "responseComments": [
     {

--- a/src/_tests/fixtures/44343-pre-travis/result.json
+++ b/src/_tests/fixtures/44343-pre-travis/result.json
@@ -16,7 +16,8 @@
     "Critical package": false,
     "Edits Infrastructure": false,
     "Edits multiple packages": false,
-    "Author is Owner": false
+    "Author is Owner": false,
+    "Merge:Auto": false
   },
   "responseComments": [
     {

--- a/src/_tests/fixtures/44343/result.json
+++ b/src/_tests/fixtures/44343/result.json
@@ -16,7 +16,8 @@
     "Critical package": false,
     "Edits Infrastructure": false,
     "Edits multiple packages": false,
-    "Author is Owner": false
+    "Author is Owner": false,
+    "Merge:Auto": false
   },
   "responseComments": [
     {

--- a/src/_tests/fixtures/44411/result.json
+++ b/src/_tests/fixtures/44411/result.json
@@ -16,7 +16,8 @@
     "Critical package": false,
     "Edits Infrastructure": false,
     "Edits multiple packages": false,
-    "Author is Owner": false
+    "Author is Owner": false,
+    "Merge:Auto": false
   },
   "responseComments": [
     {

--- a/src/_tests/fixtures/44424-1-travis-instantly-finished/result.json
+++ b/src/_tests/fixtures/44424-1-travis-instantly-finished/result.json
@@ -16,7 +16,8 @@
     "Critical package": false,
     "Edits Infrastructure": false,
     "Edits multiple packages": false,
-    "Author is Owner": true
+    "Author is Owner": true,
+    "Merge:Auto": false
   },
   "responseComments": [
     {

--- a/src/_tests/fixtures/44424-2-after-travis-second/result.json
+++ b/src/_tests/fixtures/44424-2-after-travis-second/result.json
@@ -16,7 +16,8 @@
     "Critical package": false,
     "Edits Infrastructure": false,
     "Edits multiple packages": false,
-    "Author is Owner": true
+    "Author is Owner": true,
+    "Merge:Auto": false
   },
   "responseComments": [
     {

--- a/src/compute-pr-actions.ts
+++ b/src/compute-pr-actions.ts
@@ -20,6 +20,7 @@ type LabelName =
     | "Owner Approved"
     | "Other Approved"
     | "Maintainer Approved"
+    | "Merge:Auto"
     | "Merge:LGTM"
     | "Merge:YSYL"
     | "Popular package"
@@ -60,7 +61,8 @@ function createDefaultActions(prNumber: number): Actions {
             "Critical package": false,
             "Edits Infrastructure": false,
             "Edits multiple packages": false,
-            "Author is Owner": false
+            "Author is Owner": false,
+            "Merge:Auto": false
         },
         responseComments: [],
         shouldClose: false,
@@ -118,6 +120,7 @@ export function process(info: PrInfo | BotEnsureRemovedFromProject | BotNoPackag
     context.labels["Maintainer Approved"] = !!(info.approvalFlags & ApprovalFlags.Maintainer);
     context.labels["New Definition"] = info.anyPackageIsNew;
     context.labels["Author is Owner"] = info.authorIsOwner;
+    context.labels["Merge:Auto"] = canBeMergedNow(info);
 
     // Update intro comment
     context.responseComments.push({


### PR DESCRIPTION
This means we'll be able to see which need a poke, and which have been handled post-merge