### PR TITLE
Improve the situation for single owner packages

### DIFF
--- a/src/_tests/fixtures/43151/mutations.json
+++ b/src/_tests/fixtures/43151/mutations.json
@@ -27,5 +27,14 @@
         "body": "@adamzerella Thank you for submitting this PR!\n\n***This is a live comment which I will keep updated.***\n\n\n## Code Reviews\n\nThis PR adds a new definition, so it needs to be reviewed by a DT maintainer before it can be merged.\n\n- [gaze on npm](https://www.npmjs.com/package/gaze)\n- [gaze on unpkg](https://unpkg.com/browse/gaze@latest//)\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ Only a DT maintainer can approve changes when there are new packages added\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n## Inactive\n\nThis PR has been inactive for 4 days.\n\n----------------------\n... diagnostics scrubbed ...\n<!--typescript_bot_welcome-->"
       }
     }
+  },
+  {
+    "query": "mutation($input: AddCommentInput!) { addComment(input: $input) { clientMutationId } }",
+    "variables": {
+      "input": {
+        "subjectId": "MDExOlB1bGxSZXF1ZXN0Mzg4Njk0NDU5",
+        "body": "🔔 @adamzerella — you're the only owner, but it would still be good if you find someone to [review this PR](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/43151/files) in the next few days, otherwise a maintainer will look at it. (And if you do find someone, maybe even recruit them to be a second owner to make future changes easier...)\n<!--typescript_bot_pinging-reviewers-others-->"
+      }
+    }
   }
 ]

--- a/src/_tests/fixtures/43151/result.json
+++ b/src/_tests/fixtures/43151/result.json
@@ -28,6 +28,10 @@
     {
       "tag": "welcome",
       "status": "@adamzerella Thank you for submitting this PR!\n\n***This is a live comment which I will keep updated.***\n\n\n## Code Reviews\n\nThis PR adds a new definition, so it needs to be reviewed by a DT maintainer before it can be merged.\n\n- [gaze on npm](https://www.npmjs.com/package/gaze)\n- [gaze on unpkg](https://unpkg.com/browse/gaze@latest//)\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ Only a DT maintainer can approve changes when there are new packages added\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n## Inactive\n\nThis PR has been inactive for 4 days.\n\n----------------------\n... diagnostics scrubbed ..."
+    },
+    {
+      "tag": "pinging-reviewers-others",
+      "status": "🔔 @adamzerella — you're the only owner, but it would still be good if you find someone to [review this PR](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/43151/files) in the next few days, otherwise a maintainer will look at it. (And if you do find someone, maybe even recruit them to be a second owner to make future changes easier...)"
     }
   ],
   "shouldClose": false,

--- a/src/_tests/fixtures/43314/mutations.json
+++ b/src/_tests/fixtures/43314/mutations.json
@@ -16,5 +16,14 @@
         "body": "@metonym Thank you for submitting this PR!\n\n***This is a live comment which I will keep updated.***\n\n\n## Code Reviews\n\nThis PR adds a new definition, so it needs to be reviewed by a DT maintainer before it can be merged.\n\n- [carbon__icon-helpers on npm](https://www.npmjs.com/package/carbon__icon-helpers)\n- [carbon__icon-helpers on unpkg](https://unpkg.com/browse/carbon__icon-helpers@latest//)\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ Only a DT maintainer can approve changes when there are new packages added\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n----------------------\n... diagnostics scrubbed ...\n<!--typescript_bot_welcome-->"
       }
     }
+  },
+  {
+    "query": "mutation($input: AddCommentInput!) { addComment(input: $input) { clientMutationId } }",
+    "variables": {
+      "input": {
+        "subjectId": "MDExOlB1bGxSZXF1ZXN0MzkyMDM2NjA4",
+        "body": "🔔 @metonym — you're the only owner, but it would still be good if you find someone to [review this PR](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/43314/files) in the next few days, otherwise a maintainer will look at it. (And if you do find someone, maybe even recruit them to be a second owner to make future changes easier...)\n<!--typescript_bot_pinging-reviewers-others-->"
+      }
+    }
   }
 ]

