### PR TITLE
Don't rely on the PR in the check suite webhook

### DIFF
--- a/PR-Trigger/index.js
+++ b/PR-Trigger/index.js
@@ -104,7 +104,7 @@ const httpTrigger = async function (context, _req) {
         
         if (!pr) throw new Error(`Could not get PR for the status on ${sha} - made a search query with ${query}`)
         if (pr.closed) {
-            context.log.info(`Skipped webhook, could not find an open PR for the sha referenced in the status (${webhook.sha})`)
+            context.log.info(`Skipped webhook, could not find an open PR for the sha referenced in the status (${sha})`)
             context.res = {
                 status: 204,
                 body: `NOOPing due to not finding an open PR for the sha ${sha}`

--- a/PR-Trigger/index.js
+++ b/PR-Trigger/index.js
@@ -6,6 +6,7 @@ const {executePrActions} = require("../bin/execute-pr-actions")
 const {mergeCodeOwnersOnGreen} = require("../bin/side-effects/merge-codeowner-prs")
 const verify = require("@octokit/webhooks/verify");
 const sign = require("@octokit/webhooks/sign");
+const {runQueryToGetPRMetadataForStatus} = require("../bin/queries/status-to-PR-query")
 
 /** @type {import("@azure/functions").AzureFunction} */
 const httpTrigger = async function (context, _req) {
@@ -94,6 +95,22 @@ const httpTrigger = async function (context, _req) {
         prNumber = webhook.issue.number
         prTitle = webhook.issue.title
     } else if("check_suite" in webhook) {
+        // See https://github.com/maintainers/early-access-feedback/issues/114 for more context on getting a PR from a SHA
+        // TLDR: it's not in the API, and this search hack has been in used on Peril for the last ~3 years
+        const repoString = webhook.repository.full_name
+        const sha = webhook.check_suite.head_sha
+        const query = `${sha} type:pr  repo:${repoString}` 
+        const pr = await runQueryToGetPRMetadataForStatus(query)
+        
+        if (!pr) throw new Error(`Could not get PR for the status on ${sha} - made a search query with ${query}`)
+        if (pr.closed) {
+            context.log.info(`Skipped webhook, could not find an open PR for the sha referenced in the status (${webhook.sha})`)
+            context.res = {
+                status: 204,
+                body: `NOOPing due to not finding an open PR for the sha ${sha}`
+            }
+        }
+
         prNumber = webhook.check_suite.pull_requests[0].number
         prTitle = "" // this is only used for logging, not worth an API lookup
     }

--- a/src/queries/status-to-PR-query.ts
+++ b/src/queries/status-to-PR-query.ts
@@ -1,0 +1,28 @@
+import { gql } from "apollo-boost";
+import {client} from "../graphql-client"
+import {GetPRForStatus} from "./schema/GetPRForStatus"
+
+export const runQueryToGetPRMetadataForStatus = async (query: string) => {
+  const info = await client.query<GetPRForStatus>({
+      query: GetPRForStatusQuery,
+      variables: { query },
+      fetchPolicy: "network-only",
+      fetchResults: true
+  });
+  const pr = info && info.data && info.data.search.nodes && info.data.search.nodes[0]
+  if (!pr || pr.__typename !== "PullRequest") return undefined
+
+  return pr
+}
+
+export const GetPRForStatusQuery = gql`query GetPRForStatus($query: String!) {
+  search(query: $query, first: 1, type: ISSUE) {
+    nodes {
+      ... on PullRequest {
+        title
+        number
+        closed
+      }
+    }
+  }
+}`;


### PR DESCRIPTION
#95 would have worked... If the pull request was in the webhook, but oddly enough - it isn't. This brings back the sha->PR search query I removed.

![image](https://user-images.githubusercontent.com/49038/83437232-6688e880-a40d-11ea-8779-eb4d82653d7a.png)
