### PR TITLE
Allow owners to do a "ready to merge" self-merge

### DIFF
--- a/src/_tests/fixtures/43144/mutations.json
+++ b/src/_tests/fixtures/43144/mutations.json
@@ -33,7 +33,7 @@
     "variables": {
       "input": {
         "subjectId": "MDExOlB1bGxSZXF1ZXN0Mzg4NDkxOTI2",
-        "body": "@jeffreymeng Everything looks good here. Great job! I am ready to merge this PR on your behalf.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n<!--typescript_bot_merge-offer-->"
+        "body": "@jeffreymeng Everything looks good here. Great job! I am ready to merge this PR on your behalf.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n\n(@pocesar: you can do this too.)\n<!--typescript_bot_merge-offer-->"
       }
     }
   }

--- a/src/_tests/fixtures/43144/result.json
+++ b/src/_tests/fixtures/43144/result.json
@@ -32,7 +32,7 @@
     },
     {
       "tag": "merge-offer",
-      "status": "@jeffreymeng Everything looks good here. Great job! I am ready to merge this PR on your behalf.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:"
+      "status": "@jeffreymeng Everything looks good here. Great job! I am ready to merge this PR on your behalf.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n\n(@pocesar: you can do this too.)"
     }
   ],
   "shouldClose": false,

--- a/src/_tests/fixtures/44437/mutations.json
+++ b/src/_tests/fixtures/44437/mutations.json
@@ -7,5 +7,14 @@
         "body": "@johnnyreilly Thank you for submitting this PR!\n\n***This is a live comment which I will keep updated.***\n\n\n## Code Reviews\n\nBecause you edited one package and updated the tests (👏), I can help you merge this PR once someone else signs off on it.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ✅ Most recent commit is approved by type definition owners or DT maintainers\n\nAll of the items on the list are green. **To merge, you need to post a comment including the string \"Ready to merge\"** to bring in your changes.\n\n----------------------\n... diagnostics scrubbed ...\n<!--typescript_bot_welcome-->"
       }
     }
+  },
+  {
+    "query": "mutation($input: UpdateIssueCommentInput!) { updateIssueComment(input: $input) { clientMutationId } }",
+    "variables": {
+      "input": {
+        "id": "MDEyOklzc3VlQ29tbWVudDYyMjk0NTA1NA==",
+        "body": "@johnnyreilly Everything looks good here. Great job! I am ready to merge this PR on your behalf.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n\n(@Berkays, @unindented, @kamontat, @theweirdone, @whoaa512: you can do this too.)\n<!--typescript_bot_merge-offer-->"
+      }
+    }
   }
 ]

--- a/src/_tests/fixtures/44437/result.json
+++ b/src/_tests/fixtures/44437/result.json
@@ -32,7 +32,7 @@
     },
     {
       "tag": "merge-offer",
-      "status": "@johnnyreilly Everything looks good here. Great job! I am ready to merge this PR on your behalf.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:"
+      "status": "@johnnyreilly Everything looks good here. Great job! I am ready to merge this PR on your behalf.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n\n(@Berkays, @unindented, @kamontat, @theweirdone, @whoaa512: you can do this too.)"
     }
   ],
   "shouldClose": false,

--- a/src/_tests/fixtures/44989-3days/mutations.json
+++ b/src/_tests/fixtures/44989-3days/mutations.json
@@ -7,5 +7,14 @@
         "body": "@petr-motejlek Thank you for submitting this PR!\n\n***This is a live comment which I will keep updated.***\n\n\n## Code Reviews\n\nBecause you edited one package and updated the tests (👏), I can help you merge this PR once someone else signs off on it.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ✅ Most recent commit is approved by type definition owners or DT maintainers\n\nAll of the items on the list are green. **To merge, you need to post a comment including the string \"Ready to merge\"** to bring in your changes.\n\n## Inactive\n\nThis PR has been inactive for 3 days.\n\n----------------------\n... diagnostics scrubbed ...\n<!--typescript_bot_welcome-->"
       }
     }
