### PR TITLE
A quick stab at improving the state of editing multiple packages

### DIFF
--- a/src/_tests/fixtures/45836/mutations.json
+++ b/src/_tests/fixtures/45836/mutations.json
@@ -24,7 +24,7 @@
     "variables": {
       "input": {
         "id": "MDEyOklzc3VlQ29tbWVudDY1MjY4ODU2Nw==",
-        "body": "@mmorearty Thank you for submitting this PR!\n\n***This is a live comment which I will keep updated.***\n\n\n## Code Reviews\n\nBecause this PR edits multiple packages, it can be merged once it's reviewed by a DT maintainer.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ Only a DT maintainer can approve changes [without tests](https://github.com/DefinitelyTyped/DefinitelyTyped#editing-tests-on-an-existing-package)\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n----------------------\n... diagnostics scrubbed ...\n<!--typescript_bot_welcome-->"
+        "body": "@mmorearty Thank you for submitting this PR!\n\n***This is a live comment which I will keep updated.***\n\n\n## Code Reviews\n\nBecause this PR edits multiple packages, it can be merged once it's reviewed by a DT maintainer.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ A DT maintainer needs to approve changes which affect more than one package\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n----------------------\n... diagnostics scrubbed ...\n<!--typescript_bot_welcome-->"
       }
     }
   }

--- a/src/_tests/fixtures/45836/result.json
+++ b/src/_tests/fixtures/45836/result.json
@@ -28,7 +28,7 @@
   "responseComments": [
     {
       "tag": "welcome",
-      "status": "@mmorearty Thank you for submitting this PR!\n\n***This is a live comment which I will keep updated.***\n\n\n## Code Reviews\n\nBecause this PR edits multiple packages, it can be merged once it's reviewed by a DT maintainer.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ Only a DT maintainer can approve changes [without tests](https://github.com/DefinitelyTyped/DefinitelyTyped#editing-tests-on-an-existing-package)\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n----------------------\n... diagnostics scrubbed ..."
+      "status": "@mmorearty Thank you for submitting this PR!\n\n***This is a live comment which I will keep updated.***\n\n\n## Code Reviews\n\nBecause this PR edits multiple packages, it can be merged once it's reviewed by a DT maintainer.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ A DT maintainer needs to approve changes which affect more than one package\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n----------------------\n... diagnostics scrubbed ..."
     }
   ],
   "shouldClose": false,

--- a/src/compute-pr-actions.ts
+++ b/src/compute-pr-actions.ts
@@ -407,6 +407,8 @@ function createWelcomeComment(info: PrInfo, staleness: Staleness) {
         const infraFiles = info.files.filter(f => f.kind === "infrastructure");
         const links = infraFiles.map(f => `[\`${f.path}\`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/${info.headCommitOid}/${f.path})`);
         display(` * ${emoji(approval.approved)} A DT maintainer needs to approve changes which affect DT infrastructure (${links.join(", ")})`);
+    } else if (info.dangerLevel === "MultiplePackagesEdited") {
+        display(` * ${emoji(approval.approved)} A DT maintainer needs to approve changes which affect more than one package`);
     } else if (info.dangerLevel === "ScopedAndTested" || info.maintainerBlessed) {
         display(` * ${emoji(approval.approved)} Most recent commit is approved by ${approval.requiredApprovalBy}`);
     } else if (otherOwners.length === 0) {

--- a/src/pr-info.ts
+++ b/src/pr-info.ts
@@ -421,6 +421,10 @@ export function getPackagesTouched(files: readonly FileInfo[]) {
     return [...new Set(noNulls(files.map(f => "package" in f ? f.package : null)))];
 }
 
+export function getPackagesWithSourceFilesTouched(files: readonly FileInfo[]) {
+    return [...new Set(noNulls(files.map(f => "package" in f && f.kind === "definition" ? f.package : null)))];
+}
+
 function partition<T, U extends string>(arr: ReadonlyArray<T>, sorter: (el: T) => U) {
     const res: { [K in U]?: T[] } = {};
     for (const el of arr) {
@@ -498,9 +502,11 @@ function getDangerLevel(categorizedFiles: readonly FileInfo[]): DangerLevel {
         return "Infrastructure";
     }
     const packagesTouched = getPackagesTouched(categorizedFiles);
+    const sourcePackagesTouched = getPackagesWithSourceFilesTouched(categorizedFiles);
+
     if (packagesTouched.length === 0) {
         return "Infrastructure";
-    } else if (packagesTouched.length > 1) {
+    } else if (sourcePackagesTouched.length > 1) {
         return "MultiplePackagesEdited";
     } else if (categorizedFiles.some(f => f.kind === "package-meta")) {
         return "ScopedAndConfiguration";


### PR DESCRIPTION
This attacks two problems:

 - You edit a dependency, then you have to update downstream tests as well as your own
 -  You see a non-sensical error message when blocked by being on multiple packages: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/46321

Will commenting inline