### PR TITLE
Adds `No Other Owners` label when appropriate (& not for new packages)

### DIFF
--- a/src/_tests/fixtures/38979/result.json
+++ b/src/_tests/fixtures/38979/result.json
@@ -17,6 +17,7 @@
     "Edits Infrastructure": false,
     "Edits multiple packages": false,
     "Author is Owner": false,
+    "No Other Owners": false,
     "Merge:Auto": false,
     "Untested Change": false,
     "Config Edit": true

--- a/src/_tests/fixtures/43136/result.json
+++ b/src/_tests/fixtures/43136/result.json
@@ -17,6 +17,7 @@
     "Edits Infrastructure": false,
     "Edits multiple packages": false,
     "Author is Owner": false,
+    "No Other Owners": false,
     "Merge:Auto": false,
     "Untested Change": false,
     "Config Edit": false

--- a/src/_tests/fixtures/43144/result.json
+++ b/src/_tests/fixtures/43144/result.json
@@ -17,6 +17,7 @@
     "Edits Infrastructure": false,
     "Edits multiple packages": false,
     "Author is Owner": false,
+    "No Other Owners": false,
     "Merge:Auto": true,
     "Untested Change": false,
     "Config Edit": false

--- a/src/_tests/fixtures/43151/result.json
+++ b/src/_tests/fixtures/43151/result.json
@@ -17,6 +17,7 @@
     "Edits Infrastructure": false,
     "Edits multiple packages": false,
     "Author is Owner": false,
+    "No Other Owners": false,
     "Merge:Auto": false,
     "Untested Change": false,
     "Config Edit": false

--- a/src/_tests/fixtures/43160/result.json
+++ b/src/_tests/fixtures/43160/result.json
@@ -17,6 +17,7 @@
     "Edits Infrastructure": false,
     "Edits multiple packages": false,
     "Author is Owner": false,
+    "No Other Owners": false,
     "Merge:Auto": false,
     "Untested Change": true,
     "Config Edit": false

--- a/src/_tests/fixtures/43175/result.json
+++ b/src/_tests/fixtures/43175/result.json
@@ -17,6 +17,7 @@
     "Edits Infrastructure": false,
     "Edits multiple packages": false,
     "Author is Owner": false,
+    "No Other Owners": false,
     "Merge:Auto": false,
     "Untested Change": true,
     "Config Edit": false

--- a/src/_tests/fixtures/43235/result.json
+++ b/src/_tests/fixtures/43235/result.json
@@ -17,6 +17,7 @@
     "Edits Infrastructure": false,
     "Edits multiple packages": false,
     "Author is Owner": false,
+    "No Other Owners": false,
     "Merge:Auto": false,
     "Untested Change": false,
     "Config Edit": false

--- a/src/_tests/fixtures/43314/result.json
+++ b/src/_tests/fixtures/43314/result.json
@@ -17,6 +17,7 @@
     "Edits Infrastructure": false,
     "Edits multiple packages": false,
     "Author is Owner": false,
+    "No Other Owners": false,
     "Merge:Auto": false,
     "Untested Change": false,
     "Config Edit": false

--- a/src/_tests/fixtures/43695-duplicate-comment/_response.json
+++ b/src/_tests/fixtures/43695-duplicate-comment/_response.json
@@ -23,6 +23,10 @@
               "__typename": "Label"
             },
             {
+              "name": "No Other Owners",
+              "__typename": "Label"
+            },
+            {
               "name": "Config Edit",
               "__typename": "Label"
             }

--- a/src/_tests/fixtures/43695-duplicate-comment/result.json
+++ b/src/_tests/fixtures/43695-duplicate-comment/result.json
@@ -17,6 +17,7 @@
     "Edits Infrastructure": false,
     "Edits multiple packages": false,
     "Author is Owner": false,
+    "No Other Owners": true,
     "Merge:Auto": false,
     "Untested Change": false,
     "Config Edit": true

--- a/src/_tests/fixtures/43695-post-review/result.json
+++ b/src/_tests/fixtures/43695-post-review/result.json
@@ -17,6 +17,7 @@
     "Edits Infrastructure": false,
     "Edits multiple packages": false,
     "Author is Owner": false,
+    "No Other Owners": false,
     "Merge:Auto": false,
     "Untested Change": false,
     "Config Edit": false

--- a/src/_tests/fixtures/43695/result.json
+++ b/src/_tests/fixtures/43695/result.json
@@ -17,6 +17,7 @@
     "Edits Infrastructure": false,
     "Edits multiple packages": false,
     "Author is Owner": false,
