### PR TITLE
Fix handling of non-active PRs that are not draft

### DIFF
--- a/src/_tests/fixtures/43960-post-close/derived.json
+++ b/src/_tests/fixtures/43960-post-close/derived.json
@@ -1,5 +1,6 @@
 {
   "type": "remove",
   "pr_number": 43960,
-  "message": "PR is not active"
+  "message": "PR is not active",
+  "isDraft": false
 }

--- a/src/_tests/fixtures/43960-post-close/mutations.json
+++ b/src/_tests/fixtures/43960-post-close/mutations.json
@@ -1,11 +1,1 @@
-[
-  {
-    "query": "mutation($input: MoveProjectCardInput!) { moveProjectCard(input: $input) { clientMutationId } }",
-    "variables": {
-      "input": {
-        "cardId": "MDExOlByb2plY3RDYXJkMzcyNjkxMzM=",
-        "columnId": "MDEzOlByb2plY3RDb2x1bW43NTUyOTI0"
-      }
-    }
-  }
-]
+[]

--- a/src/_tests/fixtures/43960-post-close/result.json
+++ b/src/_tests/fixtures/43960-post-close/result.json
@@ -5,8 +5,7 @@
   "shouldClose": false,
   "shouldMerge": false,
   "shouldUpdateLabels": false,
-  "shouldUpdateProjectColumn": true,
+  "shouldUpdateProjectColumn": false,
   "shouldRemoveFromActiveColumns": false,
-  "isReadyForAutoMerge": false,
-  "targetColumn": "Needs Author Action"
+  "isReadyForAutoMerge": false
 }

--- a/src/_tests/fixtures/44105/derived.json
+++ b/src/_tests/fixtures/44105/derived.json
@@ -1,5 +1,6 @@
 {
   "type": "remove",
   "pr_number": 44105,
-  "message": "PR is not active"
+  "message": "PR is not active",
+  "isDraft": false
 }

--- a/src/_tests/fixtures/44105/mutations.json
+++ b/src/_tests/fixtures/44105/mutations.json
@@ -1,11 +1,1 @@
-[
-  {
-    "query": "mutation($input: MoveProjectCardInput!) { moveProjectCard(input: $input) { clientMutationId } }",
-    "variables": {
-      "input": {
-        "cardId": "MDExOlByb2plY3RDYXJkMzcxNDk2MTU=",
-        "columnId": "MDEzOlByb2plY3RDb2x1bW43NTUyOTI0"
-      }
-    }
-  }
-]
+[]

--- a/src/_tests/fixtures/44105/result.json
+++ b/src/_tests/fixtures/44105/result.json
@@ -5,8 +5,7 @@
   "shouldClose": false,
   "shouldMerge": false,
   "shouldUpdateLabels": false,
-  "shouldUpdateProjectColumn": true,
+  "shouldUpdateProjectColumn": false,
   "shouldRemoveFromActiveColumns": false,
-  "isReadyForAutoMerge": false,
-  "targetColumn": "Needs Author Action"
+  "isReadyForAutoMerge": false
 }

--- a/src/_tests/fixtures/44256/derived.json
+++ b/src/_tests/fixtures/44256/derived.json
@@ -1,5 +1,6 @@
 {
   "type": "remove",
   "pr_number": 44256,
-  "message": "PR is not active"
+  "message": "PR is not active",
+  "isDraft": false
 }

--- a/src/_tests/fixtures/44256/mutations.json
+++ b/src/_tests/fixtures/44256/mutations.json
@@ -1,14 +1,5 @@
 [
   {
-    "query": "mutation($input: MoveProjectCardInput!) { moveProjectCard(input: $input) { clientMutationId } }",
-    "variables": {
-      "input": {
-        "cardId": "MDExOlByb2plY3RDYXJkMzcyMDUzOTQ=",
-        "columnId": "MDEzOlByb2plY3RDb2x1bW43NTUyOTI0"
-      }
-    }
-  },
-  {
     "query": "mutation($input: DeleteIssueCommentInput!) { deleteIssueComment(input: $input) { clientMutationId } }",
     "variables": {
       "input": {

--- a/src/_tests/fixtures/44256/result.json
+++ b/src/_tests/fixtures/44256/result.json
@@ -5,8 +5,7 @@
   "shouldClose": false,
   "shouldMerge": false,
   "shouldUpdateLabels": false,
-  "shouldUpdateProjectColumn": true,
+  "shouldUpdateProjectColumn": false,
   "shouldRemoveFromActiveColumns": false,
-  "isReadyForAutoMerge": false,
-  "targetColumn": "Needs Author Action"
+  "isReadyForAutoMerge": false
 }

--- a/src/_tests/fixtures/44290/derived.json
+++ b/src/_tests/fixtures/44290/derived.json
@@ -1,5 +1,6 @@
 {
   "type": "remove",
   "pr_number": 44290,
-  "message": "PR is a draft"
+  "message": "PR is a draft",
+  "isDraft": true
 }

--- a/src/compute-pr-actions.ts
+++ b/src/compute-pr-actions.ts
@@ -106,11 +106,9 @@ const uriForTestingNewPackages = "https://github.com/DefinitelyTyped/DefinitelyT
 
 export function process(info: PrInfo | BotEnsureRemovedFromProject | BotNoPackages | BotError ): Actions {
     if (info.type === "remove") {
-        return {
-            ...createEmptyActions(info.pr_number),
-            targetColumn: "Needs Author Action",
-            shouldUpdateProjectColumn: true
-        };
+        const empty = createEmptyActions(info.pr_number);
+        return !info.isDraft ? empty
+            : { ...empty, targetColumn: "Needs Author Action", shouldUpdateProjectColumn: true };
     }
 
     if (info.type === "no_packages") {

--- a/src/pr-info.ts
+++ b/src/pr-info.ts
@@ -59,6 +59,7 @@ export interface BotEnsureRemovedFromProject {
     readonly type: "remove";
     readonly pr_number: number;
     readonly message: string;
+    readonly isDraft: boolean;
 }
 
 export interface BotNoPackages {
@@ -214,8 +215,8 @@ export async function deriveStateForPR(
     const headCommit = getHeadCommit(prInfo);
     if (headCommit == null) return botError(prInfo.number, "No head commit found");
 
-    if (prInfo.state !== "OPEN") return botEnsureRemovedFromProject(prInfo.number, "PR is not active");
-    if (prInfo.isDraft) return botEnsureRemovedFromProject(prInfo.number, "PR is a draft");
+    if (prInfo.isDraft) return botEnsureRemovedFromProject(prInfo.number, "PR is a draft", true);
+    if (prInfo.state !== "OPEN") return botEnsureRemovedFromProject(prInfo.number, "PR is not active", false);
 
     const categorizedFiles = await Promise.all(
         noNulls(prInfo.files?.nodes)
@@ -284,8 +285,8 @@ export async function deriveStateForPR(
         return { type: "error", message, pr_number, author: prInfo?.author?.login };
     }
 
-    function botEnsureRemovedFromProject(pr_number: number, message: string): BotEnsureRemovedFromProject {
-        return { type: "remove", pr_number, message };
+    function botEnsureRemovedFromProject(pr_number: number, message: string, isDraft: boolean): BotEnsureRemovedFromProject {
+        return { type: "remove", pr_number, message, isDraft };
     }
 
     function botNoPackages(pr_number: number): BotNoPackages {


### PR DESCRIPTION
My earlier commit moved all PRs with a `"remove"` info to NAA, but this
is wrong for PRs that are closed or merged.  So add an `isDraft` field
to the info, and move only the draft ones to NAA.