--- a/src/_tests/fixtures/43314/result.json
+++ b/src/_tests/fixtures/43314/result.json
@@ -28,6 +28,10 @@
     {
       "tag": "welcome",
       "status": "@metonym Thank you for submitting this PR!\n\n***This is a live comment which I will keep updated.***\n\n\n## Code Reviews\n\nThis PR adds a new definition, so it needs to be reviewed by a DT maintainer before it can be merged.\n\n- [carbon__icon-helpers on npm](https://www.npmjs.com/package/carbon__icon-helpers)\n- [carbon__icon-helpers on unpkg](https://unpkg.com/browse/carbon__icon-helpers@latest//)\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ Only a DT maintainer can approve changes when there are new packages added\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n----------------------\n... diagnostics scrubbed ..."
+    },
+    {
+      "tag": "pinging-reviewers-others",
+      "status": "🔔 @metonym — you're the only owner, but it would still be good if you find someone to [review this PR](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/43314/files) in the next few days, otherwise a maintainer will look at it. (And if you do find someone, maybe even recruit them to be a second owner to make future changes easier...)"
     }
   ],
   "shouldClose": false,

--- a/src/_tests/fixtures/43695-duplicate-comment/mutations.json
+++ b/src/_tests/fixtures/43695-duplicate-comment/mutations.json
@@ -34,6 +34,15 @@
     "variables": {
       "input": {
         "subjectId": "MDExOlB1bGxSZXF1ZXN0NDAwMTAwMTk2",
+        "body": "🔔 @alexandercerutti — you're the only owner, but it would still be good if you find someone to [review this PR](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/43695/files) in the next few days, otherwise a maintainer will look at it. (And if you do find someone, maybe even recruit them to be a second owner to make future changes easier...)\n<!--typescript_bot_pinging-reviewers-others-->"
+      }
+    }
+  },
+  {
+    "query": "mutation($input: AddCommentInput!) { addComment(input: $input) { clientMutationId } }",
+    "variables": {
+      "input": {
+        "subjectId": "MDExOlB1bGxSZXF1ZXN0NDAwMTAwMTk2",
         "body": "@andrewbranch, @RyanCavanaugh Thank you for reviewing this PR! The author has pushed new commits since your last review. Could you take another look and submit a fresh review?\n<!--typescript_bot_stale-ping-61f252-a5285cd-->"
       }
     }

--- a/src/_tests/fixtures/43695-duplicate-comment/result.json
+++ b/src/_tests/fixtures/43695-duplicate-comment/result.json
@@ -30,6 +30,10 @@
       "status": "@alexandercerutti Thank you for submitting this PR!\n\n***This is a live comment which I will keep updated.***\n\n\n## Code Reviews\n\nThis PR adds a new definition, so it needs to be reviewed by a DT maintainer before it can be merged.\n\n- [accedo__accedo-one on npm](https://www.npmjs.com/package/accedo__accedo-one)\n- [accedo__accedo-one on unpkg](https://unpkg.com/browse/accedo__accedo-one@latest//)\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ Only a DT maintainer can approve changes when there are new packages added\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n----------------------\n... diagnostics scrubbed ..."
     },
     {
+      "tag": "pinging-reviewers-others",
+      "status": "🔔 @alexandercerutti — you're the only owner, but it would still be good if you find someone to [review this PR](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/43695/files) in the next few days, otherwise a maintainer will look at it. (And if you do find someone, maybe even recruit them to be a second owner to make future changes easier...)"
+    },
+    {
       "tag": "stale-ping-61f252-a5285cd",
       "status": "@andrewbranch, @RyanCavanaugh Thank you for reviewing this PR! The author has pushed new commits since your last review. Could you take another look and submit a fresh review?"
     }

--- a/src/_tests/fixtures/44282/mutations.json
+++ b/src/_tests/fixtures/44282/mutations.json
@@ -7,5 +7,14 @@
         "body": "@fishcharlie Thank you for submitting this PR! I see this is your first time submitting to DefinitelyTyped 👋 — I'm the local bot who will help you through the process of getting things through.\n\n***This is a live comment which I will keep updated.***\n\n\n## Code Reviews\n\nBecause you edited one package and updated the tests (👏), I can help you merge this PR once someone else signs off on it.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ Most recent commit is approved by type definition owners, DT maintainers or others\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n----------------------\n... diagnostics scrubbed ...\n<!--typescript_bot_welcome-->"
       }
     }
