### PR TITLE
(Try to) disable concurrent trigger runs

### DIFF
--- a/host.json
+++ b/host.json
@@ -4,6 +4,14 @@
     "id": "Microsoft.Azure.Functions.ExtensionBundle",
     "version": "[1.*, 2.0.0)"
   },
+  "extensions": {
+    "http": {
+      "routePrefix": "api",
+      "maxOutstandingRequests": 200,
+      "maxConcurrentRequests": 1,
+      "dynamicThrottlesEnabled": false
+    }
+  },
   "singleton": {
       "lockPeriod": "00:00:15",
       "listenerLockPeriod": "00:01:00",


### PR DESCRIPTION
The `singleton` settings don't seem to have an effect, so try [this thing](https://docs.microsoft.com/en-us/azure/azure-functions/functions-bindings-http-webhook-output) instead.

Note that this limits all interactions — if the bots becomes busy enough, it would be better to limit concurrency per PR instead, somehow.