### PR TITLE
Slight improvement for single owners

### DIFF
--- a/src/_tests/fixtures/46279/_downloads.json
+++ b/src/_tests/fixtures/46279/_downloads.json
@@ -1,0 +1,3 @@
+{
+  "phoenix_live_view": 1639
+}

--- a/src/_tests/fixtures/46279/_files.json
+++ b/src/_tests/fixtures/46279/_files.json
@@ -1,0 +1,3 @@
+{
+  "master:types/phoenix_live_view/index.d.ts": "// Type definitions for phoenix_live_view 0.13\n// Project: https://github.com/phoenixframework/phoenix_live_view\n// Definitions by: Peter Zingg <https://github.com/pzingg>\n// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped\n"
+}

--- a/src/_tests/fixtures/46279/_response.json
+++ b/src/_tests/fixtures/46279/_response.json
@@ -1,0 +1,176 @@
+{
+  "data": {
+    "repository": {
+      "pullRequest": {
+        "id": "MDExOlB1bGxSZXF1ZXN0NDU1NDI5NDU3",
+        "title": "phoenix_live_view v0.14.2",
+        "lastEditedAt": null,
+        "author": {
+          "login": "pzingg",
+          "__typename": "User"
+        },
+        "authorAssociation": "CONTRIBUTOR",
+        "baseRef": {
+          "name": "master",
+          "__typename": "Ref"
+        },
+        "changedFiles": 1,
+        "createdAt": "2020-07-23T01:06:45Z",
+        "labels": {
+          "nodes": [
+            {
+              "name": "Author is Owner",
+              "__typename": "Label"
+            },
+            {
+              "name": "No Other Owners",
+              "__typename": "Label"
+            },
+            {
+              "name": "Untested Change",
+              "__typename": "Label"
+            }
+          ],
+          "__typename": "LabelConnection"
+        },
+        "isDraft": false,
+        "mergeable": "UNKNOWN",
+        "number": 46279,
+        "state": "OPEN",
+        "headRefOid": "80322389c71c13e0fca466b744b35b742a3ee161",
+        "timelineItems": {
+          "nodes": [
+            {
+              "__typename": "IssueComment",
+              "author": {
+                "login": "typescript-bot",
+                "__typename": "User"
+              },
+              "createdAt": "2020-07-23T01:09:59Z"
+            },
+            {
+              "__typename": "IssueComment",
+              "author": {
+                "login": "typescript-bot",
+                "__typename": "User"
+              },
+              "createdAt": "2020-07-23T01:10:00Z"
+            },
+            {
+              "__typename": "MovedColumnsInProjectEvent",
+              "actor": {
+                "login": "sheetalkamat",
+                "__typename": "User"
+              },
+              "createdAt": "2020-07-23T18:40:41Z"
+            }
+          ],
+          "__typename": "PullRequestTimelineItemsConnection"
+        },
+        "reviews": {
+          "nodes": [],
+          "__typename": "PullRequestReviewConnection"
+        },
+        "commits": {
+          "totalCount": 1,
+          "nodes": [
+            {
+              "commit": {
+                "checkSuites": {
+                  "nodes": [
+                    {
+                      "app": {
+                        "name": "GitHub Actions",
+                        "__typename": "App"
+                      },
+                      "conclusion": "SUCCESS",
+                      "resourcePath": "/DefinitelyTyped/DefinitelyTyped/commit/80322389c71c13e0fca466b744b35b742a3ee161/checks?check_suite_id=953025934",
+                      "status": "COMPLETED",
+                      "url": "https://github.com/DefinitelyTyped/DefinitelyTyped/commit/80322389c71c13e0fca466b744b35b742a3ee161/checks?check_suite_id=953025934",
+                      "__typename": "CheckSuite"
+                    },
+                    {
+                      "app": {
+                        "name": "Azure Pipelines",
+                        "__typename": "App"
+                      },
+                      "conclusion": "SUCCESS",
+                      "resourcePath": "/DefinitelyTyped/DefinitelyTyped/commit/80322389c71c13e0fca466b744b35b742a3ee161/checks?check_suite_id=953026463",
+                      "status": "COMPLETED",
+                      "url": "https://github.com/DefinitelyTyped/DefinitelyTyped/commit/80322389c71c13e0fca466b744b35b742a3ee161/checks?check_suite_id=953026463",
+                      "__typename": "CheckSuite"
+                    }
+                  ],
+                  "__typename": "CheckSuiteConnection"
+                },
+                "status": null,
+                "authoredDate": "2020-07-23T01:03:20Z",
+                "committedDate": "2020-07-23T01:03:20Z",
+                "pushedDate": "2020-07-23T01:03:50Z",
+                "abbreviatedOid": "8032238",
+                "oid": "80322389c71c13e0fca466b744b35b742a3ee161",
+                "__typename": "Commit"
+              },
+              "__typename": "PullRequestCommit"
+            }
+          ],
+          "__typename": "PullRequestCommitConnection"
+        },
+        "comments": {
+          "totalCount": 2,
+          "nodes": [
+            {
+              "id": "MDEyOklzc3VlQ29tbWVudDY2Mjc3Mjk1MA==",
+              "author": {
+                "login": "typescript-bot",
+                "__typename": "User"
+              },
+              "body": "@pzingg Thank you for submitting this PR!\n\n***This is a live comment which I will keep updated.***\n\n This PR doesn't modify any tests, so it's hard to know what's being fixed, and your changes might regress in the future. Have you considered [adding tests](https://github.com/DefinitelyTyped/DefinitelyTyped#editing-tests-on-an-existing-package) to cover the change you're making? Including tests allows this PR to be merged by yourself and the owners of this module. This can potentially save days of time for you.\n\n## Code Reviews\n\nThis PR can be merged once it's reviewed.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ A DT maintainer can merge changes when there are no other reviewers\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n----------------------\n... diagnostics scrubbed ...\n<!--typescript_bot_welcome-->",
+              "createdAt": "2020-07-23T01:09:59Z",
+              "reactions": {
+                "nodes": [],
+                "__typename": "ReactionConnection"
+              },
+              "__typename": "IssueComment"
+            },
+            {
+              "id": "MDEyOklzc3VlQ29tbWVudDY2Mjc3Mjk1NA==",
+              "author": {
+                "login": "typescript-bot",
+                "__typename": "User"
+              },
+              "body": "🔔 @pzingg — you're the only owner, but it would still be good if you find someone to [review this PR](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/46279/files) in the next few days, otherwise a maintainer will look at it. (And if you do find someone, maybe even recruit them to be a second owner to make future changes easier...)\n<!--typescript_bot_pinging-reviewers-others-->",
+              "createdAt": "2020-07-23T01:10:00Z",
+              "reactions": {
+                "nodes": [],
+                "__typename": "ReactionConnection"
+              },
+              "__typename": "IssueComment"
+            }
+          ],
+          "__typename": "IssueCommentConnection"
+        },
+        "files": {
+          "nodes": [
+            {
+              "path": "types/phoenix_live_view/index.d.ts",
+              "additions": 22,
+              "deletions": 18,
+              "__typename": "PullRequestChangedFile"
+            }
+          ],
+          "__typename": "PullRequestChangedFileConnection"
+        },
+        "projectCards": {
+          "nodes": [],
+          "__typename": "ProjectCardConnection"
+        },
+        "__typename": "PullRequest"
+      },
+      "__typename": "Repository"
+    }
+  },
+  "loading": false,
+  "networkStatus": 7,
+  "stale": false
+}

