### PR TITLE
Fix handling non-draft non-closed prs yet again

### DIFF
--- a/src/_tests/fixtures/43960-post-close/mutations.json
+++ b/src/_tests/fixtures/43960-post-close/mutations.json
@@ -1,1 +1,10 @@
-[]
+[
+  {
+    "query": "mutation($input: DeleteProjectCardInput!) { deleteProjectCard(input: $input) { clientMutationId } }",
+    "variables": {
+      "input": {
+        "cardId": "MDExOlByb2plY3RDYXJkMzcyNjkxMzM="
+      }
+    }
+  }
+]

--- a/src/_tests/fixtures/43960-post-close/result.json
+++ b/src/_tests/fixtures/43960-post-close/result.json
@@ -6,6 +6,6 @@
   "shouldMerge": false,
   "shouldUpdateLabels": false,
   "shouldUpdateProjectColumn": false,
-  "shouldRemoveFromActiveColumns": false,
+  "shouldRemoveFromActiveColumns": true,
   "isReadyForAutoMerge": false
 }

--- a/src/_tests/fixtures/44105/mutations.json
+++ b/src/_tests/fixtures/44105/mutations.json
@@ -1,1 +1,10 @@
-[]
+[
+  {
+    "query": "mutation($input: DeleteProjectCardInput!) { deleteProjectCard(input: $input) { clientMutationId } }",
+    "variables": {
+      "input": {
+        "cardId": "MDExOlByb2plY3RDYXJkMzcxNDk2MTU="
+      }
+    }
+  }
+]

--- a/src/_tests/fixtures/44105/result.json
+++ b/src/_tests/fixtures/44105/result.json
@@ -6,6 +6,6 @@
   "shouldMerge": false,
   "shouldUpdateLabels": false,
   "shouldUpdateProjectColumn": false,
-  "shouldRemoveFromActiveColumns": false,
+  "shouldRemoveFromActiveColumns": true,
   "isReadyForAutoMerge": false
 }

--- a/src/_tests/fixtures/44256/result.json
+++ b/src/_tests/fixtures/44256/result.json
@@ -6,6 +6,6 @@
   "shouldMerge": false,
   "shouldUpdateLabels": false,
   "shouldUpdateProjectColumn": false,
-  "shouldRemoveFromActiveColumns": false,
+  "shouldRemoveFromActiveColumns": true,
   "isReadyForAutoMerge": false
 }

--- a/src/compute-pr-actions.ts
+++ b/src/compute-pr-actions.ts
@@ -106,9 +106,18 @@ const uriForTestingNewPackages = "https://github.com/DefinitelyTyped/DefinitelyT
 
 export function process(info: PrInfo | BotEnsureRemovedFromProject | BotNoPackages | BotError ): Actions {
     if (info.type === "remove") {
-        const empty = createEmptyActions(info.pr_number);
-        return !info.isDraft ? empty
-            : { ...empty, targetColumn: "Needs Author Action", shouldUpdateProjectColumn: true };
+        if (info.isDraft) {
+            return {
+                ...createEmptyActions(info.pr_number),
+                targetColumn: "Needs Author Action",
+                shouldUpdateProjectColumn: true
+            };
+        } else {
+            return {
+                ...createEmptyActions(info.pr_number),
+                shouldRemoveFromActiveColumns: true
+            };
+        };
     }
 
     if (info.type === "no_packages") {


### PR DESCRIPTION
Should have used `shouldRemoveFromActiveColumns` for these so they're
still removed from wherever they were.