### PR TITLE
Delete cards of closed PRs

### DIFF
--- a/src/queries/SHA1-to-PR-query.ts
+++ b/src/queries/SHA1-to-PR-query.ts
@@ -1,6 +1,6 @@
 import { gql } from "apollo-boost";
-import { client } from "../graphql-client"
-import { GetPRForSHA1 } from "./schema/GetPRForSHA1"
+import { client } from "../graphql-client";
+import { GetPRForSHA1 } from "./schema/GetPRForSHA1";
 
 export const runQueryToGetPRMetadataForSHA1 = async (owner: string, repo: string, sha1: string) => {
   const info = await client.query<GetPRForSHA1>({
@@ -11,7 +11,7 @@ export const runQueryToGetPRMetadataForSHA1 = async (owner: string, repo: string
   });
   const pr = info.data.search.nodes?.[0];
   return pr?.__typename === "PullRequest" ? pr : undefined;
-}
+};
 
 export const GetPRForSHA1Query = gql`
 query GetPRForSHA1($query: String!) {

--- a/src/queries/card-id-to-pr-query.ts
+++ b/src/queries/card-id-to-pr-query.ts
@@ -1,0 +1,27 @@
+import { gql } from "apollo-boost";
+import { client } from "../graphql-client";
+import { PullRequestState } from "../schema/graphql-global-types";
+import { CardIdToPr } from "./schema/CardIdToPr";
+
+interface CardPRInfo {
+    number: number;
+    state: PullRequestState;
+}
+
+export const runQueryToGetPRForCardId = async (id: string): Promise<CardPRInfo | undefined> => {
+    const info = await client.query<CardIdToPr>({
+        query: gql`
+            query CardIdToPr($id: ID!) {
+                node(id: $id) {
+                    ... on ProjectCard { content { ... on PullRequest { state number } } }
+                }
+            }`,
+        variables: { id },
+        fetchPolicy: "network-only",
+        fetchResults: true
+    });
+    const node = info.data.node;
+    return (node?.__typename === "ProjectCard" && node.content?.__typename === "PullRequest")
+        ? { number: node.content.number, state: node.content.state }
+        : undefined;
+}

--- a/src/queries/schema/CardIdToPr.ts
+++ b/src/queries/schema/CardIdToPr.ts
@@ -1,0 +1,53 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { PullRequestState } from "./../../schema/graphql-global-types";
+
+// ====================================================
+// GraphQL query operation: CardIdToPr
+// ====================================================
+
+export interface CardIdToPr_node_CodeOfConduct {
+  __typename: "CodeOfConduct" | "Enterprise" | "EnterpriseUserAccount" | "Organization" | "Package" | "PackageVersion" | "PackageFile" | "Release" | "User" | "Project" | "ProjectColumn" | "Issue" | "UserContentEdit" | "Label" | "PullRequest" | "Reaction" | "Repository" | "License" | "BranchProtectionRule" | "Ref" | "PushAllowance" | "App" | "Team" | "UserStatus" | "TeamDiscussion" | "TeamDiscussionComment" | "OrganizationInvitation" | "ReviewDismissalAllowance" | "CommitComment" | "Commit" | "CheckSuite" | "CheckRun" | "Push" | "Deployment" | "DeploymentStatus" | "Status" | "StatusContext" | "StatusCheckRollup" | "Tree" | "DeployKey" | "Language" | "Milestone" | "RepositoryTopic" | "Topic" | "RepositoryVulnerabilityAlert" | "SecurityAdvisory" | "IssueComment" | "PullRequestCommit" | "ReviewRequest" | "Mannequin" | "PullRequestReviewThread" | "PullRequestReviewComment" | "PullRequestReview" | "AssignedEvent" | "Bot" | "BaseRefForcePushedEvent" | "ClosedEvent" | "CommitCommentThread" | "CrossReferencedEvent" | "DemilestonedEvent" | "DeployedEvent" | "DeploymentEnvironmentChangedEvent" | "HeadRefDeletedEvent" | "HeadRefForcePushedEvent" | "HeadRefRestoredEvent" | "LabeledEvent" | "LockedEvent" | "MergedEvent" | "MilestonedEvent" | "ReferencedEvent" | "RenamedTitleEvent" | "ReopenedEvent" | "ReviewDismissedEvent" | "ReviewRequestRemovedEvent" | "ReviewRequestedEvent" | "SubscribedEvent" | "UnassignedEvent" | "UnlabeledEvent" | "UnlockedEvent" | "UnsubscribedEvent" | "UserBlockedEvent" | "AddedToProjectEvent" | "AutomaticBaseChangeFailedEvent" | "AutomaticBaseChangeSucceededEvent" | "BaseRefChangedEvent" | "CommentDeletedEvent" | "ConnectedEvent" | "ConvertToDraftEvent" | "ConvertedNoteToIssueEvent" | "DisconnectedEvent" | "MarkedAsDuplicateEvent" | "MentionedEvent" | "MovedColumnsInProjectEvent" | "PinnedEvent" | "PullRequestCommitCommentThread" | "ReadyForReviewEvent" | "RemovedFromProjectEvent" | "TransferredEvent" | "UnmarkedAsDuplicateEvent" | "UnpinnedEvent" | "Gist" | "GistComment" | "SponsorsListing" | "SponsorsTier" | "Sponsorship" | "PublicKey" | "SavedReply" | "ReleaseAsset" | "MembersCanDeleteReposClearAuditEntry" | "MembersCanDeleteReposDisableAuditEntry" | "MembersCanDeleteReposEnableAuditEntry" | "OauthApplicationCreateAuditEntry" | "OrgAddBillingManagerAuditEntry" | "OrgAddMemberAuditEntry" | "OrgBlockUserAuditEntry" | "OrgConfigDisableCollaboratorsOnlyAuditEntry" | "OrgConfigEnableCollaboratorsOnlyAuditEntry" | "OrgCreateAuditEntry" | "OrgDisableOauthAppRestrictionsAuditEntry" | "OrgDisableSamlAuditEntry" | "OrgDisableTwoFactorRequirementAuditEntry" | "OrgEnableOauthAppRestrictionsAuditEntry" | "OrgEnableSamlAuditEntry" | "OrgEnableTwoFactorRequirementAuditEntry" | "OrgInviteMemberAuditEntry" | "OrgInviteToBusinessAuditEntry" | "OrgOauthAppAccessApprovedAuditEntry" | "OrgOauthAppAccessDeniedAuditEntry" | "OrgOauthAppAccessRequestedAuditEntry" | "OrgRemoveBillingManagerAuditEntry" | "OrgRemoveMemberAuditEntry" | "OrgRemoveOutsideCollaboratorAuditEntry" | "OrgRestoreMemberAuditEntry" | "OrgUnblockUserAuditEntry" | "OrgUpdateDefaultRepositoryPermissionAuditEntry" | "OrgUpdateMemberAuditEntry" | "OrgUpdateMemberRepositoryCreationPermissionAuditEntry" | "OrgUpdateMemberRepositoryInvitationPermissionAuditEntry" | "PrivateRepositoryForkingDisableAuditEntry" | "PrivateRepositoryForkingEnableAuditEntry" | "RepoAccessAuditEntry" | "RepoAddMemberAuditEntry" | "RepoAddTopicAuditEntry" | "RepoArchivedAuditEntry" | "RepoChangeMergeSettingAuditEntry" | "RepoConfigDisableAnonymousGitAccessAuditEntry" | "RepoConfigDisableCollaboratorsOnlyAuditEntry" | "RepoConfigDisableContributorsOnlyAuditEntry" | "RepoConfigDisableSockpuppetDisallowedAuditEntry" | "RepoConfigEnableAnonymousGitAccessAuditEntry" | "RepoConfigEnableCollaboratorsOnlyAuditEntry" | "RepoConfigEnableContributorsOnlyAuditEntry" | "RepoConfigEnableSockpuppetDisallowedAuditEntry" | "RepoConfigLockAnonymousGitAccessAuditEntry" | "RepoConfigUnlockAnonymousGitAccessAuditEntry" | "RepoCreateAuditEntry" | "RepoDestroyAuditEntry" | "RepoRemoveMemberAuditEntry" | "RepoRemoveTopicAuditEntry" | "RepositoryVisibilityChangeDisableAuditEntry" | "RepositoryVisibilityChangeEnableAuditEntry" | "TeamAddMemberAuditEntry" | "TeamAddRepositoryAuditEntry" | "TeamChangeParentTeamAuditEntry" | "TeamRemoveMemberAuditEntry" | "TeamRemoveRepositoryAuditEntry" | "IpAllowListEntry" | "OrganizationIdentityProvider" | "ExternalIdentity" | "EnterpriseServerInstallation" | "EnterpriseServerUserAccount" | "EnterpriseServerUserAccountEmail" | "EnterpriseServerUserAccountsUpload" | "EnterpriseRepositoryInfo" | "EnterpriseAdministratorInvitation" | "RepositoryInvitation" | "EnterpriseIdentityProvider" | "MarketplaceCategory" | "MarketplaceListing" | "Blob" | "PackageTag" | "Tag";
+}
+
+export interface CardIdToPr_node_ProjectCard_content_Issue {
+  __typename: "Issue";
+}
+
+export interface CardIdToPr_node_ProjectCard_content_PullRequest {
+  __typename: "PullRequest";
+  /**
+   * Identifies the state of the pull request.
+   */
+  state: PullRequestState;
+  /**
+   * Identifies the pull request number.
+   */
+  number: number;
+}
+
+export type CardIdToPr_node_ProjectCard_content = CardIdToPr_node_ProjectCard_content_Issue | CardIdToPr_node_ProjectCard_content_PullRequest;
+
+export interface CardIdToPr_node_ProjectCard {
+  __typename: "ProjectCard";
+  /**
+   * The card content item
+   */
+  content: CardIdToPr_node_ProjectCard_content | null;
+}
+
+export type CardIdToPr_node = CardIdToPr_node_CodeOfConduct | CardIdToPr_node_ProjectCard;
+
+export interface CardIdToPr {
+  /**
+   * Fetches an object given its ID.
+   */
+  node: CardIdToPr_node | null;
+}
+
+export interface CardIdToPrVariables {
+  id: string;
+}


### PR DESCRIPTION
When doing the daily scan, close cards of closed PRs.

Note that the bot could respond to a close event and remove the card
then, but there are very few of these anyway.  (This would require
changing `PR-Trigger/index.js` and the rest of the code.)