--- a/src/_tests/fixtures/46279/derived.json
+++ b/src/_tests/fixtures/46279/derived.json
@@ -1,0 +1,38 @@
+{
+  "type": "info",
+  "now": "2020-07-23T18:40:42.000Z",
+  "pr_number": 46279,
+  "author": "pzingg",
+  "owners": [
+    "pzingg"
+  ],
+  "dangerLevel": "ScopedAndUntested",
+  "headCommitAbbrOid": "8032238",
+  "headCommitOid": "80322389c71c13e0fca466b744b35b742a3ee161",
+  "mergeIsRequested": false,
+  "stalenessInDays": 0,
+  "lastPushDate": "2020-07-23T01:03:50.000Z",
+  "lastCommentDate": "2020-07-23T01:03:50.000Z",
+  "maintainerBlessed": true,
+  "reviewLink": "https://github.com/DefinitelyTyped/DefinitelyTyped/pull/46279/files",
+  "hasMergeConflict": false,
+  "authorIsOwner": true,
+  "isFirstContribution": false,
+  "popularityLevel": "Well-liked by everyone",
+  "anyPackageIsNew": false,
+  "packages": [
+    "phoenix_live_view"
+  ],
+  "files": [
+    {
+      "path": "types/phoenix_live_view/index.d.ts",
+      "kind": "definition",
+      "package": "phoenix_live_view"
+    }
+  ],
+  "hasDismissedReview": false,
+  "ciResult": "pass",
+  "reviewersWithStaleReviews": [],
+  "approvalFlags": 0,
+  "isChangesRequested": false
+}

