### PR TITLE
Allow maintainers to approve PRs that don't affect packages

### DIFF
--- a/src/_tests/fixtures/44402/derived.json
+++ b/src/_tests/fixtures/44402/derived.json
@@ -1,4 +1,5 @@
 {
   "type": "no_packages",
+  "now": "2020-05-01T15:14:44.000Z",
   "pr_number": 44402
 }

--- a/src/_tests/fixtures/44402/derived.json
+++ b/src/_tests/fixtures/44402/derived.json
@@ -1,5 +1,10 @@
 {
   "type": "no_packages",
   "now": "2020-05-01T15:14:44.000Z",
-  "pr_number": 44402
+  "pr_number": 44402,
+  "lastReviewDate": "2020-05-01T05:46:07.000Z",
+  "firstApprovalDate": "2020-04-30T23:29:02.000Z",
+  "reviewersWithStaleReviews": [],
+  "approvalFlags": 5,
+  "isChangesRequested": false
 }

--- a/src/_tests/fixtures/44402/derived.json
+++ b/src/_tests/fixtures/44402/derived.json
@@ -1,7 +1,54 @@
 {
-  "type": "no_packages",
+  "type": "info",
   "now": "2020-05-01T15:14:44.000Z",
   "pr_number": 44402,
+  "author": "sandersn",
+  "dangerLevel": "Infrastructure",
+  "headCommitAbbrOid": "5dfb994",
+  "headCommitOid": "5dfb9945fc5c243f011a9436cbcc12d1ad12b012",
+  "mergeIsRequested": false,
+  "stalenessInDays": 0,
+  "lastPushDate": "2020-04-30T23:17:43.000Z",
+  "lastCommentDate": "2020-04-30T23:21:44.000Z",
+  "maintainerBlessed": false,
+  "reviewLink": "https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44402/files",
+  "hasMergeConflict": false,
+  "authorIsOwner": false,
+  "isFirstContribution": false,
+  "popularityLevel": "Well-liked by everyone",
+  "pkgInfo": [
+    {
+      "name": null,
+      "files": [
+        {
+          "path": "README.cn.md",
+          "kind": "infrastructure"
+        },
+        {
+          "path": "README.es.md",
+          "kind": "infrastructure"
+        },
+        {
+          "path": "README.ko.md",
+          "kind": "infrastructure"
+        },
+        {
+          "path": "README.md",
+          "kind": "infrastructure"
+        },
+        {
+          "path": "README.ru.md",
+          "kind": "infrastructure"
+        }
+      ],
+      "owners": null,
+      "addedOwners": [],
+      "deletedOwners": [],
+      "popularityLevel": "Critical"
+    }
+  ],
+  "hasDismissedReview": false,
+  "ciResult": "pass",
   "lastReviewDate": "2020-05-01T05:46:07.000Z",
   "firstApprovalDate": "2020-04-30T23:29:02.000Z",
   "reviewersWithStaleReviews": [],

--- a/src/_tests/fixtures/44402/mutations.json
+++ b/src/_tests/fixtures/44402/mutations.json
@@ -4,7 +4,9 @@
     "variables": {
       "input": {
         "labelIds": [
-          "MDU6TGFiZWwxNjA4MjA4ODM1"
+          "MDU6TGFiZWwxNjA4MjA4ODM1",
+          "MDU6TGFiZWwyMTU0ODU3ODAw",
+          "MDU6TGFiZWw2OTcwMTg5NzI="
         ],
         "labelableId": "MDExOlB1bGxSZXF1ZXN0NDExODkwMDY5"
       }
@@ -16,14 +18,6 @@
       "input": {
         "contentId": "MDExOlB1bGxSZXF1ZXN0NDExODkwMDY5",
         "projectColumnId": "MDEzOlByb2plY3RDb2x1bW45ODY3MDA2"
-      }
-    }
-  },
-  {
-    "query": "mutation($input: DeleteIssueCommentInput!) { deleteIssueComment(input: $input) { clientMutationId } }",
-    "variables": {
-      "input": {
-        "id": "MDEyOklzc3VlQ29tbWVudDYyMjE3NTQ3NA=="
       }
     }
   }

--- a/src/_tests/fixtures/44402/result.json
+++ b/src/_tests/fixtures/44402/result.json
@@ -1,7 +1,28 @@
 {
   "pr_number": 44402,
+  "targetColumn": "Needs Maintainer Action",
   "labels": {
-    "Edits Infrastructure": true
+    "Mergebot Error": false,
+    "Has Merge Conflict": false,
+    "The CI failed": false,
+    "Revision needed": false,
+    "New Definition": false,
+    "Where is GH Actions?": false,
+    "Owner Approved": false,
+    "Other Approved": true,
+    "Maintainer Approved": true,
+    "Merge:YSYL": false,
+    "Popular package": false,
+    "Critical package": false,
+    "Edits Infrastructure": true,
+    "Edits multiple packages": false,
+    "Author is Owner": false,
+    "No Other Owners": true,
+    "Too Many Owners": false,
+    "Merge:Auto": true,
+    "Untested Change": false,
+    "Config Edit": false,
+    "Abandoned": false
   },
   "responseComments": [],
   "shouldClose": false,
@@ -9,6 +30,5 @@
   "shouldUpdateLabels": true,
   "shouldUpdateProjectColumn": true,
   "shouldRemoveFromActiveColumns": false,
-  "isReadyForAutoMerge": false,
-  "targetColumn": "Needs Maintainer Action"
+  "isReadyForAutoMerge": true
 }