+  },
+  {
+    "query": "mutation($input: AddCommentInput!) { addComment(input: $input) { clientMutationId } }",
+    "variables": {
+      "input": {
+        "subjectId": "MDExOlB1bGxSZXF1ZXN0NDA5ODAxMzk2",
+        "body": "🔔 @fishcharlie — you're the only owner, but it would still be good if you find someone to [review this PR](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44282/files) in the next few days, otherwise a maintainer will look at it. (And if you do find someone, maybe even recruit them to be a second owner to make future changes easier...)\n<!--typescript_bot_pinging-reviewers-others-->"
+      }
+    }
   }
 ]

--- a/src/_tests/fixtures/44282/result.json
+++ b/src/_tests/fixtures/44282/result.json
@@ -28,6 +28,10 @@
     {
       "tag": "welcome",
       "status": "@fishcharlie Thank you for submitting this PR! I see this is your first time submitting to DefinitelyTyped 👋 — I'm the local bot who will help you through the process of getting things through.\n\n***This is a live comment which I will keep updated.***\n\n\n## Code Reviews\n\nBecause you edited one package and updated the tests (👏), I can help you merge this PR once someone else signs off on it.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ Most recent commit is approved by type definition owners, DT maintainers or others\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n----------------------\n... diagnostics scrubbed ..."
+    },
+    {
+      "tag": "pinging-reviewers-others",
+      "status": "🔔 @fishcharlie — you're the only owner, but it would still be good if you find someone to [review this PR](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44282/files) in the next few days, otherwise a maintainer will look at it. (And if you do find someone, maybe even recruit them to be a second owner to make future changes easier...)"
     }
   ],
   "shouldClose": false,

--- a/src/_tests/fixtures/44299-with-files/mutations.json
+++ b/src/_tests/fixtures/44299-with-files/mutations.json
@@ -16,5 +16,14 @@
         "body": "@geopic Thank you for submitting this PR! I see this is your first time submitting to DefinitelyTyped 👋 — I'm the local bot who will help you through the process of getting things through.\n\n***This is a live comment which I will keep updated.***\n\n\n## Code Reviews\n\nThis PR adds a new definition, so it needs to be reviewed by a DT maintainer before it can be merged.\n\n- [hcaptcha__vue-hcaptcha on npm](https://www.npmjs.com/package/hcaptcha__vue-hcaptcha)\n- [hcaptcha__vue-hcaptcha on unpkg](https://unpkg.com/browse/hcaptcha__vue-hcaptcha@latest//)\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ Only a DT maintainer can approve changes when there are new packages added\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n----------------------\n... diagnostics scrubbed ...\n<!--typescript_bot_welcome-->"
       }
     }
+  },
+  {
+    "query": "mutation($input: AddCommentInput!) { addComment(input: $input) { clientMutationId } }",
+    "variables": {
+      "input": {
+        "subjectId": "MDExOlB1bGxSZXF1ZXN0NDEwMjE2Nzgz",
+        "body": "🔔 @geopic — you're the only owner, but it would still be good if you find someone to [review this PR](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44299/files) in the next few days, otherwise a maintainer will look at it. (And if you do find someone, maybe even recruit them to be a second owner to make future changes easier...)\n<!--typescript_bot_pinging-reviewers-others-->"
+      }
+    }
   }
 ]

--- a/src/_tests/fixtures/44299-with-files/result.json
+++ b/src/_tests/fixtures/44299-with-files/result.json
@@ -28,6 +28,10 @@
     {
       "tag": "welcome",
       "status": "@geopic Thank you for submitting this PR! I see this is your first time submitting to DefinitelyTyped 👋 — I'm the local bot who will help you through the process of getting things through.\n\n***This is a live comment which I will keep updated.***\n\n\n## Code Reviews\n\nThis PR adds a new definition, so it needs to be reviewed by a DT maintainer before it can be merged.\n\n- [hcaptcha__vue-hcaptcha on npm](https://www.npmjs.com/package/hcaptcha__vue-hcaptcha)\n- [hcaptcha__vue-hcaptcha on unpkg](https://unpkg.com/browse/hcaptcha__vue-hcaptcha@latest//)\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ Only a DT maintainer can approve changes when there are new packages added\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n----------------------\n... diagnostics scrubbed ..."
+    },
+    {
+      "tag": "pinging-reviewers-others",
+      "status": "🔔 @geopic — you're the only owner, but it would still be good if you find someone to [review this PR](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44299/files) in the next few days, otherwise a maintainer will look at it. (And if you do find someone, maybe even recruit them to be a second owner to make future changes easier...)"
     }
   ],
   "shouldClose": false,