--- a/src/_tests/fixtures/46279/mutations.json
+++ b/src/_tests/fixtures/46279/mutations.json
@@ -1,0 +1,20 @@
+[
+  {
+    "query": "mutation($input: AddProjectCardInput!) { addProjectCard(input: $input) { clientMutationId } }",
+    "variables": {
+      "input": {
+        "contentId": "MDExOlB1bGxSZXF1ZXN0NDU1NDI5NDU3",
+        "projectColumnId": "MDEzOlByb2plY3RDb2x1bW43NTUyOTIy"
+      }
+    }
+  },
+  {
+    "query": "mutation($input: UpdateIssueCommentInput!) { updateIssueComment(input: $input) { clientMutationId } }",
+    "variables": {
+      "input": {
+        "id": "MDEyOklzc3VlQ29tbWVudDY2Mjc3Mjk1MA==",
+        "body": "@pzingg Thank you for submitting this PR!\n\n***This is a live comment which I will keep updated.***\n\n This PR doesn't modify any tests, so it's hard to know what's being fixed, and your changes might regress in the future. Have you considered [adding tests](https://github.com/DefinitelyTyped/DefinitelyTyped#editing-tests-on-an-existing-package) to cover the change you're making? Including tests allows this PR to be merged by yourself and the owners of this module. This can potentially save days of time for you.\n\n## Code Reviews\n\nThis PR can be merged once it's reviewed.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ Most recent commit is approved by type definition owners or DT maintainers\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n----------------------\n... diagnostics scrubbed ...\n<!--typescript_bot_welcome-->"
+      }
+    }
+  }
+]

--- a/src/_tests/fixtures/46279/result.json
+++ b/src/_tests/fixtures/46279/result.json
@@ -1,0 +1,44 @@
+{
+  "pr_number": 46279,
+  "targetColumn": "Needs Maintainer Review",
+  "labels": {
+    "Mergebot Error": false,
+    "Has Merge Conflict": false,
+    "The CI failed": false,
+    "Revision needed": false,
+    "New Definition": false,
+    "Where is GH Actions?": false,
+    "Owner Approved": false,
+    "Other Approved": false,
+    "Maintainer Approved": false,
+    "Merge:LGTM": false,
+    "Merge:YSYL": false,
+    "Popular package": false,
+    "Critical package": false,
+    "Edits Infrastructure": false,
+    "Edits multiple packages": false,
+    "Author is Owner": true,
+    "No Other Owners": true,
+    "Too Many Owners": false,
+    "Merge:Auto": false,
+    "Untested Change": true,
+    "Config Edit": false,
+    "Abandoned": false
+  },
+  "responseComments": [
+    {
+      "tag": "welcome",
+      "status": "@pzingg Thank you for submitting this PR!\n\n***This is a live comment which I will keep updated.***\n\n This PR doesn't modify any tests, so it's hard to know what's being fixed, and your changes might regress in the future. Have you considered [adding tests](https://github.com/DefinitelyTyped/DefinitelyTyped#editing-tests-on-an-existing-package) to cover the change you're making? Including tests allows this PR to be merged by yourself and the owners of this module. This can potentially save days of time for you.\n\n## Code Reviews\n\nThis PR can be merged once it's reviewed.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ Most recent commit is approved by type definition owners or DT maintainers\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n----------------------\n... diagnostics scrubbed ..."
+    },
+    {
+      "tag": "pinging-reviewers-others",
+      "status": "🔔 @pzingg — you're the only owner, but it would still be good if you find someone to [review this PR](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/46279/files) in the next few days, otherwise a maintainer will look at it. (And if you do find someone, maybe even recruit them to be a second owner to make future changes easier...)"
+    }
+  ],
+  "shouldClose": false,
+  "shouldMerge": false,
+  "shouldUpdateLabels": true,
+  "shouldUpdateProjectColumn": true,
+  "shouldRemoveFromActiveColumns": false,
+  "isReadyForAutoMerge": false
+}

--- a/src/compute-pr-actions.ts
+++ b/src/compute-pr-actions.ts
@@ -402,7 +402,7 @@ function createWelcomeComment(info: PrInfo, staleness: Staleness) {
         const infraFiles = info.files.filter(f => f.kind === "infrastructure")
         const links = infraFiles.map(f => `[\`${f.path}\`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/${info.headCommitOid}/${f.path})`);
         display(` * ${emoji(approval.approved)} A DT maintainer needs to approve changes which affect DT infrastructure (${links.join(", ")})`);
-    } else if (info.dangerLevel === "ScopedAndTested") {
+    } else if (info.dangerLevel === "ScopedAndTested" || info.maintainerBlessed) {
         display(` * ${emoji(approval.approved)} Most recent commit is approved by ${approval.requiredApprovalBy}`);
     } else if (otherOwners.length === 0) {
         display(` * ${emoji(approval.approved)} A DT maintainer can merge changes when there are no other reviewers`);


### PR DESCRIPTION
Make the main checklist show

> Most recent commit is approved by type definition owners or DT maintainers

It still is confusing that it's only a minor phrasing response for
blessing the PR, but it's still in the maintainer queue column.  It
might be better to have something more concrete for single owners, but
anything I can think about is a major change.