+  },
+  {
+    "query": "mutation($input: UpdateIssueCommentInput!) { updateIssueComment(input: $input) { clientMutationId } }",
+    "variables": {
+      "input": {
+        "id": "MDEyOklzc3VlQ29tbWVudDYzMzAxODkyMw==",
+        "body": "@petr-motejlek Everything looks good here. Great job! I am ready to merge this PR on your behalf.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n\n(@TheHandsomeCoder, @donnut, @mdekrey, @sbking, @afharo, @teves-castro, @1M0reBug, @hojberg, @samsonkeung, @angeloocana, @raynerd, @moshensky, @ethanresnick, @deftomat, @blimusiek, @biern, @rayhaneh, @rgm, @drewwyatt, @jottenlips, @minitesh, @krantisinh, @pirix-gh, @brekk, @nemo108, @jituanlin, @Philippe-mills, @Saul-Mirone, @Nicholaiii: you can do this too.)\n<!--typescript_bot_merge-offer-->"
+      }
+    }
   }
 ]

--- a/src/_tests/fixtures/44989-3days/result.json
+++ b/src/_tests/fixtures/44989-3days/result.json
@@ -32,7 +32,7 @@
     },
     {
       "tag": "merge-offer",
-      "status": "@petr-motejlek Everything looks good here. Great job! I am ready to merge this PR on your behalf.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:"
+      "status": "@petr-motejlek Everything looks good here. Great job! I am ready to merge this PR on your behalf.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n\n(@TheHandsomeCoder, @donnut, @mdekrey, @sbking, @afharo, @teves-castro, @1M0reBug, @hojberg, @samsonkeung, @angeloocana, @raynerd, @moshensky, @ethanresnick, @deftomat, @blimusiek, @biern, @rayhaneh, @rgm, @drewwyatt, @jottenlips, @minitesh, @krantisinh, @pirix-gh, @brekk, @nemo108, @jituanlin, @Philippe-mills, @Saul-Mirone, @Nicholaiii: you can do this too.)"
     }
   ],
   "shouldClose": false,

--- a/src/_tests/fixtures/44989-5days/mutations.json
+++ b/src/_tests/fixtures/44989-5days/mutations.json
@@ -7,5 +7,14 @@
         "body": "@petr-motejlek Thank you for submitting this PR!\n\n***This is a live comment which I will keep updated.***\n\n\n## Code Reviews\n\nBecause you edited one package and updated the tests (👏), I can help you merge this PR once someone else signs off on it.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ✅ Most recent commit is approved by type definition owners or DT maintainers\n\nAll of the items on the list are green. **To merge, you need to post a comment including the string \"Ready to merge\"** to bring in your changes.\n\n## Inactive\n\nThis PR has been inactive for 5 days — please merge or say something if there's a problem, otherwise it will move to the DT maintainer queue soon!\n\n----------------------\n... diagnostics scrubbed ...\n<!--typescript_bot_welcome-->"
       }
     }
+  },
+  {
+    "query": "mutation($input: UpdateIssueCommentInput!) { updateIssueComment(input: $input) { clientMutationId } }",
+    "variables": {
+      "input": {
+        "id": "MDEyOklzc3VlQ29tbWVudDYzMzAxODkyMw==",
+        "body": "@petr-motejlek Everything looks good here. Great job! I am ready to merge this PR on your behalf.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n\n(@TheHandsomeCoder, @donnut, @mdekrey, @sbking, @afharo, @teves-castro, @1M0reBug, @hojberg, @samsonkeung, @angeloocana, @raynerd, @moshensky, @ethanresnick, @deftomat, @blimusiek, @biern, @rayhaneh, @rgm, @drewwyatt, @jottenlips, @minitesh, @krantisinh, @pirix-gh, @brekk, @nemo108, @jituanlin, @Philippe-mills, @Saul-Mirone, @Nicholaiii: you can do this too.)\n<!--typescript_bot_merge-offer-->"
+      }
+    }
   }
 ]

--- a/src/_tests/fixtures/44989-5days/result.json
+++ b/src/_tests/fixtures/44989-5days/result.json
@@ -32,7 +32,7 @@
     },
     {
       "tag": "merge-offer",
-      "status": "@petr-motejlek Everything looks good here. Great job! I am ready to merge this PR on your behalf.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:"
+      "status": "@petr-motejlek Everything looks good here. Great job! I am ready to merge this PR on your behalf.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n\n(@TheHandsomeCoder, @donnut, @mdekrey, @sbking, @afharo, @teves-castro, @1M0reBug, @hojberg, @samsonkeung, @angeloocana, @raynerd, @moshensky, @ethanresnick, @deftomat, @blimusiek, @biern, @rayhaneh, @rgm, @drewwyatt, @jottenlips, @minitesh, @krantisinh, @pirix-gh, @brekk, @nemo108, @jituanlin, @Philippe-mills, @Saul-Mirone, @Nicholaiii: you can do this too.)"
     }
   ],
   "shouldClose": false,

