### PR TITLE
Avoid throwing an error if we couldn't find a pr

### DIFF
--- a/PR-Trigger/index.js
+++ b/PR-Trigger/index.js
@@ -109,13 +109,14 @@ const httpTrigger = async function (context, _req) {
         const repo = webhook.repository.name;
         const sha = webhook.check_suite.head_sha;
         const pr = await runQueryToGetPRMetadataForSHA1(owner, repo, sha);
-        if (!pr) throw new Error(`Could not get PR for the status on ${sha}`);
-        if (pr.closed) {
-            context.log.info(`Skipped webhook, could not find an open PR for the sha referenced in the status (${sha})`);
+        if (!pr || pr.closed) {
+            const whatFailed = !pr ? "a PR" : "an open PR";
+            context.log.info(`Skipped webhook, could not find ${whatFailed} for the sha referenced in the status (${sha})`);
             context.res = {
                 status: 204,
-                body: `NOOPing due to not finding an open PR for the sha ${sha}`
+                body: `NOOPing due to not finding ${whatFailed} for the sha ${sha}`
             };
+            return;
         }
         prNumber = pr.number;
     }


### PR DESCRIPTION
There were cases where the sha1 search didn't find a PR, probably
because the PR was already closed: avoid throwing an error and instead
show text in the log, which makes it easy to find these things
later (and will not mark the GH hook delivery as failed).

Note also the added `return`, which I think should have been there to
really be a NOOP.  (But maybe it *should have not been* a NOOP?)