### PR TITLE
Add the ability to fetch meta files and test them

### DIFF
--- a/src/_tests/fixtures/44299-with-files/_downloads.json
+++ b/src/_tests/fixtures/44299-with-files/_downloads.json
@@ -1,0 +1,3 @@
+{
+  "hcaptcha__vue-hcaptcha": 0
+}

--- a/src/_tests/fixtures/44299-with-files/_files.json
+++ b/src/_tests/fixtures/44299-with-files/_files.json
@@ -1,0 +1,3 @@
+{
+  "683fb3b1298223256be3a49823686f35bd94a730:types/hcaptcha__vue-hcaptcha/tslint.json": "{\n  \"extends\": \"dtslint/dt.json\"\n}\n"
+}

--- a/src/_tests/fixtures/44299-with-files/_response.json
+++ b/src/_tests/fixtures/44299-with-files/_response.json
@@ -1,0 +1,297 @@
+{
+  "data": {
+    "repository": {
+      "pullRequest": {
+        "id": "MDExOlB1bGxSZXF1ZXN0NDEwMjE2Nzgz",
+        "title": "Add types for hcaptcha__vue-hcaptcha",
+        "lastEditedAt": "2020-04-29T03:48:45Z",
+        "author": {
+          "login": "geopic",
+          "__typename": "User"
+        },
+        "authorAssociation": "FIRST_TIME_CONTRIBUTOR",
+        "baseRef": {
+          "name": "master",
+          "__typename": "Ref"
+        },
+        "changedFiles": 5,
+        "createdAt": "2020-04-28T16:08:24Z",
+        "labels": {
+          "nodes": [
+            {
+              "name": "New Definition",
+              "__typename": "Label"
+            }
+          ],
+          "__typename": "LabelConnection"
+        },
+        "isDraft": false,
+        "mergeable": "UNKNOWN",
+        "number": 44299,
+        "state": "OPEN",
+        "headRefOid": "683fb3b1298223256be3a49823686f35bd94a730",
+        "timelineItems": {
+          "nodes": [
+            {
+              "__typename": "IssueComment"
+            },
+            {
+              "__typename": "IssueComment"
+            },
+            {
+              "__typename": "IssueComment"
+            },
+            {
+              "__typename": "IssueComment"
+            },
+            {
+              "__typename": "IssueComment"
+            },
+            {
+              "__typename": "IssueComment"
+            },
+            {
+              "__typename": "IssueComment"
+            },
+            {
+              "__typename": "PullRequestCommit",
+              "commit": {
+                "oid": "683fb3b1298223256be3a49823686f35bd94a730",
+                "__typename": "Commit"
+              }
+            }
+          ],
+          "__typename": "PullRequestTimelineItemsConnection"
+        },
+        "reviews": {
+          "nodes": [],
+          "__typename": "PullRequestReviewConnection"
+        },
+        "commits": {
+          "totalCount": 1,
+          "nodes": [
+            {
+              "commit": {
+                "checkSuites": {
+                  "nodes": [
+                    {
+                      "app": {
+                        "name": "Azure Pipelines",
+                        "__typename": "App"
+                      },
+                      "conclusion": "SUCCESS",
+                      "resourcePath": "/DefinitelyTyped/DefinitelyTyped/commit/683fb3b1298223256be3a49823686f35bd94a730/checks?check_suite_id=638535702",
+                      "status": "COMPLETED",
+                      "url": "https://github.com/DefinitelyTyped/DefinitelyTyped/commit/683fb3b1298223256be3a49823686f35bd94a730/checks?check_suite_id=638535702",
+                      "__typename": "CheckSuite"
+                    },
+                    {
+                      "app": {
+                        "name": "GitHub Actions",
+                        "__typename": "App"
+                      },
+                      "conclusion": "SUCCESS",
+                      "resourcePath": "/DefinitelyTyped/DefinitelyTyped/commit/22c73c88cc9c09efd4c2998ec360607dd4c36c2e/checks?check_suite_id=731664306",
+                      "status": "SUCCESS",
+                      "url": "https://github.com/DefinitelyTyped/DefinitelyTyped/commit/22c73c88cc9c09efd4c2998ec360607dd4c36c2e/checks?check_suite_id=731664306",
+                      "__typename": "CheckSuite"
+                    }
+                  ],
+                  "__typename": "CheckSuiteConnection"
+                },
+                "status": {
+                  "state": "SUCCESS",
+                  "contexts": [
+                    {
+                      "state": "SUCCESS",
+                      "description": "The Travis CI build passed",
+                      "creator": {
+                        "login": "johnnyreilly",
+                        "__typename": "User"
+                      },
+                      "targetUrl": "https://travis-ci.org/github/DefinitelyTyped/DefinitelyTyped/builds/680953798?utm_source=github_status&utm_medium=notification",
+                      "__typename": "StatusContext"
+                    }
+                  ],
+                  "__typename": "Status"
+                },
+                "authoredDate": "2020-04-28T16:07:43Z",
+                "committedDate": "2020-04-29T10:58:34Z",
+                "pushedDate": "2020-04-29T10:57:59Z",
+                "abbreviatedOid": "683fb3b",
+                "oid": "683fb3b1298223256be3a49823686f35bd94a730",
+                "__typename": "Commit"
+              },
+              "__typename": "PullRequestCommit"
+            }
+          ],
+          "__typename": "PullRequestCommitConnection"
+        },
+        "comments": {
+          "totalCount": 7,
+          "nodes": [
+            {
+              "id": "MDEyOklzc3VlQ29tbWVudDYyMDcwMjk5OQ==",
+              "author": {
+                "login": "typescript-bot",
+                "__typename": "User"
+              },
+              "body": "@geopic Thank you for submitting this PR!  I see this is your first time submitting to DefinitelyTyped 👋 - keep an eye on this comment as I'll be updating it with information as things progress.\n\n\n## Code Reviews\n\nThis PR adds a new definition, so it needs to be reviewed by a DT maintainer before it can be merged.\n\n- [hcaptcha__vue-hcaptcha](https://www.npmjs.com/package/hcaptcha__vue-hcaptcha)\n\n\n## Status\n\n * ✅ No merge conflicts\n * ❌ Continuous integration tests have passed\n * ❌ Only a DT maintainer can merge changes when there are new packages added\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n----------------------\n... diagnostics scrubbed ...\n<!--typescript_bot_welcome-->",
+              "createdAt": "2020-04-28T16:08:30Z",
+              "reactions": {
+                "nodes": [],
+                "__typename": "ReactionConnection"
+              },
+              "__typename": "IssueComment"
+            },
+            {
+              "id": "MDEyOklzc3VlQ29tbWVudDYyMDcwNTM4NA==",
+              "author": {
+                "login": "typescript-bot",
+                "__typename": "User"
+              },
+              "body": "<!-- @dt-perf {\"version\":2,\"data\":{\"benchmarks\":[{\"createdAt\":\"2020-04-28T16:12:22.801Z\"}]}} -->\n\n👋 **Hi there!** I’ve run some quick measurements against master and your PR. These metrics should help the humans reviewing this PR gauge whether it might negatively affect compile times or editor responsiveness for users who install these typings.\n\n\nLet’s review the numbers, shall we?\n\nThese typings are for a package that doesn’t yet exist on master, so I don’t have anything to compare against yet! In the future, I’ll be able to compare PRs to hcaptcha__vue-hcaptcha with its source on master.\n\n\n<details>\n<summary><strong>Comparison details</strong> 📊</summary>\n\n| **Batch compilation**                                                                     |                                                                                                                                                            |\n| ----------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |\n| Type count                                                                                | 10861                                                                                                                                                      |\n| Assignability cache size                                                                  | 34615                                                                                                                                                      |\n|                                                                                           |                                                                                                                                                            |\n| **Language service measurements**                                                         |                                                                                                                                                            |\n| Samples taken                                                                             | 5                                                                                                                                                          |\n| Identifiers in tests                                                                      | 5                                                                                                                                                          |\n| **`getCompletionsAtPosition`**                                                            |                                                                                                                                                            |\n| &nbsp;&nbsp;&nbsp;&nbsp;Mean duration (ms)                                                | 367.2                                                                                                                                                      |\n| &nbsp;&nbsp;&nbsp;&nbsp;Mean [CV](https://en.wikipedia.org/wiki/Coefficient_of_variation) | 14.0%                                                                                                                                                      |\n| &nbsp;&nbsp;&nbsp;&nbsp;Worst duration (ms)                                               | 421.3                                                                                                                                                      |\n| &nbsp;&nbsp;&nbsp;&nbsp;Worst identifier                                                  | [HCaptcha](/DefinitelyTyped/DefinitelyTyped/blob/049eb546453f9af959b75c5b07f68cea5b3d8b35/types/hcaptcha__vue-hcaptcha/hcaptcha__vue-hcaptcha-tests.ts#L4) |\n| **`getQuickInfoAtPosition`**                                                              |                                                                                                                                                            |\n| &nbsp;&nbsp;&nbsp;&nbsp;Mean duration (ms)                                                | 358.7                                                                                                                                                      |\n| &nbsp;&nbsp;&nbsp;&nbsp;Mean [CV](https://en.wikipedia.org/wiki/Coefficient_of_variation) | 15.9%                                                                                                                                                      |\n| &nbsp;&nbsp;&nbsp;&nbsp;Worst duration (ms)                                               | 384.3                                                                                                                                                      |\n| &nbsp;&nbsp;&nbsp;&nbsp;Worst identifier                                                  | [HCaptcha](/DefinitelyTyped/DefinitelyTyped/blob/049eb546453f9af959b75c5b07f68cea5b3d8b35/types/hcaptcha__vue-hcaptcha/hcaptcha__vue-hcaptcha-tests.ts#L4) |\n|                                                                                           |                                                                                                                                                            |\n| **System information**                                                                    |                                                                                                                                                            |\n| Node version                                                                              | v12.16.1                                                                                                                                                   |\n| CPU count                                                                                 | 2                                                                                                                                                          |\n| CPU speed                                                                                 | 2.397 GHz                                                                                                                                                  |\n| CPU model                                                                                 | Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz                                                                                                                  |\n| CPU Architecture                                                                          | x64                                                                                                                                                        |\n| Memory                                                                                    | 6.8 GiB                                                                                                                                                    |\n| Platform                                                                                  | linux                                                                                                                                                      |\n| Release                                                                                   | 4.15.0-1077-azure                                                                                                                                          |\n\n\n</details>\n",
+              "createdAt": "2020-04-28T16:12:24Z",
+              "reactions": {
+                "nodes": [],
+                "__typename": "ReactionConnection"
+              },
+              "__typename": "IssueComment"
+            },
+            {
+              "id": "MDEyOklzc3VlQ29tbWVudDYyMDk3NDc1NA==",
+              "author": {
+                "login": "typescript-bot",
+                "__typename": "User"
+              },
+              "body": "@geopic The Travis CI build failed! Please [review the logs for more information](https://github.com/DefinitelyTyped/DefinitelyTyped/commit/f3b29741af4a674ab5e3f82a9c45347b3fb2797a/checks?check_suite_id=636061669).\r\n\r\nOnce you've pushed the fixes, the build will automatically re-run. Thanks!\n<!--typescript_bot_travis-complaint-f3b2974-->",
+              "createdAt": "2020-04-29T03:48:48Z",
+              "reactions": {
+                "nodes": [],
+                "__typename": "ReactionConnection"
+              },
+              "__typename": "IssueComment"
+            },
+            {
+              "id": "MDEyOklzc3VlQ29tbWVudDYyMTExNTE0Ng==",
+              "author": {
+                "login": "typescript-bot",
+                "__typename": "User"
+              },
+              "body": "@geopic The Travis CI build failed! Please [review the logs for more information](https://travis-ci.org/github/DefinitelyTyped/DefinitelyTyped/builds/680945008?utm_source=github_status&utm_medium=notification).\r\n\r\nOnce you've pushed the fixes, the build will automatically re-run. Thanks!\n<!--typescript_bot_travis-complaint-83c2a63-->",
+              "createdAt": "2020-04-29T10:26:42Z",
+              "reactions": {
+                "nodes": [],
+                "__typename": "ReactionConnection"
+              },
+              "__typename": "IssueComment"
+            },
+            {
+              "id": "MDEyOklzc3VlQ29tbWVudDYyMTExODgzNQ==",
+              "author": {
+                "login": "typescript-bot",
+                "__typename": "User"
+              },
+              "body": "@geopic The Travis CI build failed! Please [review the logs for more information](https://travis-ci.org/github/DefinitelyTyped/DefinitelyTyped/builds/680947420?utm_source=github_status&utm_medium=notification).\r\n\r\nOnce you've pushed the fixes, the build will automatically re-run. Thanks!\n<!--typescript_bot_travis-complaint-1e61cc0-->",
+              "createdAt": "2020-04-29T10:35:38Z",
+              "reactions": {
+                "nodes": [],
+                "__typename": "ReactionConnection"
+              },
+              "__typename": "IssueComment"
+            },
+            {
+              "id": "MDEyOklzc3VlQ29tbWVudDYyMTEyNDIyMw==",
+              "author": {
+                "login": "typescript-bot",
+                "__typename": "User"
+              },
+              "body": "@geopic The Travis CI build failed! Please [review the logs for more information](https://travis-ci.org/github/DefinitelyTyped/DefinitelyTyped/builds/680951042?utm_source=github_status&utm_medium=notification).\r\n\r\nOnce you've pushed the fixes, the build will automatically re-run. Thanks!\n<!--typescript_bot_travis-complaint-9ff1f9f-->",
+              "createdAt": "2020-04-29T10:48:57Z",
+              "reactions": {
+                "nodes": [],
+                "__typename": "ReactionConnection"
+              },
+              "__typename": "IssueComment"
+            },
+            {
+              "id": "MDEyOklzc3VlQ29tbWVudDYyMTEyODE3MA==",
+              "author": {
+                "login": "typescript-bot",
+                "__typename": "User"
+              },
+              "body": "@geopic The Travis CI build failed! Please [review the logs for more information](https://travis-ci.org/github/DefinitelyTyped/DefinitelyTyped/builds/680953798?utm_source=github_status&utm_medium=notification).\r\n\r\nOnce you've pushed the fixes, the build will automatically re-run. Thanks!\n<!--typescript_bot_travis-complaint-683fb3b-->",
+              "createdAt": "2020-04-29T10:58:12Z",
+              "reactions": {
+                "nodes": [],
+                "__typename": "ReactionConnection"
+              },
+              "__typename": "IssueComment"
+            }
+          ],
+          "__typename": "IssueCommentConnection"
+        },
+        "files": {
+          "nodes": [
+            {
+              "path": "types/hcaptcha__vue-hcaptcha/hcaptcha__vue-hcaptcha-tests.ts",
+              "additions": 9,
+              "deletions": 0,
+              "__typename": "PullRequestChangedFile"
+            },
+            {
+              "path": "types/hcaptcha__vue-hcaptcha/index.d.ts",
+              "additions": 31,
+              "deletions": 0,
+              "__typename": "PullRequestChangedFile"
+            },
+            {
+              "path": "types/hcaptcha__vue-hcaptcha/package.json",
+              "additions": 6,
+              "deletions": 0,
+              "__typename": "PullRequestChangedFile"
+            },
+            {
+              "path": "types/hcaptcha__vue-hcaptcha/tsconfig.json",
+              "additions": 32,
+              "deletions": 0,
+              "__typename": "PullRequestChangedFile"
+            },
+            {
+              "path": "types/hcaptcha__vue-hcaptcha/tslint.json",
+              "additions": 3,
+              "deletions": 0,
+              "__typename": "PullRequestChangedFile"
+            }
+          ],
+          "__typename": "PullRequestChangedFileConnection"
+        },
+        "projectCards": {
+          "nodes": [
+            {
+              "id": "MDExOlByb2plY3RDYXJkMzcxODExMTU=",
+              "project": {
+                "id": "MDc6UHJvamVjdDM3NDExMDQ=",
+                "number": 5,
+                "name": "New Pull Request Status Board",
+                "__typename": "Project"
+              },
+              "column": {
+                "id": "MDEzOlByb2plY3RDb2x1bW43NTUyOTMw",
+                "name": "Waiting for Code Reviews",
+                "__typename": "ProjectColumn"
+              },
+              "__typename": "ProjectCard"
+            }
+          ],
+          "__typename": "ProjectCardConnection"
+        },
+        "__typename": "PullRequest"
+      },
+      "__typename": "Repository"
+    }
+  },
+  "loading": false,
+  "networkStatus": 7,
+  "stale": false
+}

