### PR TITLE
Move all stale PRs to the maintainer queue

### DIFF
--- a/src/_tests/fixtures/44989-40days/mutations.json
+++ b/src/_tests/fixtures/44989-40days/mutations.json
@@ -11,6 +11,15 @@
     }
   },
   {
+    "query": "mutation($input: MoveProjectCardInput!) { moveProjectCard(input: $input) { clientMutationId } }",
+    "variables": {
+      "input": {
+        "cardId": "MDExOlByb2plY3RDYXJkMzg3NDg0NDE=",
+        "columnId": "MDEzOlByb2plY3RDb2x1bW43NTUyOTIy"
+      }
+    }
+  },
+  {
     "query": "mutation($input: UpdateIssueCommentInput!) { updateIssueComment(input: $input) { clientMutationId } }",
     "variables": {
       "input": {

--- a/src/_tests/fixtures/44989-40days/result.json
+++ b/src/_tests/fixtures/44989-40days/result.json
@@ -1,6 +1,6 @@
 {
   "pr_number": 44989,
-  "targetColumn": "Waiting for Author to Merge",
+  "targetColumn": "Needs Maintainer Review",
   "labels": {
     "Has Merge Conflict": false,
     "The CI failed": false,
@@ -28,10 +28,6 @@
     {
       "tag": "welcome",
       "status": "@petr-motejlek Thank you for submitting this PR!\n\n***This is a live comment which I will keep updated.***\n\n\n## Code Reviews\n\nBecause you edited one package and updated the tests (👏), I can help you merge this PR once someone else signs off on it.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ✅ Most recent commit is approved by type definition owners or DT maintainers\n\nAll of the items on the list are green. **To merge, you need to post a comment including the string \"Ready to merge\"** to bring in your changes.\n\n## Inactive\n\nThis PR has been inactive for 40 days — it is considered abandoned!\n\n----------------------\n<details><summary>Diagnostic Information: What the bot saw about this PR</summary>\n\n```json\n{\n  \"type\": \"info\",\n  \"now\": \"-\",\n  \"pr_number\": 44989,\n  \"author\": \"petr-motejlek\",\n  \"owners\": [\n    \"TheHandsomeCoder\",\n    \"donnut\",\n    \"mdekrey\",\n    \"sbking\",\n    \"afharo\",\n    \"teves-castro\",\n    \"1M0reBug\",\n    \"hojberg\",\n    \"samsonkeung\",\n    \"angeloocana\",\n    \"raynerd\",\n    \"moshensky\",\n    \"ethanresnick\",\n    \"deftomat\",\n    \"blimusiek\",\n    \"biern\",\n    \"rayhaneh\",\n    \"rgm\",\n    \"drewwyatt\",\n    \"jottenlips\",\n    \"minitesh\",\n    \"krantisinh\",\n    \"pirix-gh\",\n    \"brekk\",\n    \"nemo108\",\n    \"jituanlin\",\n    \"Philippe-mills\",\n    \"Saul-Mirone\",\n    \"Nicholaiii\"\n  ],\n  \"dangerLevel\": \"ScopedAndTested\",\n  \"headCommitAbbrOid\": \"9ca6086\",\n  \"headCommitOid\": \"9ca60862ea56c9ff8d6b0f26c28b7e0bdaef4b34\",\n  \"mergeIsRequested\": false,\n  \"stalenessInDays\": 40,\n  \"lastCommitDate\": \"2020-05-23T08:41:39.000Z\",\n  \"lastCommentDate\": \"2020-05-23T08:45:20.000Z\",\n  \"reviewLink\": \"https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44989/files\",\n  \"hasMergeConflict\": false,\n  \"authorIsOwner\": false,\n  \"isFirstContribution\": false,\n  \"popularityLevel\": \"Popular\",\n  \"anyPackageIsNew\": false,\n  \"packages\": [\n    \"ramda\"\n  ],\n  \"files\": [\n    {\n      \"filePath\": \"types/ramda/index.d.ts\",\n      \"kind\": \"definition\",\n      \"package\": \"ramda\"\n    },\n    {\n      \"filePath\": \"types/ramda/test/paths-tests.ts\",\n      \"kind\": \"test\",\n      \"package\": \"ramda\"\n    }\n  ],\n  \"hasDismissedReview\": false,\n  \"ciResult\": \"pass\",\n  \"lastReviewDate\": \"2020-05-23T10:05:48.000Z\",\n  \"reviewersWithStaleReviews\": [],\n  \"approvalFlags\": 2,\n  \"isChangesRequested\": false\n}\n```\n\n</details>"
-    },
-    {
-      "tag": "merge-offer",
-      "status": "@petr-motejlek Everything looks good here. Great job! I am ready to merge this PR on your behalf.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:"
     }
   ],
   "shouldClose": false,

--- a/src/compute-pr-actions.ts
+++ b/src/compute-pr-actions.ts
@@ -189,6 +189,10 @@ export function process(info: PrInfo | BotEnsureRemovedFromProject | BotNoPackag
                 break;
         }
     }
+    // Stale & doesn't need author attention => move to maintainer queue
+    else if (staleness == Staleness.Abandoned) {
+        context.targetColumn = "Needs Maintainer Review";
+    }
     // CI is running; default column is Waiting for Reviewers
     else if (info.ciResult === CIResult.Pending) {
         context.targetColumn = "Waiting for Code Reviews";


### PR DESCRIPTION
Stale & bad PRs are abandoned as usual (= closed), but stale *good* PRs
are moved to the maintainer queue, to decide if they should be merged or
not.