### PR TITLE
Consider only the last review from each author

### DIFF
--- a/src/_tests/fixtures/45836/_downloads.json
+++ b/src/_tests/fixtures/45836/_downloads.json
@@ -1,0 +1,4 @@
+{
+  "prosemirror-commands": 135564,
+  "prosemirror-keymap": 136105
+}

--- a/src/_tests/fixtures/45836/_owners.json
+++ b/src/_tests/fixtures/45836/_owners.json
@@ -1,0 +1,10 @@
+{
+  "allOwners": [
+    "bradleyayers",
+    "davidka",
+    "timjb",
+    "patsimm",
+    "mmorearty"
+  ],
+  "anyPackageIsNew": false
+}

--- a/src/_tests/fixtures/45836/_response.json
+++ b/src/_tests/fixtures/45836/_response.json
@@ -1,0 +1,553 @@
+{
+  "data": {
+    "repository": {
+      "pullRequest": {
+        "id": "MDExOlB1bGxSZXF1ZXN0NDQzMDQ3Njgy",
+        "title": "prosemirror-commands: Add types Command and Keymap",
+        "lastEditedAt": null,
+        "author": {
+          "login": "mmorearty",
+          "__typename": "User"
+        },
+        "authorAssociation": "CONTRIBUTOR",
+        "baseRef": {
+          "name": "master",
+          "__typename": "Ref"
+        },
+        "changedFiles": 3,
+        "createdAt": "2020-07-01T23:08:00Z",
+        "labels": {
+          "nodes": [
+            {
+              "name": "Author is Owner",
+              "__typename": "Label"
+            },
+            {
+              "name": "Edits multiple packages",
+              "__typename": "Label"
+            },
+            {
+              "name": "Owner Approved",
+              "__typename": "Label"
+            },
+            {
+              "name": "Perf: Worse",
+              "__typename": "Label"
+            },
+            {
+              "name": "Revision needed",
+              "__typename": "Label"
+            }
+          ],
+          "__typename": "LabelConnection"
+        },
+        "isDraft": false,
+        "mergeable": "MERGEABLE",
+        "number": 45836,
+        "state": "OPEN",
+        "headRefOid": "6c7735e2b8f39640cb73e40ae04cb6642a8ab2cd",
+        "timelineItems": {
+          "nodes": [
+            {
+              "__typename": "IssueComment",
+              "author": {
+                "login": "typescript-bot",
+                "__typename": "User"
+              },
+              "createdAt": "2020-07-01T23:08:10Z"
+            },
+            {
+              "__typename": "IssueComment",
+              "author": {
+                "login": "typescript-bot",
+                "__typename": "User"
+              },
+              "createdAt": "2020-07-01T23:08:10Z"
+            },
+            {
+              "__typename": "IssueComment",
+              "author": {
+                "login": "mmorearty",
+                "__typename": "User"
+              },
+              "createdAt": "2020-07-01T23:09:38Z"
+            },
+            {
+              "__typename": "MovedColumnsInProjectEvent",
+              "actor": {
+                "login": "typescript-bot",
+                "__typename": "User"
+              },
+              "createdAt": "2020-07-01T23:09:41Z"
+            },
+            {
+              "__typename": "MovedColumnsInProjectEvent",
+              "actor": {
+                "login": "typescript-bot",
+                "__typename": "User"
+              },
+              "createdAt": "2020-07-01T23:11:35Z"
+            },
+            {
+              "__typename": "IssueComment",
+              "author": {
+                "login": "typescript-bot",
+                "__typename": "User"
+              },
+              "createdAt": "2020-07-01T23:18:16Z"
+            },
+            {
+              "__typename": "MovedColumnsInProjectEvent",
+              "actor": {
+                "login": "typescript-bot",
+                "__typename": "User"
+              },
+              "createdAt": "2020-07-02T10:52:03Z"
+            },
+            {
+              "__typename": "IssueComment",
+              "author": {
+                "login": "typescript-bot",
+                "__typename": "User"
+              },
+              "createdAt": "2020-07-02T10:52:04Z"
+            },
+            {
+              "__typename": "IssueComment",
+              "author": {
+                "login": "mmorearty",
+                "__typename": "User"
+              },
+              "createdAt": "2020-07-07T04:57:01Z"
+            },
+            {
+              "__typename": "IssueComment",
+              "author": {
+                "login": "mmorearty",
+                "__typename": "User"
+              },
+              "createdAt": "2020-07-08T17:47:50Z"
+            },
+            {
+              "__typename": "IssueComment",
+              "author": {
+                "login": "mmorearty",
+                "__typename": "User"
+              },
+              "createdAt": "2020-07-08T17:50:50Z"
+            },
+            {
+              "__typename": "IssueComment",
+              "author": {
+                "login": "mmorearty",
+                "__typename": "User"
+              },
+              "createdAt": "2020-07-08T18:10:18Z"
+            },
+            {
+              "__typename": "IssueComment",
+              "author": {
+                "login": "elibarzilay",
+                "__typename": "User"
+              },
+              "createdAt": "2020-07-08T18:13:23Z"
+            }
+          ],
+          "__typename": "PullRequestTimelineItemsConnection"
+        },
+        "reviews": {
+          "nodes": [
+            {
+              "author": {
+                "login": "mmorearty",
+                "__typename": "User"
+              },
+              "commit": {
+                "oid": "6c7735e2b8f39640cb73e40ae04cb6642a8ab2cd",
+                "abbreviatedOid": "6c7735e",
+                "__typename": "Commit"
+              },
+              "comments": {
+                "nodes": [
+                  {
+                    "author": {
+                      "login": "mmorearty",
+                      "__typename": "User"
+                    },
+                    "createdAt": "2020-07-01T23:10:27Z",
+                    "__typename": "PullRequestReviewComment"
+                  }
+                ],
+                "__typename": "PullRequestReviewCommentConnection"
+              },
+              "authorAssociation": "CONTRIBUTOR",
+              "state": "COMMENTED",
+              "submittedAt": "2020-07-01T23:10:27Z",
+              "url": "https://github.com/DefinitelyTyped/DefinitelyTyped/pull/45836#pullrequestreview-441250761",
+              "__typename": "PullRequestReview"
+            },
+            {
+              "author": {
+                "login": "timjb",
+                "__typename": "User"
+              },
+              "commit": {
+                "oid": "6c7735e2b8f39640cb73e40ae04cb6642a8ab2cd",
+                "abbreviatedOid": "6c7735e",
+                "__typename": "Commit"
+              },
+              "comments": {
+                "nodes": [
+                  {
+                    "author": {
+                      "login": "timjb",
+                      "__typename": "User"
+                    },
+                    "createdAt": "2020-07-02T10:29:47Z",
+                    "__typename": "PullRequestReviewComment"
+                  },
+                  {
+                    "author": {
+                      "login": "timjb",
+                      "__typename": "User"
+                    },
+                    "createdAt": "2020-07-02T10:43:59Z",
+                    "__typename": "PullRequestReviewComment"
+                  },
+                  {
+                    "author": {
+                      "login": "timjb",
+                      "__typename": "User"
+                    },
+                    "createdAt": "2020-07-02T10:45:30Z",
+                    "__typename": "PullRequestReviewComment"
+                  },
+                  {
+                    "author": {
+                      "login": "timjb",
+                      "__typename": "User"
+                    },
+                    "createdAt": "2020-07-02T10:45:56Z",
+                    "__typename": "PullRequestReviewComment"
+                  }
+                ],
+                "__typename": "PullRequestReviewCommentConnection"
+              },
+              "authorAssociation": "CONTRIBUTOR",
+              "state": "CHANGES_REQUESTED",
+              "submittedAt": "2020-07-02T10:51:55Z",
+              "url": "https://github.com/DefinitelyTyped/DefinitelyTyped/pull/45836#pullrequestreview-441551874",
+              "__typename": "PullRequestReview"
+            },
+            {
+              "author": {
+                "login": "mmorearty",
+                "__typename": "User"
+              },
+              "commit": {
+                "oid": "6c7735e2b8f39640cb73e40ae04cb6642a8ab2cd",
+                "abbreviatedOid": "6c7735e",
+                "__typename": "Commit"
+              },
+              "comments": {
+                "nodes": [
+                  {
+                    "author": {
+                      "login": "mmorearty",
+                      "__typename": "User"
+                    },
+                    "createdAt": "2020-07-02T16:31:58Z",
+                    "__typename": "PullRequestReviewComment"
+                  }
+                ],
+                "__typename": "PullRequestReviewCommentConnection"
+              },
+              "authorAssociation": "CONTRIBUTOR",
+              "state": "COMMENTED",
+              "submittedAt": "2020-07-02T16:37:37Z",
+              "url": "https://github.com/DefinitelyTyped/DefinitelyTyped/pull/45836#pullrequestreview-441853464",
+              "__typename": "PullRequestReview"
+            },
+            {
+              "author": {
+                "login": "timjb",
+                "__typename": "User"
+              },
+              "commit": {
+                "oid": "6c7735e2b8f39640cb73e40ae04cb6642a8ab2cd",
+                "abbreviatedOid": "6c7735e",
+                "__typename": "Commit"
+              },
+              "comments": {
+                "nodes": [
+                  {
+                    "author": {
+                      "login": "timjb",
+                      "__typename": "User"
+                    },
+                    "createdAt": "2020-07-03T22:30:36Z",
+                    "__typename": "PullRequestReviewComment"
+                  },
+                  {
+                    "author": {
+                      "login": "timjb",
+                      "__typename": "User"
+                    },
+                    "createdAt": "2020-07-03T22:30:43Z",
+                    "__typename": "PullRequestReviewComment"
+                  }
+                ],
+                "__typename": "PullRequestReviewCommentConnection"
+              },
+              "authorAssociation": "CONTRIBUTOR",
+              "state": "APPROVED",
+              "submittedAt": "2020-07-03T22:31:28Z",
+              "url": "https://github.com/DefinitelyTyped/DefinitelyTyped/pull/45836#pullrequestreview-442569775",
+              "__typename": "PullRequestReview"
+            }
+          ],
+          "__typename": "PullRequestReviewConnection"
+        },
+        "commits": {
+          "totalCount": 1,
+          "nodes": [
+            {
+              "commit": {
+                "checkSuites": {
+                  "nodes": [
+                    {
+                      "app": {
+                        "name": "GitHub Actions",
+                        "__typename": "App"
+                      },
+                      "conclusion": "SUCCESS",
+                      "resourcePath": "/DefinitelyTyped/DefinitelyTyped/commit/6c7735e2b8f39640cb73e40ae04cb6642a8ab2cd/checks?check_suite_id=866017431",
+                      "status": "COMPLETED",
+                      "url": "https://github.com/DefinitelyTyped/DefinitelyTyped/commit/6c7735e2b8f39640cb73e40ae04cb6642a8ab2cd/checks?check_suite_id=866017431",
+                      "__typename": "CheckSuite"
+                    },
+                    {
+                      "app": {
+                        "name": "Azure Pipelines",
+                        "__typename": "App"
+                      },
+                      "conclusion": "SUCCESS",
+                      "resourcePath": "/DefinitelyTyped/DefinitelyTyped/commit/6c7735e2b8f39640cb73e40ae04cb6642a8ab2cd/checks?check_suite_id=866018153",
+                      "status": "COMPLETED",
+                      "url": "https://github.com/DefinitelyTyped/DefinitelyTyped/commit/6c7735e2b8f39640cb73e40ae04cb6642a8ab2cd/checks?check_suite_id=866018153",
+                      "__typename": "CheckSuite"
+                    }
+                  ],
+                  "__typename": "CheckSuiteConnection"
+                },
+                "status": null,
+                "authoredDate": "2020-07-01T21:30:35Z",
+                "committedDate": "2020-07-01T23:00:12Z",
+                "pushedDate": "2020-07-01T23:06:38Z",
+                "abbreviatedOid": "6c7735e",
+                "oid": "6c7735e2b8f39640cb73e40ae04cb6642a8ab2cd",
+                "__typename": "Commit"
+              },
+              "__typename": "PullRequestCommit"
+            }
+          ],
+          "__typename": "PullRequestCommitConnection"
+        },
+        "comments": {
+          "totalCount": 10,
+          "nodes": [
+            {
+              "id": "MDEyOklzc3VlQ29tbWVudDY1MjY4ODU2Nw==",
+              "author": {
+                "login": "typescript-bot",
+                "__typename": "User"
+              },
+              "body": "@mmorearty Thank you for submitting this PR!\n\n***This is a live comment which I will keep updated.***\n\n\n## Code Reviews\n\nBecause this PR edits multiple packages, it can be merged once it's reviewed by a DT maintainer.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ Only a DT maintainer can merge changes [without tests](https://github.com/DefinitelyTyped/DefinitelyTyped#editing-tests-on-an-existing-package)\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n----------------------\n<details><summary>Diagnostic Information: What the bot saw about this PR</summary>\n\n```json\n{\n  \"type\": \"info\",\n  \"now\": \"-\",\n  \"pr_number\": 45836,\n  \"author\": \"mmorearty\",\n  \"owners\": [\n    \"bradleyayers\",\n    \"davidka\",\n    \"timjb\",\n    \"patsimm\",\n    \"mmorearty\"\n  ],\n  \"dangerLevel\": \"MultiplePackagesEdited\",\n  \"headCommitAbbrOid\": \"6c7735e\",\n  \"headCommitOid\": \"6c7735e2b8f39640cb73e40ae04cb6642a8ab2cd\",\n  \"mergeIsRequested\": true,\n  \"stalenessInDays\": 0,\n  \"lastCommitDate\": \"2020-07-01T23:06:38.000Z\",\n  \"lastCommentDate\": \"2020-07-08T18:13:23.000Z\",\n  \"maintainerBlessed\": false,\n  \"reviewLink\": \"https://github.com/DefinitelyTyped/DefinitelyTyped/pull/45836/files\",\n  \"hasMergeConflict\": false,\n  \"authorIsOwner\": true,\n  \"isFirstContribution\": false,\n  \"popularityLevel\": \"Well-liked by everyone\",\n  \"anyPackageIsNew\": false,\n  \"packages\": [\n    \"prosemirror-commands\",\n    \"prosemirror-keymap\"\n  ],\n  \"files\": [\n    {\n      \"path\": \"types/prosemirror-commands/index.d.ts\",\n      \"kind\": \"definition\",\n      \"package\": \"prosemirror-commands\"\n    },\n    {\n      \"path\": \"types/prosemirror-commands/prosemirror-commands-tests.ts\",\n      \"kind\": \"test\",\n      \"package\": \"prosemirror-commands\"\n    },\n    {\n      \"path\": \"types/prosemirror-keymap/index.d.ts\",\n      \"kind\": \"definition\",\n      \"package\": \"prosemirror-keymap\"\n    }\n  ],\n  \"hasDismissedReview\": false,\n  \"ciResult\": \"pass\",\n  \"lastReviewDate\": \"2020-07-03T22:31:28.000Z\",\n  \"reviewersWithStaleReviews\": [],\n  \"approvalFlags\": 2,\n  \"isChangesRequested\": true\n}\n```\n\n</details>\n<!--typescript_bot_welcome-->",
+              "createdAt": "2020-07-01T23:08:10Z",
+              "reactions": {
+                "nodes": [],
+                "__typename": "ReactionConnection"
+              },
+              "__typename": "IssueComment"
+            },
+            {
+              "id": "MDEyOklzc3VlQ29tbWVudDY1MjY4ODU3MA==",
+              "author": {
+                "login": "typescript-bot",
+                "__typename": "User"
+              },
+              "body": "🔔 @bradleyayers @davidka @timjb @patsimm - please [review this PR](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/45836/files) in the next few days. Be sure to explicitly select **`Approve`** or **`Request Changes`** in the GitHub UI so I know what's going on.\n<!--typescript_bot_pinging-reviewers-->",
+              "createdAt": "2020-07-01T23:08:10Z",
+              "reactions": {
+                "nodes": [],
+                "__typename": "ReactionConnection"
+              },
+              "__typename": "IssueComment"
+            },
+            {
+              "id": "MDEyOklzc3VlQ29tbWVudDY1MjY4ODk2Nw==",
+              "author": {
+                "login": "mmorearty",
+                "__typename": "User"
+              },
+              "body": "@timjb you actually suggested something like this in a [comment](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44705#discussion_r426287907) on an earlier PR of mine; I didn't do it at that time, but it turns out that now it would be helpful to me!",
+              "createdAt": "2020-07-01T23:09:38Z",
+              "reactions": {
+                "nodes": [],
+                "__typename": "ReactionConnection"
+              },
+              "__typename": "IssueComment"
+            },
+            {
+              "id": "MDEyOklzc3VlQ29tbWVudDY1MjY5MTMwNQ==",
+              "author": {
+                "login": "typescript-bot",
+                "__typename": "User"
+              },
+              "body": "<!-- @dt-perf {\"version\":2,\"data\":{\"overallChange\":1,\"benchmarks\":[{\"createdAt\":\"2020-07-01T23:14:30.873Z\"},{\"createdAt\":\"2020-07-01T23:18:16.070Z\"}]}} -->\n\n👋 **Hi there!** I’ve run some quick measurements against master and your PR. These metrics should help the humans reviewing this PR gauge whether it might negatively affect compile times or editor responsiveness for users who install these typings.\n\n\nLet’s review the numbers, shall we?\n\n### prosemirror-commands/v*\n\n\n|                                                                                           | master                                                                                                                                                        | #45836                                                                                                                                                        | diff               |\n| ----------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ |\n| **Batch compilation**                                                                     |                                                                                                                                                               |                                                                                                                                                               |                    |\n| Memory usage (MiB)                                                                        | 76.3                                                                                                                                                          | 79.4                                                                                                                                                          | +4.0%              |\n| Type count                                                                                | 12324                                                                                                                                                         | 12350                                                                                                                                                         | 0%                 |\n| Assignability cache size                                                                  | 3888                                                                                                                                                          | 3901                                                                                                                                                          | 0%                 |\n|                                                                                           |                                                                                                                                                               |                                                                                                                                                               |                    |\n| **Language service**                                                                      |                                                                                                                                                               |                                                                                                                                                               |                    |\n| Samples taken                                                                             | 16                                                                                                                                                            | 40                                                                                                                                                            | +150%              |\n| Identifiers in tests                                                                      | 16                                                                                                                                                            | 40                                                                                                                                                            | +150%              |\n| **`getCompletionsAtPosition`**                                                            |                                                                                                                                                               |                                                                                                                                                               |                    |\n| &nbsp;&nbsp;&nbsp;&nbsp;Mean duration (ms)                                                | 424.6                                                                                                                                                         | 414.5                                                                                                                                                         | -2.4%              |\n| &nbsp;&nbsp;&nbsp;&nbsp;Mean [CV](https://en.wikipedia.org/wiki/Coefficient_of_variation) | 10.2%                                                                                                                                                         | 14.1%                                                                                                                                                         |                    |\n| &nbsp;&nbsp;&nbsp;&nbsp;Worst duration (ms)                                               | 562.8                                                                                                                                                         | 645.2                                                                                                                                                         | +14.6%             |\n| &nbsp;&nbsp;&nbsp;&nbsp;Worst identifier                                                  | [state](/DefinitelyTyped/DefinitelyTyped/blob/336f38bc44c82cfcd66bd316daa5969609586075/types/prosemirror-commands/prosemirror-commands-tests.ts#L8)           | [commands](/DefinitelyTyped/DefinitelyTyped/blob/735afb8a3fd79acb86485cab87d818977be95fb9/types/prosemirror-commands/prosemirror-commands-tests.ts#L10)       |                    |\n| **`getQuickInfoAtPosition`**                                                              |                                                                                                                                                               |                                                                                                                                                               |                    |\n| &nbsp;&nbsp;&nbsp;&nbsp;Mean duration (ms)                                                | 419.4                                                                                                                                                         | 418.4                                                                                                                                                         | -0.2%              |\n| &nbsp;&nbsp;&nbsp;&nbsp;Mean [CV](https://en.wikipedia.org/wiki/Coefficient_of_variation) | 9.9%                                                                                                                                                          | 12.8%                                                                                                                                                         | +29.2%             |\n| &nbsp;&nbsp;&nbsp;&nbsp;Worst duration (ms)                                               | 565.4                                                                                                                                                         | 734.4                                                                                                                                                         | **+29.9%**&nbsp;🔸 |\n| &nbsp;&nbsp;&nbsp;&nbsp;Worst identifier                                                  | [deleteSelection](/DefinitelyTyped/DefinitelyTyped/blob/336f38bc44c82cfcd66bd316daa5969609586075/types/prosemirror-commands/prosemirror-commands-tests.ts#L8) | [deleteSelection](/DefinitelyTyped/DefinitelyTyped/blob/735afb8a3fd79acb86485cab87d818977be95fb9/types/prosemirror-commands/prosemirror-commands-tests.ts#L8) |                    |\n\n\n\nLooks like there were a couple significant differences—take a look at **worst-case duration for getting quick info at a position** to make sure everything looks ok.\n\n### prosemirror-keymap/v*\n\n\n<details>\n<summary><strong>Comparison details for prosemirror-keymap/*</strong> 📊</summary>\n\n|                                                                                           | master                                                                                                                                           | #45836                                                                                                                                             | diff  |\n| ----------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------- | ----- |\n| **Batch compilation**                                                                     |                                                                                                                                                  |                                                                                                                                                    |       |\n| Memory usage (MiB)                                                                        | 80.2                                                                                                                                             | 80.3                                                                                                                                               | +0.1% |\n| Type count                                                                                | 12223                                                                                                                                            | 12395                                                                                                                                              | +1%   |\n| Assignability cache size                                                                  | 3908                                                                                                                                             | 3907                                                                                                                                               | 0%    |\n|                                                                                           |                                                                                                                                                  |                                                                                                                                                    |       |\n| **Language service**                                                                      |                                                                                                                                                  |                                                                                                                                                    |       |\n| Samples taken                                                                             | 31                                                                                                                                               | 31                                                                                                                                                 | 0%    |\n| Identifiers in tests                                                                      | 31                                                                                                                                               | 31                                                                                                                                                 | 0%    |\n| **`getCompletionsAtPosition`**                                                            |                                                                                                                                                  |                                                                                                                                                    |       |\n| &nbsp;&nbsp;&nbsp;&nbsp;Mean duration (ms)                                                | 434.9                                                                                                                                            | 437.5                                                                                                                                              | +0.6% |\n| &nbsp;&nbsp;&nbsp;&nbsp;Mean [CV](https://en.wikipedia.org/wiki/Coefficient_of_variation) | 11.8%                                                                                                                                            | 13.5%                                                                                                                                              |       |\n| &nbsp;&nbsp;&nbsp;&nbsp;Worst duration (ms)                                               | 587.3                                                                                                                                            | 604.0                                                                                                                                              | +2.8% |\n| &nbsp;&nbsp;&nbsp;&nbsp;Worst identifier                                                  | [tr](/DefinitelyTyped/DefinitelyTyped/blob/336f38bc44c82cfcd66bd316daa5969609586075/types/prosemirror-keymap/prosemirror-keymap-tests.ts#L17)    | [tr](/DefinitelyTyped/DefinitelyTyped/blob/735afb8a3fd79acb86485cab87d818977be95fb9/types/prosemirror-keymap/prosemirror-keymap-tests.ts#L17)      |       |\n| **`getQuickInfoAtPosition`**                                                              |                                                                                                                                                  |                                                                                                                                                    |       |\n| &nbsp;&nbsp;&nbsp;&nbsp;Mean duration (ms)                                                | 489.8                                                                                                                                            | 481.1                                                                                                                                              | -1.8% |\n| &nbsp;&nbsp;&nbsp;&nbsp;Mean [CV](https://en.wikipedia.org/wiki/Coefficient_of_variation) | 13.6%                                                                                                                                            | 13.8%                                                                                                                                              | +1.7% |\n| &nbsp;&nbsp;&nbsp;&nbsp;Worst duration (ms)                                               | 591.7                                                                                                                                            | 606.4                                                                                                                                              | +2.5% |\n| &nbsp;&nbsp;&nbsp;&nbsp;Worst identifier                                                  | [keymap](/DefinitelyTyped/DefinitelyTyped/blob/336f38bc44c82cfcd66bd316daa5969609586075/types/prosemirror-keymap/prosemirror-keymap-tests.ts#L4) | [dispatch](/DefinitelyTyped/DefinitelyTyped/blob/735afb8a3fd79acb86485cab87d818977be95fb9/types/prosemirror-keymap/prosemirror-keymap-tests.ts#L6) |       |\n\n\n</details>\n\nIt looks like nothing changed too much. I won’t post performance data again unless it gets worse.",
+              "createdAt": "2020-07-01T23:18:16Z",
+              "reactions": {
+                "nodes": [],
+                "__typename": "ReactionConnection"
+              },
+              "__typename": "IssueComment"
+            },
+            {
+              "id": "MDEyOklzc3VlQ29tbWVudDY1MjkzNTU1OA==",
+              "author": {
+                "login": "typescript-bot",
+                "__typename": "User"
+              },
+              "body": "@mmorearty One or more reviewers has requested changes. Please address their comments. I'll be back once they sign off or you've pushed new commits or comments. If you disagree with the reviewer's comments, you can \"dismiss\" the review using GitHub's review UI. Thank you!\n<!--typescript_bot_reviewer-complaint-6c7735e-->",
+              "createdAt": "2020-07-02T10:52:04Z",
+              "reactions": {
+                "nodes": [],
+                "__typename": "ReactionConnection"
+              },
+              "__typename": "IssueComment"
+            },
+            {
+              "id": "MDEyOklzc3VlQ29tbWVudDY1NDU5OTc5Mw==",
+              "author": {
+                "login": "mmorearty",
+                "__typename": "User"
+              },
+              "body": "@RyanCavanaugh does the typescript-bot need a nudge? This PR has been approved.",
+              "createdAt": "2020-07-07T04:57:01Z",
+              "reactions": {
+                "nodes": [],
+                "__typename": "ReactionConnection"
+              },
+              "__typename": "IssueComment"
+            },
+            {
+              "id": "MDEyOklzc3VlQ29tbWVudDY1NTY2NDE5NA==",
+              "author": {
+                "login": "mmorearty",
+                "__typename": "User"
+              },
+              "body": "Ready to merge",
+              "createdAt": "2020-07-08T17:47:50Z",
+              "reactions": {
+                "nodes": [],
+                "__typename": "ReactionConnection"
+              },
+              "__typename": "IssueComment"
+            },
+            {
+              "id": "MDEyOklzc3VlQ29tbWVudDY1NTY2NTc3NQ==",
+              "author": {
+                "login": "mmorearty",
+                "__typename": "User"
+              },
+              "body": "Argh, how do I get this PR un-stuck? It still has a \"Revision needed\" label.",
+              "createdAt": "2020-07-08T17:50:50Z",
+              "reactions": {
+                "nodes": [],
+                "__typename": "ReactionConnection"
+              },
+              "__typename": "IssueComment"
+            },
+            {
+              "id": "MDEyOklzc3VlQ29tbWVudDY1NTY3NDkwOA==",
+              "author": {
+                "login": "mmorearty",
+                "__typename": "User"
+              },
+              "body": "Regarding this PR being stuck, Ryan Cavanaugh [says](https://twitter.com/SeaRyanC/status/1280924907921010688): \"Thanks for the ping; I've passed this on to the engineers working on the DT automation this week\"",
+              "createdAt": "2020-07-08T18:10:18Z",
+              "reactions": {
+                "nodes": [],
+                "__typename": "ReactionConnection"
+              },
+              "__typename": "IssueComment"
+            },
+            {
+              "id": "MDEyOklzc3VlQ29tbWVudDY1NTY3NjM1Mg==",
+              "author": {
+                "login": "elibarzilay",
+                "__typename": "User"
+              },
+              "body": "(If anyone sees this, please don't merge, so I can catch the bug...)",
+              "createdAt": "2020-07-08T18:13:23Z",
+              "reactions": {
+                "nodes": [],
+                "__typename": "ReactionConnection"
+              },
+              "__typename": "IssueComment"
+            }
+          ],
+          "__typename": "IssueCommentConnection"
+        },
+        "files": {
+          "nodes": [
+            {
+              "path": "types/prosemirror-commands/index.d.ts",
+              "additions": 17,
+              "deletions": 4,
+              "__typename": "PullRequestChangedFile"
+            },
+            {
+              "path": "types/prosemirror-commands/prosemirror-commands-tests.ts",
+              "additions": 10,
+              "deletions": 0,
+              "__typename": "PullRequestChangedFile"
+            },
+            {
+              "path": "types/prosemirror-keymap/index.d.ts",
+              "additions": 7,
+              "deletions": 16,
+              "__typename": "PullRequestChangedFile"
+            }
+          ],
+          "__typename": "PullRequestChangedFileConnection"
+        },
+        "projectCards": {
+          "nodes": [
+            {
+              "id": "MDExOlByb2plY3RDYXJkNDExMTI5NzY=",
+              "project": {
+                "id": "MDc6UHJvamVjdDM3NDExMDQ=",
+                "number": 5,
+                "name": "New Pull Request Status Board",
+                "__typename": "Project"
+              },
+              "column": {
+                "id": "MDEzOlByb2plY3RDb2x1bW43NTUyOTI0",
+                "name": "Needs Author Action",
+                "__typename": "ProjectColumn"
+              },
+              "__typename": "ProjectCard"
+            }
+          ],
+          "__typename": "ProjectCardConnection"
+        },
+        "__typename": "PullRequest"
+      },
+      "__typename": "Repository"
+    }
+  },
+  "loading": false,
+  "networkStatus": 7,
+  "stale": false
+}