--- a/src/_tests/fixtures/44299-with-files/derived.json
+++ b/src/_tests/fixtures/44299-with-files/derived.json
@@ -1,0 +1,56 @@
+{
+  "type": "info",
+  "now": "2020-04-29T17:19:10.716Z",
+  "pr_number": 44299,
+  "author": "geopic",
+  "owners": [],
+  "dangerLevel": "ScopedAndConfiguration",
+  "headCommitAbbrOid": "683fb3b",
+  "headCommitOid": "683fb3b1298223256be3a49823686f35bd94a730",
+  "mergeIsRequested": false,
+  "stalenessInDays": 0,
+  "lastPushDate": "2020-04-29T10:57:59.000Z",
+  "lastCommentDate": "2020-04-29T10:57:59.000Z",
+  "maintainerBlessed": false,
+  "reviewLink": "https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44299/files",
+  "hasMergeConflict": false,
+  "authorIsOwner": false,
+  "isFirstContribution": true,
+  "popularityLevel": "Well-liked by everyone",
+  "anyPackageIsNew": true,
+  "packages": [
+    "hcaptcha__vue-hcaptcha"
+  ],
+  "files": [
+    {
+      "path": "types/hcaptcha__vue-hcaptcha/hcaptcha__vue-hcaptcha-tests.ts",
+      "kind": "test",
+      "package": "hcaptcha__vue-hcaptcha"
+    },
+    {
+      "path": "types/hcaptcha__vue-hcaptcha/index.d.ts",
+      "kind": "definition",
+      "package": "hcaptcha__vue-hcaptcha"
+    },
+    {
+      "path": "types/hcaptcha__vue-hcaptcha/package.json",
+      "kind": "package-meta",
+      "package": "hcaptcha__vue-hcaptcha"
+    },
+    {
+      "path": "types/hcaptcha__vue-hcaptcha/tsconfig.json",
+      "kind": "package-meta",
+      "package": "hcaptcha__vue-hcaptcha"
+    },
+    {
+      "path": "types/hcaptcha__vue-hcaptcha/tslint.json",
+      "kind": "package-meta-ok",
+      "package": "hcaptcha__vue-hcaptcha"
+    }
+  ],
+  "hasDismissedReview": false,
+  "ciResult": "pass",
+  "reviewersWithStaleReviews": [],
+  "approvalFlags": 0,
+  "isChangesRequested": false
+}

