### PR TITLE
Temporary: Show failed data, disable sequential processing

### DIFF
--- a/PR-Trigger/index.js
+++ b/PR-Trigger/index.js
@@ -131,7 +131,7 @@ const httpTrigger = async function (context, _req) {
 
     // If it didn't work, bail early
     if (state.type === "fail") {
-        const isIssueNotPR = state.message === "No PR with this number exists" && "issue" in webhook;
+        const isIssueNotPR = state.message.startsWith("No PR with this number exists") && "issue" in webhook;
         if (isIssueNotPR) {
             context.res = {
                 status: 204,

--- a/host.json
+++ b/host.json
@@ -4,14 +4,6 @@
     "id": "Microsoft.Azure.Functions.ExtensionBundle",
     "version": "[1.*, 2.0.0)"
   },
-  "extensions": {
-    "http": {
-      "routePrefix": "api",
-      "maxOutstandingRequests": 200,
-      "maxConcurrentRequests": 1,
-      "dynamicThrottlesEnabled": false
-    }
-  },
   "singleton": {
       "lockPeriod": "00:00:15",
       "listenerLockPeriod": "00:01:00",

--- a/src/pr-info.ts
+++ b/src/pr-info.ts
@@ -210,7 +210,7 @@ export async function deriveStateForPR(
 ): Promise<PrInfo | BotFail | BotError | BotEnsureRemovedFromProject | BotNoPackages>  {
     const prInfo = info.data.repository?.pullRequest;
 
-    if (!prInfo) return botFail("No PR with this number exists");
+    if (!prInfo) return botFail(`No PR with this number exists, (${JSON.stringify(info)})`);
     if (prInfo.author == null) return botError(prInfo.number, "PR author does not exist");
 
     const headCommit = getHeadCommit(prInfo);


### PR DESCRIPTION
Trying to debug why there is no `pullRequest` data in some cases.  Also,
disable sequential http processing to see if that causes the
weirdnesses.