+    "No Other Owners": false,
     "Merge:Auto": false,
     "Untested Change": false,
     "Config Edit": false

--- a/src/_tests/fixtures/43960/_response.json
+++ b/src/_tests/fixtures/43960/_response.json
@@ -30,6 +30,10 @@
             {
               "name": "Revision needed",
               "__typename": "Label"
+            },
+            {
+              "name": "No Other Owners",
+              "__typename": "Label"
             }
           ],
           "__typename": "LabelConnection"

--- a/src/_tests/fixtures/43960/result.json
+++ b/src/_tests/fixtures/43960/result.json
@@ -17,6 +17,7 @@
     "Edits Infrastructure": false,
     "Edits multiple packages": false,
     "Author is Owner": false,
+    "No Other Owners": true,
     "Merge:Auto": false,
     "Untested Change": false,
     "Config Edit": false

--- a/src/_tests/fixtures/44267/result.json
+++ b/src/_tests/fixtures/44267/result.json
@@ -17,6 +17,7 @@
     "Edits Infrastructure": false,
     "Edits multiple packages": false,
     "Author is Owner": false,
+    "No Other Owners": false,
     "Merge:Auto": false,
     "Untested Change": true,
     "Config Edit": false

--- a/src/_tests/fixtures/44282/_response.json
+++ b/src/_tests/fixtures/44282/_response.json
@@ -21,6 +21,10 @@
             {
               "name": "Perf: Same",
               "__typename": "Label"
+            },
+            {
+              "name": "No Other Owners",
+              "__typename": "Label"
             }
           ],
           "__typename": "LabelConnection"

--- a/src/_tests/fixtures/44282/result.json
+++ b/src/_tests/fixtures/44282/result.json
@@ -17,6 +17,7 @@
     "Edits Infrastructure": false,
     "Edits multiple packages": false,
     "Author is Owner": false,
+    "No Other Owners": true,
     "Merge:Auto": false,
     "Untested Change": false,
     "Config Edit": false

--- a/src/_tests/fixtures/44288/result.json
+++ b/src/_tests/fixtures/44288/result.json
@@ -17,6 +17,7 @@
     "Edits Infrastructure": false,
     "Edits multiple packages": false,
     "Author is Owner": false,
+    "No Other Owners": false,
     "Merge:Auto": false,
     "Untested Change": false,
     "Config Edit": false

--- a/src/_tests/fixtures/44299/result.json
+++ b/src/_tests/fixtures/44299/result.json
@@ -17,6 +17,7 @@
     "Edits Infrastructure": false,
     "Edits multiple packages": false,
     "Author is Owner": false,
+    "No Other Owners": false,
     "Merge:Auto": false,
     "Untested Change": false,
     "Config Edit": false

--- a/src/_tests/fixtures/44316/_response.json
+++ b/src/_tests/fixtures/44316/_response.json
@@ -23,6 +23,10 @@
               "__typename": "Label"
             },
             {
+              "name": "No Other Owners",
+              "__typename": "Label"
+            },
+            {
               "name": "Config Edit",
               "__typename": "Label"
             }

--- a/src/_tests/fixtures/44316/result.json
+++ b/src/_tests/fixtures/44316/result.json
@@ -17,6 +17,7 @@
     "Edits Infrastructure": false,
     "Edits multiple packages": false,
     "Author is Owner": true,
+    "No Other Owners": true,
     "Merge:Auto": false,
     "Untested Change": false,
     "Config Edit": true

--- a/src/_tests/fixtures/44343-pending-travis/_response.json
+++ b/src/_tests/fixtures/44343-pending-travis/_response.json
@@ -17,7 +17,11 @@
         "changedFiles": 1,
         "createdAt": "2020-04-29T15:57:10Z",
         "labels": {
-          "nodes": [],
+          "nodes": [
+            {
+              "name": "No Other Owners",
+              "__typename": "Label"
+            }],
           "__typename": "LabelConnection"
         },
         "isDraft": false,

--- a/src/_tests/fixtures/44343-pending-travis/result.json
+++ b/src/_tests/fixtures/44343-pending-travis/result.json
@@ -17,6 +17,7 @@
     "Edits Infrastructure": false,
     "Edits multiple packages": false,
     "Author is Owner": false,
+    "No Other Owners": true,
     "Merge:Auto": false,
     "Untested Change": false,
     "Config Edit": false