--- a/src/_tests/fixtures/44989-6days/mutations.json
+++ b/src/_tests/fixtures/44989-6days/mutations.json
@@ -7,5 +7,14 @@
         "body": "@petr-motejlek Thank you for submitting this PR!\n\n***This is a live comment which I will keep updated.***\n\n\n## Code Reviews\n\nBecause you edited one package and updated the tests (👏), I can help you merge this PR once someone else signs off on it.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ✅ Most recent commit is approved by type definition owners or DT maintainers\n\nAll of the items on the list are green. **To merge, you need to post a comment including the string \"Ready to merge\"** to bring in your changes.\n\n## Inactive\n\nThis PR has been inactive for 6 days — please merge or say something if there's a problem, otherwise it will move to the DT maintainer queue soon!\n\n----------------------\n... diagnostics scrubbed ...\n<!--typescript_bot_welcome-->"
       }
     }
+  },
+  {
+    "query": "mutation($input: UpdateIssueCommentInput!) { updateIssueComment(input: $input) { clientMutationId } }",
+    "variables": {
+      "input": {
+        "id": "MDEyOklzc3VlQ29tbWVudDYzMzAxODkyMw==",
+        "body": "@petr-motejlek Everything looks good here. Great job! I am ready to merge this PR on your behalf.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n\n(@TheHandsomeCoder, @donnut, @mdekrey, @sbking, @afharo, @teves-castro, @1M0reBug, @hojberg, @samsonkeung, @angeloocana, @raynerd, @moshensky, @ethanresnick, @deftomat, @blimusiek, @biern, @rayhaneh, @rgm, @drewwyatt, @jottenlips, @minitesh, @krantisinh, @pirix-gh, @brekk, @nemo108, @jituanlin, @Philippe-mills, @Saul-Mirone, @Nicholaiii: you can do this too.)\n<!--typescript_bot_merge-offer-->"
+      }
+    }
   }
 ]

--- a/src/_tests/fixtures/44989-6days/result.json
+++ b/src/_tests/fixtures/44989-6days/result.json
@@ -32,7 +32,7 @@
     },
     {
       "tag": "merge-offer",
-      "status": "@petr-motejlek Everything looks good here. Great job! I am ready to merge this PR on your behalf.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:"
+      "status": "@petr-motejlek Everything looks good here. Great job! I am ready to merge this PR on your behalf.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n\n(@TheHandsomeCoder, @donnut, @mdekrey, @sbking, @afharo, @teves-castro, @1M0reBug, @hojberg, @samsonkeung, @angeloocana, @raynerd, @moshensky, @ethanresnick, @deftomat, @blimusiek, @biern, @rayhaneh, @rgm, @drewwyatt, @jottenlips, @minitesh, @krantisinh, @pirix-gh, @brekk, @nemo108, @jituanlin, @Philippe-mills, @Saul-Mirone, @Nicholaiii: you can do this too.)"
     }
   ],
   "shouldClose": false,

--- a/src/_tests/fixtures/45884/mutations.json
+++ b/src/_tests/fixtures/45884/mutations.json
@@ -7,5 +7,14 @@
         "body": "@sgratzl Thank you for submitting this PR! I see this is your first time submitting to DefinitelyTyped 👋 — I'm the local bot who will help you through the process of getting things through.\n\n***This is a live comment which I will keep updated.***\n\n This PR doesn't modify any tests, so it's hard to know what's being fixed, and your changes might regress in the future. Have you considered [adding tests](https://github.com/DefinitelyTyped/DefinitelyTyped#editing-tests-on-an-existing-package) to cover the change you're making? Including tests allows this PR to be merged by yourself and the owners of this module. This can potentially save days of time for you.\n\n## Code Reviews\n\nThis PR can be merged once it's reviewed.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ✅ Most recent commit is approved by type definition owners or DT maintainers\n\nAll of the items on the list are green. **To merge, you need to post a comment including the string \"Ready to merge\"** to bring in your changes.\n\n----------------------\n... diagnostics scrubbed ...\n<!--typescript_bot_welcome-->"
       }
     }
