### PR TITLE
Move PRs to NMA when the cannot be blessed

### DIFF
--- a/src/_tests/fixtures/43151/mutations.json
+++ b/src/_tests/fixtures/43151/mutations.json
@@ -15,7 +15,7 @@
     "variables": {
       "input": {
         "contentId": "MDExOlB1bGxSZXF1ZXN0Mzg4Njk0NDU5",
-        "projectColumnId": "MDEzOlByb2plY3RDb2x1bW43NTUyOTIy"
+        "projectColumnId": "MDEzOlByb2plY3RDb2x1bW45ODY3MDA2"
       }
     }
   },

--- a/src/_tests/fixtures/43151/result.json
+++ b/src/_tests/fixtures/43151/result.json
@@ -1,6 +1,6 @@
 {
   "pr_number": 43151,
-  "targetColumn": "Needs Maintainer Review",
+  "targetColumn": "Needs Maintainer Action",
   "labels": {
     "Mergebot Error": false,
     "Has Merge Conflict": false,

--- a/src/_tests/fixtures/43314/mutations.json
+++ b/src/_tests/fixtures/43314/mutations.json
@@ -4,7 +4,7 @@
     "variables": {
       "input": {
         "cardId": "MDExOlByb2plY3RDYXJkMzQ5NjgxMDk=",
-        "columnId": "MDEzOlByb2plY3RDb2x1bW43NTUyOTIy"
+        "columnId": "MDEzOlByb2plY3RDb2x1bW45ODY3MDA2"
       }
     }
   },

--- a/src/_tests/fixtures/43314/result.json
+++ b/src/_tests/fixtures/43314/result.json
@@ -1,6 +1,6 @@
 {
   "pr_number": 43314,
-  "targetColumn": "Needs Maintainer Review",
+  "targetColumn": "Needs Maintainer Action",
   "labels": {
     "Mergebot Error": false,
     "Has Merge Conflict": false,

--- a/src/_tests/fixtures/43695-duplicate-comment/mutations.json
+++ b/src/_tests/fixtures/43695-duplicate-comment/mutations.json
@@ -16,7 +16,7 @@
     "variables": {
       "input": {
         "cardId": "MDExOlByb2plY3RDYXJkMzU4NjkxNTQ=",
-        "columnId": "MDEzOlByb2plY3RDb2x1bW43NTUyOTIy"
+        "columnId": "MDEzOlByb2plY3RDb2x1bW45ODY3MDA2"
       }
     }
   },

--- a/src/_tests/fixtures/43695-duplicate-comment/result.json
+++ b/src/_tests/fixtures/43695-duplicate-comment/result.json
@@ -1,6 +1,6 @@
 {
   "pr_number": 43695,
-  "targetColumn": "Needs Maintainer Review",
+  "targetColumn": "Needs Maintainer Action",
   "labels": {
     "Mergebot Error": false,
     "Has Merge Conflict": false,

--- a/src/_tests/fixtures/44299-with-files/mutations.json
+++ b/src/_tests/fixtures/44299-with-files/mutations.json
@@ -4,7 +4,7 @@
     "variables": {
       "input": {
         "cardId": "MDExOlByb2plY3RDYXJkMzcxODExMTU=",
-        "columnId": "MDEzOlByb2plY3RDb2x1bW43NTUyOTIy"
+        "columnId": "MDEzOlByb2plY3RDb2x1bW45ODY3MDA2"
       }
     }
   },

--- a/src/_tests/fixtures/44299-with-files/result.json
+++ b/src/_tests/fixtures/44299-with-files/result.json
@@ -1,6 +1,6 @@
 {
   "pr_number": 44299,
-  "targetColumn": "Needs Maintainer Review",
+  "targetColumn": "Needs Maintainer Action",
   "labels": {
     "Mergebot Error": false,
     "Has Merge Conflict": false,

--- a/src/_tests/fixtures/44299/mutations.json
+++ b/src/_tests/fixtures/44299/mutations.json
@@ -4,7 +4,7 @@
     "variables": {
       "input": {
         "cardId": "MDExOlByb2plY3RDYXJkMzcxODExMTU=",
-        "columnId": "MDEzOlByb2plY3RDb2x1bW43NTUyOTIy"
+        "columnId": "MDEzOlByb2plY3RDb2x1bW45ODY3MDA2"
       }
     }
   },

--- a/src/_tests/fixtures/44299/result.json
+++ b/src/_tests/fixtures/44299/result.json
@@ -1,6 +1,6 @@
 {
   "pr_number": 44299,
-  "targetColumn": "Needs Maintainer Review",
+  "targetColumn": "Needs Maintainer Action",
   "labels": {
     "Mergebot Error": false,
     "Has Merge Conflict": false,

--- a/src/_tests/fixtures/44316/mutations.json
+++ b/src/_tests/fixtures/44316/mutations.json
@@ -4,7 +4,7 @@
     "variables": {
       "input": {
         "cardId": "MDExOlByb2plY3RDYXJkMzcyMDMzMzU=",
-        "columnId": "MDEzOlByb2plY3RDb2x1bW43NTUyOTIy"
+        "columnId": "MDEzOlByb2plY3RDb2x1bW45ODY3MDA2"
       }
     }
   },

--- a/src/_tests/fixtures/44316/result.json
+++ b/src/_tests/fixtures/44316/result.json
@@ -1,6 +1,6 @@
 {
   "pr_number": 44316,
-  "targetColumn": "Needs Maintainer Review",
+  "targetColumn": "Needs Maintainer Action",
   "labels": {
     "Mergebot Error": false,
     "Has Merge Conflict": false,

--- a/src/_tests/fixtures/44439/mutations.json
+++ b/src/_tests/fixtures/44439/mutations.json
@@ -4,7 +4,7 @@
     "variables": {
       "input": {
         "cardId": "MDExOlByb2plY3RDYXJkMzc0MjY3NjE=",
-        "columnId": "MDEzOlByb2plY3RDb2x1bW43NTUyOTIy"
+        "columnId": "MDEzOlByb2plY3RDb2x1bW45ODY3MDA2"
       }
     }
   },

--- a/src/_tests/fixtures/44439/result.json
+++ b/src/_tests/fixtures/44439/result.json
@@ -1,6 +1,6 @@
 {
   "pr_number": 44439,
-  "targetColumn": "Needs Maintainer Review",
+  "targetColumn": "Needs Maintainer Action",
   "labels": {
     "Mergebot Error": false,
     "Has Merge Conflict": false,

--- a/src/_tests/fixtures/45890/mutations.json
+++ b/src/_tests/fixtures/45890/mutations.json
@@ -1,5 +1,14 @@
 [
   {
+    "query": "mutation($input: MoveProjectCardInput!) { moveProjectCard(input: $input) { clientMutationId } }",
+    "variables": {
+      "input": {
+        "cardId": "MDExOlByb2plY3RDYXJkNDEyNzAzNzE=",
+        "columnId": "MDEzOlByb2plY3RDb2x1bW45ODY3MDA2"
+      }
+    }
+  },
+  {
     "query": "mutation($input: UpdateIssueCommentInput!) { updateIssueComment(input: $input) { clientMutationId } }",
     "variables": {
       "input": {

--- a/src/_tests/fixtures/45890/result.json
+++ b/src/_tests/fixtures/45890/result.json
@@ -1,6 +1,6 @@
 {
   "pr_number": 45890,
-  "targetColumn": "Needs Maintainer Review",
+  "targetColumn": "Needs Maintainer Action",
   "labels": {
     "Mergebot Error": false,
     "Has Merge Conflict": false,

--- a/src/_tests/fixtures/45946/mutations.json
+++ b/src/_tests/fixtures/45946/mutations.json
@@ -1,5 +1,14 @@
 [
   {
+    "query": "mutation($input: MoveProjectCardInput!) { moveProjectCard(input: $input) { clientMutationId } }",
+    "variables": {
+      "input": {
+        "cardId": "MDExOlByb2plY3RDYXJkNDE0NzQyMjY=",
+        "columnId": "MDEzOlByb2plY3RDb2x1bW45ODY3MDA2"
+      }
+    }
+  },
+  {
     "query": "mutation($input: UpdateIssueCommentInput!) { updateIssueComment(input: $input) { clientMutationId } }",
     "variables": {
       "input": {

--- a/src/_tests/fixtures/45946/result.json
+++ b/src/_tests/fixtures/45946/result.json
@@ -1,6 +1,6 @@
 {
   "pr_number": 45946,
-  "targetColumn": "Needs Maintainer Review",
+  "targetColumn": "Needs Maintainer Action",
   "labels": {
     "Mergebot Error": false,
     "Has Merge Conflict": false,

--- a/src/_tests/fixtures/46279/mutations.json
+++ b/src/_tests/fixtures/46279/mutations.json
@@ -4,7 +4,7 @@
     "variables": {
       "input": {
         "contentId": "MDExOlB1bGxSZXF1ZXN0NDU1NDI5NDU3",
-        "projectColumnId": "MDEzOlByb2plY3RDb2x1bW43NTUyOTIy"
+        "projectColumnId": "MDEzOlByb2plY3RDb2x1bW45ODY3MDA2"
       }
     }
   },

--- a/src/_tests/fixtures/46279/result.json
+++ b/src/_tests/fixtures/46279/result.json
@@ -1,6 +1,6 @@
 {
   "pr_number": 46279,
-  "targetColumn": "Needs Maintainer Review",
+  "targetColumn": "Needs Maintainer Action",
   "labels": {
     "Mergebot Error": false,
     "Has Merge Conflict": false,

--- a/src/_tests/fixtures/46879/mutations.json
+++ b/src/_tests/fixtures/46879/mutations.json
@@ -26,7 +26,7 @@
     "variables": {
       "input": {
         "contentId": "MDExOlB1bGxSZXF1ZXN0NDY5Njk3ODc4",
-        "projectColumnId": "MDEzOlByb2plY3RDb2x1bW43NTUyOTIy"
+        "projectColumnId": "MDEzOlByb2plY3RDb2x1bW45ODY3MDA2"
       }
     }
   },

--- a/src/_tests/fixtures/46879/result.json
+++ b/src/_tests/fixtures/46879/result.json
@@ -1,6 +1,6 @@
 {
   "pr_number": 46879,
-  "targetColumn": "Needs Maintainer Review",
+  "targetColumn": "Needs Maintainer Action",
   "labels": {
     "Mergebot Error": false,
     "Has Merge Conflict": false,


### PR DESCRIPTION
This finally makes the NMA column more useful as an indicator of when a
PR cannot be blessed away.

* Sorted out `otherOwners` and related:
  - made it into a function
  - new `noOtherOwners` function
  (Not efficient but hukaires.)

* Rename `hasFinalApproval` -> `getApproval`, and make it also return a
  `blessable` boolean, which is how the above is implemented.