--- a/src/_tests/fixtures/44343-pre-travis/_response.json
+++ b/src/_tests/fixtures/44343-pre-travis/_response.json
@@ -17,7 +17,11 @@
         "changedFiles": 1,
         "createdAt": "2020-04-29T15:57:10Z",
         "labels": {
-          "nodes": [],
+          "nodes": [
+            {
+              "name": "No Other Owners",
+              "__typename": "Label"
+            }],
           "__typename": "LabelConnection"
         },
         "isDraft": false,

--- a/src/_tests/fixtures/44343-pre-travis/result.json
+++ b/src/_tests/fixtures/44343-pre-travis/result.json
@@ -17,6 +17,7 @@
     "Edits Infrastructure": false,
     "Edits multiple packages": false,
     "Author is Owner": false,
+    "No Other Owners": true,
     "Merge:Auto": false,
     "Untested Change": false,
     "Config Edit": false

--- a/src/_tests/fixtures/44343/_response.json
+++ b/src/_tests/fixtures/44343/_response.json
@@ -17,7 +17,11 @@
         "changedFiles": 1,
         "createdAt": "2020-04-29T15:57:10Z",
         "labels": {
-          "nodes": [],
+          "nodes": [
+            {
+              "name": "No Other Owners",
+              "__typename": "Label"
+            }],
           "__typename": "LabelConnection"
         },
         "isDraft": false,

--- a/src/_tests/fixtures/44343/result.json
+++ b/src/_tests/fixtures/44343/result.json
@@ -17,6 +17,7 @@
     "Edits Infrastructure": false,
     "Edits multiple packages": false,
     "Author is Owner": false,
+    "No Other Owners": true,
     "Merge:Auto": false,
     "Untested Change": false,
     "Config Edit": false

--- a/src/_tests/fixtures/44411/result.json
+++ b/src/_tests/fixtures/44411/result.json
@@ -17,6 +17,7 @@
     "Edits Infrastructure": false,
     "Edits multiple packages": false,
     "Author is Owner": false,
+    "No Other Owners": false,
     "Merge:Auto": false,
     "Untested Change": false,
     "Config Edit": true

--- a/src/_tests/fixtures/44424-1-travis-instantly-finished/result.json
+++ b/src/_tests/fixtures/44424-1-travis-instantly-finished/result.json
@@ -17,6 +17,7 @@
     "Edits Infrastructure": false,
     "Edits multiple packages": false,
     "Author is Owner": true,
+    "No Other Owners": false,
     "Merge:Auto": false,
     "Untested Change": false,
     "Config Edit": true

--- a/src/_tests/fixtures/44424-2-after-travis-second/result.json
+++ b/src/_tests/fixtures/44424-2-after-travis-second/result.json
@@ -17,6 +17,7 @@
     "Edits Infrastructure": false,
     "Edits multiple packages": false,
     "Author is Owner": true,
+    "No Other Owners": false,
     "Merge:Auto": false,
     "Untested Change": false,
     "Config Edit": true

--- a/src/_tests/fixtures/44437/result.json
+++ b/src/_tests/fixtures/44437/result.json
@@ -17,6 +17,7 @@
     "Edits Infrastructure": false,
     "Edits multiple packages": false,
     "Author is Owner": false,
+    "No Other Owners": false,
     "Merge:Auto": true,
     "Untested Change": false,
     "Config Edit": false

--- a/src/_tests/fixtures/44439/result.json
+++ b/src/_tests/fixtures/44439/result.json
@@ -17,6 +17,7 @@
     "Edits Infrastructure": false,
     "Edits multiple packages": false,
     "Author is Owner": false,
+    "No Other Owners": false,
     "Merge:Auto": false,
     "Untested Change": false,
     "Config Edit": false

--- a/src/_tests/fixtures/44631/result.json
+++ b/src/_tests/fixtures/44631/result.json
@@ -17,6 +17,7 @@
     "Edits Infrastructure": false,
     "Edits multiple packages": false,
     "Author is Owner": false,
+    "No Other Owners": false,
     "Merge:Auto": false,
     "Untested Change": false,
     "Config Edit": false

--- a/src/_tests/fixtures/45137/result.json
+++ b/src/_tests/fixtures/45137/result.json
@@ -17,6 +17,7 @@
     "Edits Infrastructure": false,
     "Edits multiple packages": false,
     "Author is Owner": true,
+    "No Other Owners": false,
     "Merge:Auto": false,
     "Untested Change": true,
     "Config Edit": false


### PR DESCRIPTION
Note that it moves `const otherOwners` higher, so it can be used by the
label code.