--- a/src/_tests/fixtures/45836/derived.json
+++ b/src/_tests/fixtures/45836/derived.json
@@ -1,0 +1,54 @@
+{
+  "type": "info",
+  "now": "2020-07-08T18:57:14.868Z",
+  "pr_number": 45836,
+  "author": "mmorearty",
+  "owners": [
+    "bradleyayers",
+    "davidka",
+    "timjb",
+    "patsimm",
+    "mmorearty"
+  ],
+  "dangerLevel": "MultiplePackagesEdited",
+  "headCommitAbbrOid": "6c7735e",
+  "headCommitOid": "6c7735e2b8f39640cb73e40ae04cb6642a8ab2cd",
+  "mergeIsRequested": true,
+  "stalenessInDays": 0,
+  "lastCommitDate": "2020-07-01T23:06:38.000Z",
+  "lastCommentDate": "2020-07-08T18:13:23.000Z",
+  "maintainerBlessed": false,
+  "reviewLink": "https://github.com/DefinitelyTyped/DefinitelyTyped/pull/45836/files",
+  "hasMergeConflict": false,
+  "authorIsOwner": true,
+  "isFirstContribution": false,
+  "popularityLevel": "Well-liked by everyone",
+  "anyPackageIsNew": false,
+  "packages": [
+    "prosemirror-commands",
+    "prosemirror-keymap"
+  ],
+  "files": [
+    {
+      "filePath": "types/prosemirror-commands/index.d.ts",
+      "kind": "definition",
+      "package": "prosemirror-commands"
+    },
+    {
+      "filePath": "types/prosemirror-commands/prosemirror-commands-tests.ts",
+      "kind": "test",
+      "package": "prosemirror-commands"
+    },
+    {
+      "filePath": "types/prosemirror-keymap/index.d.ts",
+      "kind": "definition",
+      "package": "prosemirror-keymap"
+    }
+  ],
+  "hasDismissedReview": false,
+  "ciResult": "pass",
+  "lastReviewDate": "2020-07-03T22:31:28.000Z",
+  "reviewersWithStaleReviews": [],
+  "approvalFlags": 2,
+  "isChangesRequested": false
+}