--- a/src/_tests/fixtures/44299/mutations.json
+++ b/src/_tests/fixtures/44299/mutations.json
@@ -16,5 +16,14 @@
         "body": "@geopic Thank you for submitting this PR! I see this is your first time submitting to DefinitelyTyped 👋 — I'm the local bot who will help you through the process of getting things through.\n\n***This is a live comment which I will keep updated.***\n\n\n## Code Reviews\n\nThis PR adds a new definition, so it needs to be reviewed by a DT maintainer before it can be merged.\n\n- [hcaptcha__vue-hcaptcha on npm](https://www.npmjs.com/package/hcaptcha__vue-hcaptcha)\n- [hcaptcha__vue-hcaptcha on unpkg](https://unpkg.com/browse/hcaptcha__vue-hcaptcha@latest//)\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ Only a DT maintainer can approve changes when there are new packages added\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n----------------------\n... diagnostics scrubbed ...\n<!--typescript_bot_welcome-->"
       }
     }
+  },
+  {
+    "query": "mutation($input: AddCommentInput!) { addComment(input: $input) { clientMutationId } }",
+    "variables": {
+      "input": {
+        "subjectId": "MDExOlB1bGxSZXF1ZXN0NDEwMjE2Nzgz",
+        "body": "🔔 @geopic — you're the only owner, but it would still be good if you find someone to [review this PR](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44299/files) in the next few days, otherwise a maintainer will look at it. (And if you do find someone, maybe even recruit them to be a second owner to make future changes easier...)\n<!--typescript_bot_pinging-reviewers-others-->"
+      }
+    }
   }
 ]

--- a/src/_tests/fixtures/44299/result.json
+++ b/src/_tests/fixtures/44299/result.json
@@ -28,6 +28,10 @@
     {
       "tag": "welcome",
       "status": "@geopic Thank you for submitting this PR! I see this is your first time submitting to DefinitelyTyped 👋 — I'm the local bot who will help you through the process of getting things through.\n\n***This is a live comment which I will keep updated.***\n\n\n## Code Reviews\n\nThis PR adds a new definition, so it needs to be reviewed by a DT maintainer before it can be merged.\n\n- [hcaptcha__vue-hcaptcha on npm](https://www.npmjs.com/package/hcaptcha__vue-hcaptcha)\n- [hcaptcha__vue-hcaptcha on unpkg](https://unpkg.com/browse/hcaptcha__vue-hcaptcha@latest//)\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ Only a DT maintainer can approve changes when there are new packages added\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n----------------------\n... diagnostics scrubbed ..."
+    },
+    {
+      "tag": "pinging-reviewers-others",
+      "status": "🔔 @geopic — you're the only owner, but it would still be good if you find someone to [review this PR](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44299/files) in the next few days, otherwise a maintainer will look at it. (And if you do find someone, maybe even recruit them to be a second owner to make future changes easier...)"
     }
   ],
   "shouldClose": false,

--- a/src/_tests/fixtures/44316/mutations.json
+++ b/src/_tests/fixtures/44316/mutations.json
@@ -16,5 +16,14 @@
         "body": "@mattleff Thank you for submitting this PR!\n\n***This is a live comment which I will keep updated.***\n\n\n## Code Reviews\n\nThere aren't any other owners of this package, so a DT maintainer will review it.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ A DT maintainer can merge changes when there are no other reviewers\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n----------------------\n... diagnostics scrubbed ...\n<!--typescript_bot_welcome-->"
       }
     }