--- a/src/pr-info.ts
+++ b/src/pr-info.ts
@@ -64,12 +64,6 @@ export interface BotEnsureRemovedFromProject {
     readonly isDraft: boolean;
 }
 
-export interface BotNoPackages {
-    readonly type: "no_packages";
-    readonly now: string;
-    readonly pr_number: number;
-}
-
 type PackageInfo = {
     name: string | null; // null => not in a package (= infra files)
     files: FileInfo[];
@@ -218,7 +212,7 @@ export async function deriveStateForPR(
     fetchFile = defaultFetchFile,
     getDownloads = getMonthlyDownloadCount,
     getNow = () => new Date(),
-): Promise<PrInfo | BotFail | BotError | BotEnsureRemovedFromProject | BotNoPackages>  {
+): Promise<PrInfo | BotFail | BotError | BotEnsureRemovedFromProject>  {
     const prInfo = info.data.repository?.pullRequest;
 
     if (!prInfo) return botFail(`No PR with this number exists, (${JSON.stringify(info)})`);
@@ -256,8 +250,6 @@ export async function deriveStateForPR(
     const activityDates = [createdDate, lastPushDate, lastCommentDate, lastBlessing, reopenedDate, reviewAnalysis.lastReviewDate];
 
     const dangerLevel = getDangerLevel(pkgInfo);
-
-    if (!pkgInfo.some(p => p.name)) return { type: "no_packages", now, pr_number: prInfo.number, ...reviewAnalysis };
 
     return {
         type: "info",

--- a/src/pr-info.ts
+++ b/src/pr-info.ts
@@ -66,6 +66,7 @@ export interface BotEnsureRemovedFromProject {
 
 export interface BotNoPackages {
     readonly type: "no_packages";
+    readonly now: string;
     readonly pr_number: number;
 }
 
@@ -234,7 +235,6 @@ export async function deriveStateForPR(
         headCommit.oid, fetchFile, getDownloads);
     if (pkgInfoEtc instanceof Error) return botError(prInfo.number, pkgInfoEtc.message);
     const { pkgInfo, popularityLevel } = pkgInfoEtc;
-    if (!pkgInfo.some(p => p.name)) return botNoPackages(prInfo.number);
 
     const allOwners = pkgInfoAllOwners(pkgInfo);
 
@@ -256,6 +256,8 @@ export async function deriveStateForPR(
     const activityDates = [createdDate, lastPushDate, lastCommentDate, lastBlessing, reopenedDate, reviewAnalysis.lastReviewDate];
 
     const dangerLevel = getDangerLevel(pkgInfo);
+
+    if (!pkgInfo.some(p => p.name)) return { type: "no_packages", now, pr_number: prInfo.number, ...reviewAnalysis };
 
     return {
         type: "info",
@@ -293,10 +295,6 @@ export async function deriveStateForPR(
 
     function botEnsureRemovedFromProject(pr_number: number, message: string, isDraft: boolean): BotEnsureRemovedFromProject {
         return { type: "remove", pr_number, message, isDraft };
-    }
-
-    function botNoPackages(pr_number: number): BotNoPackages {
-        return { type: "no_packages", pr_number };
     }
 
     function isOwner(login: string) {


### PR DESCRIPTION
Should maintainers be able to approve PRs that don't affect packages, e.g. DefinitelyTyped/DefinitelyTyped#49120, or is the bot strictly about packages?

#50 is the change that mostly short circuited the bot if the PR doesn't affect packages.

I haven't updated [`process()`](https://github.com/DefinitelyTyped/dt-mergebot/blob/febdf9ba6e193dcb51945c85382434fd73e2338b/src/compute-pr-actions.ts#L170) yet, just looking for confirmation before proceeding. Since #50 we don't call [`analyzeReviews()`](https://github.com/DefinitelyTyped/dt-mergebot/blob/febdf9ba6e193dcb51945c85382434fd73e2338b/src/pr-info.ts#L255) on [PRs that don't affect packages](https://github.com/DefinitelyTyped/dt-mergebot/blob/febdf9ba6e193dcb51945c85382434fd73e2338b/src/pr-info.ts#L237), so at a minimum I need to restore that?