### PR TITLE
`.gitignore`: fix and add `coverage`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
-bin/
-node_modules/
+/bin/
+/node_modules/
+/coverage/


### PR DESCRIPTION
(`coverage` is for the generated jest coverage reports.)