--- a/src/_tests/fixtures/45836/mutations.json
+++ b/src/_tests/fixtures/45836/mutations.json
@@ -1,0 +1,31 @@
+[
+  {
+    "query": "mutation($input: RemoveLabelsFromLabelableInput!) { removeLabelsFromLabelable(input: $input) { clientMutationId } }",
+    "variables": {
+      "input": {
+        "labelIds": [
+          "MDU6TGFiZWwzOTU2NzkwNTk="
+        ],
+        "labelableId": "MDExOlB1bGxSZXF1ZXN0NDQzMDQ3Njgy"
+      }
+    }
+  },
+  {
+    "query": "mutation($input: MoveProjectCardInput!) { moveProjectCard(input: $input) { clientMutationId } }",
+    "variables": {
+      "input": {
+        "cardId": "MDExOlByb2plY3RDYXJkNDExMTI5NzY=",
+        "columnId": "MDEzOlByb2plY3RDb2x1bW43NTUyOTIy"
+      }
+    }
+  },
+  {
+    "query": "mutation($input: UpdateIssueCommentInput!) { updateIssueComment(input: $input) { clientMutationId } }",
+    "variables": {
+      "input": {
+        "id": "MDEyOklzc3VlQ29tbWVudDY1MjY4ODU2Nw==",
+        "body": "@mmorearty Thank you for submitting this PR!\n\n***This is a live comment which I will keep updated.***\n\n\n## Code Reviews\n\nBecause this PR edits multiple packages, it can be merged once it's reviewed by a DT maintainer.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ Only a DT maintainer can merge changes [without tests](https://github.com/DefinitelyTyped/DefinitelyTyped#editing-tests-on-an-existing-package)\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n----------------------\n<details><summary>Diagnostic Information: What the bot saw about this PR</summary>\n\n```json\n{\n  \"type\": \"info\",\n  \"now\": \"-\",\n  \"pr_number\": 45836,\n  \"author\": \"mmorearty\",\n  \"owners\": [\n    \"bradleyayers\",\n    \"davidka\",\n    \"timjb\",\n    \"patsimm\",\n    \"mmorearty\"\n  ],\n  \"dangerLevel\": \"MultiplePackagesEdited\",\n  \"headCommitAbbrOid\": \"6c7735e\",\n  \"headCommitOid\": \"6c7735e2b8f39640cb73e40ae04cb6642a8ab2cd\",\n  \"mergeIsRequested\": true,\n  \"stalenessInDays\": 0,\n  \"lastCommitDate\": \"2020-07-01T23:06:38.000Z\",\n  \"lastCommentDate\": \"2020-07-08T18:13:23.000Z\",\n  \"maintainerBlessed\": false,\n  \"reviewLink\": \"https://github.com/DefinitelyTyped/DefinitelyTyped/pull/45836/files\",\n  \"hasMergeConflict\": false,\n  \"authorIsOwner\": true,\n  \"isFirstContribution\": false,\n  \"popularityLevel\": \"Well-liked by everyone\",\n  \"anyPackageIsNew\": false,\n  \"packages\": [\n    \"prosemirror-commands\",\n    \"prosemirror-keymap\"\n  ],\n  \"files\": [\n    {\n      \"filePath\": \"types/prosemirror-commands/index.d.ts\",\n      \"kind\": \"definition\",\n      \"package\": \"prosemirror-commands\"\n    },\n    {\n      \"filePath\": \"types/prosemirror-commands/prosemirror-commands-tests.ts\",\n      \"kind\": \"test\",\n      \"package\": \"prosemirror-commands\"\n    },\n    {\n      \"filePath\": \"types/prosemirror-keymap/index.d.ts\",\n      \"kind\": \"definition\",\n      \"package\": \"prosemirror-keymap\"\n    }\n  ],\n  \"hasDismissedReview\": false,\n  \"ciResult\": \"pass\",\n  \"lastReviewDate\": \"2020-07-03T22:31:28.000Z\",\n  \"reviewersWithStaleReviews\": [],\n  \"approvalFlags\": 2,\n  \"isChangesRequested\": false\n}\n```\n\n</details>\n<!--typescript_bot_welcome-->"
+      }
+    }
+  }
+]