+  },
+  {
+    "query": "mutation($input: UpdateIssueCommentInput!) { updateIssueComment(input: $input) { clientMutationId } }",
+    "variables": {
+      "input": {
+        "id": "MDEyOklzc3VlQ29tbWVudDY1NDA0ODc4NQ==",
+        "body": "@sgratzl Everything looks good here. Great job! I am ready to merge this PR on your behalf.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n\n(@phreed, @wy193777, @ypconstante, @janniclas, @cerberuser, @gsbelarus, @peterjferrarotto, @spaxe, @appleparan, @Veckodag: you can do this too.)\n<!--typescript_bot_merge-offer-->"
+      }
+    }
   }
 ]

--- a/src/_tests/fixtures/45884/result.json
+++ b/src/_tests/fixtures/45884/result.json
@@ -32,7 +32,7 @@
     },
     {
       "tag": "merge-offer",
-      "status": "@sgratzl Everything looks good here. Great job! I am ready to merge this PR on your behalf.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:"
+      "status": "@sgratzl Everything looks good here. Great job! I am ready to merge this PR on your behalf.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n\n(@phreed, @wy193777, @ypconstante, @janniclas, @cerberuser, @gsbelarus, @peterjferrarotto, @spaxe, @appleparan, @Veckodag: you can do this too.)"
     }
   ],
   "shouldClose": false,

--- a/src/_tests/fixtures/45999/mutations.json
+++ b/src/_tests/fixtures/45999/mutations.json
@@ -33,7 +33,7 @@
     "variables": {
       "input": {
         "subjectId": "MDExOlB1bGxSZXF1ZXN0NDQ3Mzc2MjE3",
-        "body": "@alexpyzhianov Everything looks good here. Great job! I am ready to merge this PR on your behalf.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n<!--typescript_bot_merge-offer-->"
+        "body": "@alexpyzhianov Everything looks good here. Great job! I am ready to merge this PR on your behalf.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n\n(@johnnyreilly, @bbenezech, @pzavolinsky, @digiguru, @ericanderson, @DovydasNavickas, @theruther4d, @guilhermehubner, @ferdaber, @jrakotoharisoa, @pascaloliv, @hotell, @franklixuefei, @Jessidhia, @saranshkataria, @lukyth, @eps1lon, @zieka, @dancerphil, @dimitropoulos, @disjukr, @vhfmag, @hellatan: you can do this too.)\n<!--typescript_bot_merge-offer-->"
       }
     }
   }

--- a/src/_tests/fixtures/45999/result.json
+++ b/src/_tests/fixtures/45999/result.json
@@ -32,7 +32,7 @@
     },
     {
       "tag": "merge-offer",
-      "status": "@alexpyzhianov Everything looks good here. Great job! I am ready to merge this PR on your behalf.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:"
+      "status": "@alexpyzhianov Everything looks good here. Great job! I am ready to merge this PR on your behalf.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n\n(@johnnyreilly, @bbenezech, @pzavolinsky, @digiguru, @ericanderson, @DovydasNavickas, @theruther4d, @guilhermehubner, @ferdaber, @jrakotoharisoa, @pascaloliv, @hotell, @franklixuefei, @Jessidhia, @saranshkataria, @lukyth, @eps1lon, @zieka, @dancerphil, @dimitropoulos, @disjukr, @vhfmag, @hellatan: you can do this too.)"
     }
   ],
   "shouldClose": false,

--- a/src/_tests/fixtures/46008/mutations.json
+++ b/src/_tests/fixtures/46008/mutations.json
@@ -33,7 +33,7 @@
     "variables": {
       "input": {
         "subjectId": "MDExOlB1bGxSZXF1ZXN0NDQ3NTU0NTEw",
-        "body": "@risingBirdSong Everything looks good here. Great job! I am ready to merge this PR on your behalf.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n<!--typescript_bot_merge-offer-->"
+        "body": "@risingBirdSong Everything looks good here. Great job! I am ready to merge this PR on your behalf.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n\n(@p5-types, @Zalastax: you can do this too.)\n<!--typescript_bot_merge-offer-->"
       }
     }
   }