+  },
+  {
+    "query": "mutation($input: AddCommentInput!) { addComment(input: $input) { clientMutationId } }",
+    "variables": {
+      "input": {
+        "subjectId": "MDExOlB1bGxSZXF1ZXN0NDEwMzk4NzAw",
+        "body": "🔔 @mattleff — you're the only owner, but it would still be good if you find someone to [review this PR](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44316/files) in the next few days, otherwise a maintainer will look at it. (And if you do find someone, maybe even recruit them to be a second owner to make future changes easier...)\n<!--typescript_bot_pinging-reviewers-others-->"
+      }
+    }
   }
 ]

--- a/src/_tests/fixtures/44316/result.json
+++ b/src/_tests/fixtures/44316/result.json
@@ -28,6 +28,10 @@
     {
       "tag": "welcome",
       "status": "@mattleff Thank you for submitting this PR!\n\n***This is a live comment which I will keep updated.***\n\n\n## Code Reviews\n\nThere aren't any other owners of this package, so a DT maintainer will review it.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ A DT maintainer can merge changes when there are no other reviewers\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n----------------------\n... diagnostics scrubbed ..."
+    },
+    {
+      "tag": "pinging-reviewers-others",
+      "status": "🔔 @mattleff — you're the only owner, but it would still be good if you find someone to [review this PR](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44316/files) in the next few days, otherwise a maintainer will look at it. (And if you do find someone, maybe even recruit them to be a second owner to make future changes easier...)"
     }
   ],
   "shouldClose": false,

--- a/src/_tests/fixtures/45890/mutations.json
+++ b/src/_tests/fixtures/45890/mutations.json
@@ -7,5 +7,14 @@
         "body": "@dimkirt Thank you for submitting this PR! I see this is your first time submitting to DefinitelyTyped 👋 — I'm the local bot who will help you through the process of getting things through.\n\n***This is a live comment which I will keep updated.***\n\n\n## Code Reviews\n\nThis PR adds a new definition, so it needs to be reviewed by a DT maintainer before it can be merged.\n\n- [greek-utils on npm](https://www.npmjs.com/package/greek-utils)\n- [greek-utils on unpkg](https://unpkg.com/browse/greek-utils@latest//)\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ Only a DT maintainer can approve changes when there are new packages added\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n----------------------\n... diagnostics scrubbed ...\n<!--typescript_bot_welcome-->"
       }
     }
+  },
+  {
+    "query": "mutation($input: AddCommentInput!) { addComment(input: $input) { clientMutationId } }",
+    "variables": {
+      "input": {
+        "subjectId": "MDExOlB1bGxSZXF1ZXN0NDQ0MzI2NjIy",
+        "body": "🔔 @dimkirt — you're the only owner, but it would still be good if you find someone to [review this PR](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/45890/files) in the next few days, otherwise a maintainer will look at it. (And if you do find someone, maybe even recruit them to be a second owner to make future changes easier...)\n<!--typescript_bot_pinging-reviewers-others-->"
+      }
+    }
   }
 ]

--- a/src/_tests/fixtures/45890/result.json
+++ b/src/_tests/fixtures/45890/result.json
@@ -28,6 +28,10 @@
     {
       "tag": "welcome",
       "status": "@dimkirt Thank you for submitting this PR! I see this is your first time submitting to DefinitelyTyped 👋 — I'm the local bot who will help you through the process of getting things through.\n\n***This is a live comment which I will keep updated.***\n\n\n## Code Reviews\n\nThis PR adds a new definition, so it needs to be reviewed by a DT maintainer before it can be merged.\n\n- [greek-utils on npm](https://www.npmjs.com/package/greek-utils)\n- [greek-utils on unpkg](https://unpkg.com/browse/greek-utils@latest//)\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ Only a DT maintainer can approve changes when there are new packages added\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n----------------------\n... diagnostics scrubbed ..."
+    },
+    {
+      "tag": "pinging-reviewers-others",
+      "status": "🔔 @dimkirt — you're the only owner, but it would still be good if you find someone to [review this PR](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/45890/files) in the next few days, otherwise a maintainer will look at it. (And if you do find someone, maybe even recruit them to be a second owner to make future changes easier...)"
     }
   ],
   "shouldClose": false,