--- a/src/_tests/fixtures/44299-with-files/mutations.json
+++ b/src/_tests/fixtures/44299-with-files/mutations.json
@@ -1,0 +1,20 @@
+[
+  {
+    "query": "mutation($input: MoveProjectCardInput!) { moveProjectCard(input: $input) { clientMutationId } }",
+    "variables": {
+      "input": {
+        "cardId": "MDExOlByb2plY3RDYXJkMzcxODExMTU=",
+        "columnId": "MDEzOlByb2plY3RDb2x1bW43NTUyOTIy"
+      }
+    }
+  },
+  {
+    "query": "mutation($input: UpdateIssueCommentInput!) { updateIssueComment(input: $input) { clientMutationId } }",
+    "variables": {
+      "input": {
+        "id": "MDEyOklzc3VlQ29tbWVudDYyMDcwMjk5OQ==",
+        "body": "@geopic Thank you for submitting this PR! I see this is your first time submitting to DefinitelyTyped 👋 — I'm the local bot who will help you through the process of getting things through.\n\n***This is a live comment which I will keep updated.***\n\n\n## Code Reviews\n\nThis PR adds a new definition, so it needs to be reviewed by a DT maintainer before it can be merged.\n\n- [hcaptcha__vue-hcaptcha on npm](https://www.npmjs.com/package/hcaptcha__vue-hcaptcha)\n- [hcaptcha__vue-hcaptcha on unpkg](https://unpkg.com/browse/hcaptcha__vue-hcaptcha@latest//)\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ Only a DT maintainer can merge changes when there are new packages added\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n----------------------\n... diagnostics scrubbed ...\n<!--typescript_bot_welcome-->"
+      }
+    }
+  }
+]