--- a/src/_tests/fixtures/45836/result.json
+++ b/src/_tests/fixtures/45836/result.json
@@ -1,0 +1,39 @@
+{
+  "pr_number": 45836,
+  "targetColumn": "Needs Maintainer Review",
+  "labels": {
+    "Has Merge Conflict": false,
+    "The CI failed": false,
+    "Revision needed": false,
+    "New Definition": false,
+    "Where is GH Actions?": false,
+    "Owner Approved": true,
+    "Other Approved": false,
+    "Maintainer Approved": false,
+    "Merge:LGTM": false,
+    "Merge:YSYL": false,
+    "Popular package": false,
+    "Critical package": false,
+    "Edits Infrastructure": false,
+    "Edits multiple packages": true,
+    "Author is Owner": true,
+    "No Other Owners": false,
+    "Too Many Owners": false,
+    "Merge:Auto": false,
+    "Untested Change": false,
+    "Config Edit": false,
+    "Abandoned": false
+  },
+  "responseComments": [
+    {
+      "tag": "welcome",
+      "status": "@mmorearty Thank you for submitting this PR!\n\n***This is a live comment which I will keep updated.***\n\n\n## Code Reviews\n\nBecause this PR edits multiple packages, it can be merged once it's reviewed by a DT maintainer.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ Only a DT maintainer can merge changes [without tests](https://github.com/DefinitelyTyped/DefinitelyTyped#editing-tests-on-an-existing-package)\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n----------------------\n<details><summary>Diagnostic Information: What the bot saw about this PR</summary>\n\n```json\n{\n  \"type\": \"info\",\n  \"now\": \"-\",\n  \"pr_number\": 45836,\n  \"author\": \"mmorearty\",\n  \"owners\": [\n    \"bradleyayers\",\n    \"davidka\",\n    \"timjb\",\n    \"patsimm\",\n    \"mmorearty\"\n  ],\n  \"dangerLevel\": \"MultiplePackagesEdited\",\n  \"headCommitAbbrOid\": \"6c7735e\",\n  \"headCommitOid\": \"6c7735e2b8f39640cb73e40ae04cb6642a8ab2cd\",\n  \"mergeIsRequested\": true,\n  \"stalenessInDays\": 0,\n  \"lastCommitDate\": \"2020-07-01T23:06:38.000Z\",\n  \"lastCommentDate\": \"2020-07-08T18:13:23.000Z\",\n  \"maintainerBlessed\": false,\n  \"reviewLink\": \"https://github.com/DefinitelyTyped/DefinitelyTyped/pull/45836/files\",\n  \"hasMergeConflict\": false,\n  \"authorIsOwner\": true,\n  \"isFirstContribution\": false,\n  \"popularityLevel\": \"Well-liked by everyone\",\n  \"anyPackageIsNew\": false,\n  \"packages\": [\n    \"prosemirror-commands\",\n    \"prosemirror-keymap\"\n  ],\n  \"files\": [\n    {\n      \"filePath\": \"types/prosemirror-commands/index.d.ts\",\n      \"kind\": \"definition\",\n      \"package\": \"prosemirror-commands\"\n    },\n    {\n      \"filePath\": \"types/prosemirror-commands/prosemirror-commands-tests.ts\",\n      \"kind\": \"test\",\n      \"package\": \"prosemirror-commands\"\n    },\n    {\n      \"filePath\": \"types/prosemirror-keymap/index.d.ts\",\n      \"kind\": \"definition\",\n      \"package\": \"prosemirror-keymap\"\n    }\n  ],\n  \"hasDismissedReview\": false,\n  \"ciResult\": \"pass\",\n  \"lastReviewDate\": \"2020-07-03T22:31:28.000Z\",\n  \"reviewersWithStaleReviews\": [],\n  \"approvalFlags\": 2,\n  \"isChangesRequested\": false\n}\n```\n\n</details>"
+    }
+  ],
+  "shouldClose": false,
+  "shouldMerge": false,
+  "shouldUpdateLabels": true,
+  "shouldUpdateProjectColumn": true,
+  "shouldRemoveFromActiveColumns": false,
+  "isReadyForAutoMerge": false
+}


### PR DESCRIPTION
The code was already ignoring stale reviews for a different
`headRefOid`, but it might be that a second review approves a request
without changes, so the first review for the same author should be
ignored even if it's the same headref.

(Note that the test case still doesn't want to merge it, because the PR
also edited multiple packages.)