--- a/src/_tests/fixtures/45946/mutations.json
+++ b/src/_tests/fixtures/45946/mutations.json
@@ -7,5 +7,14 @@
         "body": "@rubensworks Thank you for submitting this PR!\n\n***This is a live comment which I will keep updated.***\n\n This PR touches some part of DefinitelyTyped infrastructure, so a DT maintainer will need to review it. This is rare — did you mean to do this?\n\n## Code Reviews\n\nThere aren't any other owners of this package, so a DT maintainer will review it.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ A DT maintainer needs to approve changes which affect DT infrastructure ([`notNeededPackages.json`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/a5eb1f19e7a31387e7d7c79b3acc483b0e60b32e/notNeededPackages.json))\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n----------------------\n... diagnostics scrubbed ...\n<!--typescript_bot_welcome-->"
       }
     }
+  },
+  {
+    "query": "mutation($input: AddCommentInput!) { addComment(input: $input) { clientMutationId } }",
+    "variables": {
+      "input": {
+        "subjectId": "MDExOlB1bGxSZXF1ZXN0NDQ2MDIxMjkw",
+        "body": "🔔 @rubensworks — you're the only owner, but it would still be good if you find someone to [review this PR](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/45946/files) in the next few days, otherwise a maintainer will look at it. (And if you do find someone, maybe even recruit them to be a second owner to make future changes easier...)\n<!--typescript_bot_pinging-reviewers-others-->"
+      }
+    }
   }
 ]

--- a/src/_tests/fixtures/45946/result.json
+++ b/src/_tests/fixtures/45946/result.json
@@ -28,6 +28,10 @@
     {
       "tag": "welcome",
       "status": "@rubensworks Thank you for submitting this PR!\n\n***This is a live comment which I will keep updated.***\n\n This PR touches some part of DefinitelyTyped infrastructure, so a DT maintainer will need to review it. This is rare — did you mean to do this?\n\n## Code Reviews\n\nThere aren't any other owners of this package, so a DT maintainer will review it.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ A DT maintainer needs to approve changes which affect DT infrastructure ([`notNeededPackages.json`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/a5eb1f19e7a31387e7d7c79b3acc483b0e60b32e/notNeededPackages.json))\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n----------------------\n... diagnostics scrubbed ..."
+    },
+    {
+      "tag": "pinging-reviewers-others",
+      "status": "🔔 @rubensworks — you're the only owner, but it would still be good if you find someone to [review this PR](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/45946/files) in the next few days, otherwise a maintainer will look at it. (And if you do find someone, maybe even recruit them to be a second owner to make future changes easier...)"
     }
   ],
   "shouldClose": false,

--- a/src/comments.ts
+++ b/src/comments.ts
@@ -40,17 +40,17 @@ export const ChangesRequest = (headOid: string, user: string) => ({
     status: `@${user} One or more reviewers has requested changes. Please address their comments. I'll be back once they sign off or you've pushed new commits or comments. If you disagree with the reviewer's comments, you can "dismiss" the review using GitHub's review UI. Thank you!`
 });
 