--- a/src/_tests/fixtures/46008/result.json
+++ b/src/_tests/fixtures/46008/result.json
@@ -32,7 +32,7 @@
     },
     {
       "tag": "merge-offer",
-      "status": "@risingBirdSong Everything looks good here. Great job! I am ready to merge this PR on your behalf.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:"
+      "status": "@risingBirdSong Everything looks good here. Great job! I am ready to merge this PR on your behalf.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n\n(@p5-types, @Zalastax: you can do this too.)"
     }
   ],
   "shouldClose": false,

--- a/src/_tests/fixtures/46019/mutations.json
+++ b/src/_tests/fixtures/46019/mutations.json
@@ -7,5 +7,14 @@
         "body": "@peterblazejewicz Thank you for submitting this PR!\n\n***This is a live comment which I will keep updated.***\n\n\n## Code Reviews\n\nThis PR adds a new definition, so it needs to be reviewed by a DT maintainer before it can be merged.\n\n- [is-secret on npm](https://www.npmjs.com/package/is-secret)\n- [is-secret on unpkg](https://unpkg.com/browse/is-secret@latest//)\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ✅ Only a DT maintainer can approve changes when there are new packages added\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n----------------------\n... diagnostics scrubbed ...\n<!--typescript_bot_welcome-->"
       }
     }
+  },
+  {
+    "query": "mutation($input: UpdateIssueCommentInput!) { updateIssueComment(input: $input) { clientMutationId } }",
+    "variables": {
+      "input": {
+        "id": "MDEyOklzc3VlQ29tbWVudDY1NzE3MjMxMA==",
+        "body": "@peterblazejewicz Everything looks good here. Great job! I am ready to merge this PR on your behalf.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n\n<!--typescript_bot_merge-offer-->"
+      }
+    }
   }
 ]

--- a/src/_tests/fixtures/46019/result.json
+++ b/src/_tests/fixtures/46019/result.json
@@ -32,7 +32,7 @@
     },
     {
       "tag": "merge-offer",
-      "status": "@peterblazejewicz Everything looks good here. Great job! I am ready to merge this PR on your behalf.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:"
+      "status": "@peterblazejewicz Everything looks good here. Great job! I am ready to merge this PR on your behalf.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n"
     }
   ],
   "shouldClose": false,

--- a/src/comments.ts
+++ b/src/comments.ts
@@ -72,7 +72,7 @@ export const PingStaleReviewer = (reviewedAbbrOid: string, reviewers: string[]) 
     status: `@${reviewers.join(", @")} Thank you for reviewing this PR! The author has pushed new commits since your last review. Could you take another look and submit a fresh review?`
 });
 
-export const AskForAutoMergePermission = (user: string) => ({
+export const AskForAutoMergePermission = (user: string, otherOwners: string[]) => ({
     tag: `merge-offer`,
     status: `@${user} Everything looks good here. Great job! I am ready to merge this PR on your behalf.
 
@@ -80,7 +80,9 @@ If you'd like that to happen, please post a comment saying:
 
 > Ready to merge
 
-and I'll merge this PR almost instantly. Thanks for helping out! :heart:`});
+and I'll merge this PR almost instantly. Thanks for helping out! :heart:
+${otherOwners.length === 0 ? "" : `
+(${otherOwners.map(o => "@" + o).join(", ")}: you can do this too.)`}`});
 
 function tinyHash(s: string): string {
     return crypto.createHash("sha256").update(s).digest("hex").substr(0, 6);

--- a/src/compute-pr-actions.ts
+++ b/src/compute-pr-actions.ts
@@ -236,7 +236,10 @@ export function process(info: PrInfo | BotEnsureRemovedFromProject | BotNoPackag
             context.targetColumn = "Recently Merged";
         }
         else {
-            context.responseComments.push(Comments.AskForAutoMergePermission(info.author));
+            context.responseComments.push(Comments.AskForAutoMergePermission(
+                info.author,
+                (tooManyOwners(info) || !info.dangerLevel.startsWith("Scoped")) ? []
+                    : info.owners.filter(owner => owner !== info.author)));
             context.targetColumn = "Waiting for Author to Merge";
         }
 


### PR DESCRIPTION
Add text to the comment telling owners that it can be done --- *except*
when there are too many owners, or when there are multiple packages.
(Owners can still do it if there are many, only multiple packages block
the whole thing.)

Closes #98.

Also remove an unused `const approvals` line.