--- a/src/_tests/fixtures/44299-with-files/result.json
+++ b/src/_tests/fixtures/44299-with-files/result.json
@@ -1,0 +1,39 @@
+{
+  "pr_number": 44299,
+  "targetColumn": "Needs Maintainer Review",
+  "labels": {
+    "Has Merge Conflict": false,
+    "The CI failed": false,
+    "Revision needed": false,
+    "New Definition": true,
+    "Where is GH Actions?": false,
+    "Owner Approved": false,
+    "Other Approved": false,
+    "Maintainer Approved": false,
+    "Merge:LGTM": false,
+    "Merge:YSYL": false,
+    "Popular package": false,
+    "Critical package": false,
+    "Edits Infrastructure": false,
+    "Edits multiple packages": false,
+    "Author is Owner": false,
+    "No Other Owners": false,
+    "Too Many Owners": false,
+    "Merge:Auto": false,
+    "Untested Change": false,
+    "Config Edit": false,
+    "Abandoned": false
+  },
+  "responseComments": [
+    {
+      "tag": "welcome",
+      "status": "@geopic Thank you for submitting this PR! I see this is your first time submitting to DefinitelyTyped 👋 — I'm the local bot who will help you through the process of getting things through.\n\n***This is a live comment which I will keep updated.***\n\n\n## Code Reviews\n\nThis PR adds a new definition, so it needs to be reviewed by a DT maintainer before it can be merged.\n\n- [hcaptcha__vue-hcaptcha on npm](https://www.npmjs.com/package/hcaptcha__vue-hcaptcha)\n- [hcaptcha__vue-hcaptcha on unpkg](https://unpkg.com/browse/hcaptcha__vue-hcaptcha@latest//)\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ Only a DT maintainer can merge changes when there are new packages added\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n----------------------\n... diagnostics scrubbed ..."
+    }
+  ],
+  "shouldClose": false,
+  "shouldMerge": false,
+  "shouldUpdateLabels": true,
+  "shouldUpdateProjectColumn": true,
+  "shouldRemoveFromActiveColumns": false,
+  "isReadyForAutoMerge": false
+}


### PR DESCRIPTION
Includes simple tests for valid `OTHER_FILES.txt` and `tslint.json`,
marking them as `package-meta-ok` which is ignored for the decision to
put a PR in the maintainer queue.