-export const ApprovedByOwner = () => ({
+export const ApprovedByOwner = () => ({ // UNUSED
     tag: "merge",
     status: "A definition owner has approved this PR ⭐️. A maintainer will merge this PR shortly. If it shouldn't be merged yet, please leave a comment saying so and we'll wait. Thank you for your contribution to DefinitelyTyped!"
 });
 
-export const AuthorIsOwnerAndGreen = () => ({
+export const AuthorIsOwnerAndGreen = () => ({ // UNUSED
     tag: "merge",
     status: "Since you're a listed owner and the build passed, this PR is fast-tracked. A maintainer will merge shortly. If it shouldn't be merged yet, please leave a comment saying so and we'll wait. Thank you for your contribution to DefinitelyTyped!"
 });
 
-export const LGTM = () => ({
+export const LGTM = () => ({ // UNUSED
     tag: "merge",
     status: "We've gotten sign-off from a reviewer 👏. A maintainer will soon review this PR and merge it if there are no issues. If it shouldn't be merged yet, please leave a comment saying so and we'll wait. Thank you for contributing to DefinitelyTyped!"
 });
@@ -68,11 +68,7 @@ export const PingReviewersTooMany = (names: readonly string[]) => ({
 <summary>People who would have been pinged</summary>
 ${names.map(n => `${n}`).join(" ")}
 </details>`
-})
-
-export const Welcome = (login: string, isFirstPR: boolean) => `@${login} Thank you for submitting this PR!${isFirstPR ? " I see this is your first PR to DefinitelyTyped - don't worry, I'll be helping you throughout the process. Stay tuned for updates." : ""}`;
-export const NewDefinition = `Because this is a new definition, a DefinitelyTyped maintainer will be reviewing this PR in the next few days once the CI build passes.`;
-export const NoOtherReviewers = `Because this PR doesn't have any code reviewers, a DefinitelyTyped maintainer will be reviewing it in the next few days once the CI build passes.`;
+});
 
 export const PingStaleReviewer = (reviewedAbbrOid: string, reviewers: string[]) => ({
     tag: `stale-ping-${tinyHash(reviewers.join("-"))}-${reviewedAbbrOid}`,

--- a/src/comments.ts
+++ b/src/comments.ts
@@ -60,6 +60,11 @@ export const PingReviewers = (names: readonly string[], reviewLink: string) => (
     status: `🔔 ${names.map(n => `@${n}`).join(" ")} — please [review this PR](${reviewLink}) in the next few days. Be sure to explicitly select **\`Approve\`** or **\`Request Changes\`** in the GitHub UI so I know what's going on.`
 });
 
+export const PingReviewersOther = (author: string, reviewLink: string) => ({
+    tag: "pinging-reviewers-others",
+    status: `🔔 @${author} — you're the only owner, but it would still be good if you find someone to [review this PR](${reviewLink}) in the next few days, otherwise a maintainer will look at it. (And if you do find someone, maybe even recruit them to be a second owner to make future changes easier...)`
+});
+
 export const PingReviewersTooMany = (names: readonly string[]) => ({
     tag: "pinging-reviewers-too-many",
     status: `⚠️ There are too many reviewers for this PR change (${names.length}). Merging can only be handled by a DT maintainer.

--- a/src/compute-pr-actions.ts
+++ b/src/compute-pr-actions.ts
@@ -22,7 +22,7 @@ type LabelName =
     | "Other Approved"
     | "Maintainer Approved"
     | "Merge:Auto"
-    | "Merge:LGTM"
+    | "Merge:LGTM" // UNUSED
     | "Merge:YSYL"
     | "Popular package"
     | "Critical package"

--- a/src/pr-info.ts
+++ b/src/pr-info.ts
@@ -32,7 +32,6 @@ export type DangerLevel =
     | "ScopedAndTested"
     | "ScopedAndUntested"
     | "ScopedAndConfiguration"
-    | "NewDefinition"
     | "MultiplePackagesEdited"
     | "Infrastructure";
 
@@ -220,7 +219,7 @@ export async function deriveStateForPR(
     const freshReviewsByState = partition(noNulls(prInfo.reviews?.nodes), r => r.state);
     const approvals = noNulls(freshReviewsByState.APPROVED);
     const hasDismissedReview = !!freshReviewsByState.DISMISSED?.length;
-    const approvalsByRole = partition(approvals, review => {
+    const approvalsByRole = partition(approvals, review => { // UNUSED
         if (review?.author?.login === prInfo.author?.login) {
             return "self";
         }
@@ -474,7 +473,7 @@ function getDangerLevel(categorizedFiles: readonly FileInfo[]) {
         return "Infrastructure";
     }
     const packagesTouched = getPackagesTouched(categorizedFiles);
-    if (packagesTouched.length === 0) { // ????
+    if (packagesTouched.length === 0) {
         return "Infrastructure";
     } else if (packagesTouched.length > 1) {
         return "MultiplePackagesEdited";


### PR DESCRIPTION
* If this is a single-owner package, and its popularity is `Popular`,
  then make the required reviewers be "others" (and not "owners", which
  doesn't apply for these packages).

* In the case of single-owner packages whose popularity is not
  `Critical` (i.e., including the above case), spit out a comment
  encouraging the owner to find someone else to review and maybe
  recruit them as an owner.  (See my comment on #105.)

Closes #105.