### PR TITLE
More info shuffling and refactoring

### DIFF
--- a/src/_tests/fixtures/38979/derived.json
+++ b/src/_tests/fixtures/38979/derived.json
@@ -3,7 +3,6 @@
   "now": "2020-05-12T19:14:42.000Z",
   "pr_number": 38979,
   "author": "ExE-Boss",
-  "dangerLevel": "ScopedAndConfiguration",
   "headCommitAbbrOid": "2223341",
   "headCommitOid": "222334139e52fc16369464cfb5dc95c82f71192f",
   "mergeIsRequested": false,
@@ -12,9 +11,7 @@
   "reopenedDate": "2019-10-18T22:52:06.000Z",
   "lastCommentDate": "2020-05-12T15:13:19.000Z",
   "maintainerBlessed": false,
-  "reviewLink": "https://github.com/DefinitelyTyped/DefinitelyTyped/pull/38979/files",
   "hasMergeConflict": false,
-  "authorIsOwner": false,
   "isFirstContribution": false,
   "popularityLevel": "Critical",
   "pkgInfo": [
@@ -320,22 +317,25 @@
       "popularityLevel": "Critical"
     }
   ],
-  "hasDismissedReview": true,
-  "ciResult": "pass",
-  "lastReviewDate": "2020-05-12T04:51:52.000Z",
-  "firstApprovalDate": "2020-05-12T04:51:52.000Z",
-  "reviewersWithStaleReviews": [
+  "reviews": [
     {
-      "reviewedAbbrOid": "3aba5ac",
-      "reviewer": "sandersn",
-      "date": "2019-10-22T22:56:09Z"
+      "type": "approved",
+      "reviewer": "ljharb",
+      "date": "2020-05-12T04:51:52.000Z",
+      "isMaintainer": false
     },
     {
-      "reviewedAbbrOid": "0e6e7f4",
+      "type": "stale",
+      "reviewer": "sandersn",
+      "date": "2019-10-22T22:56:09.000Z",
+      "abbrOid": "3aba5ac"
+    },
+    {
+      "type": "stale",
       "reviewer": "weswigham",
-      "date": "2019-10-22T21:43:25Z"
+      "date": "2019-10-22T22:20:55.000Z",
+      "abbrOid": "0e6e7f4"
     }
   ],
-  "approvalFlags": 1,
-  "isChangesRequested": false
+  "ciResult": "pass"
 }

--- a/src/_tests/fixtures/43136/derived.json
+++ b/src/_tests/fixtures/43136/derived.json
@@ -3,7 +3,6 @@
   "now": "2020-03-19T19:14:42.000Z",
   "pr_number": 43136,
   "author": "larsrh",
-  "dangerLevel": "ScopedAndTested",
   "headCommitAbbrOid": "e686353",
   "headCommitOid": "e6863537248bbfee8f0ef8c636bb00c25cf40b96",
   "mergeIsRequested": false,
@@ -11,9 +10,7 @@
   "lastPushDate": "2020-03-16T14:26:42.000Z",
   "lastCommentDate": "2020-03-16T14:26:42.000Z",
   "maintainerBlessed": false,
-  "reviewLink": "https://github.com/DefinitelyTyped/DefinitelyTyped/pull/43136/files",
   "hasMergeConflict": false,
-  "authorIsOwner": false,
   "isFirstContribution": true,
   "popularityLevel": "Critical",
   "pkgInfo": [
@@ -37,15 +34,13 @@
       "popularityLevel": "Critical"
     }
   ],
-  "hasDismissedReview": false,
-  "ciResult": "pass",
-  "reviewersWithStaleReviews": [
+  "reviews": [
     {
-      "reviewedAbbrOid": "37d784d",
+      "type": "stale",
       "reviewer": "RReverser",
-      "date": "2020-03-14T19:22:34Z"
+      "date": "2020-03-14T19:23:36.000Z",
+      "abbrOid": "37d784d"
     }
   ],
-  "approvalFlags": 0,
-  "isChangesRequested": false
+  "ciResult": "pass"
 }

--- a/src/_tests/fixtures/43144/derived.json
+++ b/src/_tests/fixtures/43144/derived.json
@@ -3,7 +3,6 @@
   "now": "2020-03-19T04:59:48.000Z",
   "pr_number": 43144,
   "author": "jeffreymeng",
-  "dangerLevel": "ScopedAndTested",
   "headCommitAbbrOid": "f1f5c4b",
   "headCommitOid": "f1f5c4bb0ae553f56766882f6458d2e22baa87c7",
   "mergeIsRequested": false,
@@ -11,9 +10,7 @@
   "lastPushDate": "2020-03-15T00:11:48.000Z",
   "lastCommentDate": "2020-03-15T00:11:48.000Z",
   "maintainerBlessed": false,
-  "reviewLink": "https://github.com/DefinitelyTyped/DefinitelyTyped/pull/43144/files",
   "hasMergeConflict": false,
-  "authorIsOwner": false,
   "isFirstContribution": false,
   "popularityLevel": "Well-liked by everyone",
   "pkgInfo": [
@@ -37,11 +34,13 @@
       "popularityLevel": "Well-liked by everyone"
     }
   ],
-  "hasDismissedReview": false,
-  "ciResult": "pass",
-  "lastReviewDate": "2020-03-15T01:29:09.000Z",
-  "firstApprovalDate": "2020-03-15T01:29:09.000Z",
-  "reviewersWithStaleReviews": [],
-  "approvalFlags": 2,
-  "isChangesRequested": false
+  "reviews": [
+    {
+      "type": "approved",
+      "reviewer": "pocesar",
+      "date": "2020-03-15T01:29:09.000Z",
+      "isMaintainer": false
+    }
+  ],
+  "ciResult": "pass"
 }

--- a/src/_tests/fixtures/43151/derived.json
+++ b/src/_tests/fixtures/43151/derived.json
@@ -3,7 +3,6 @@
   "now": "2020-03-19T17:38:20.000Z",
   "pr_number": 43151,
   "author": "adamzerella",
-  "dangerLevel": "ScopedAndConfiguration",
   "headCommitAbbrOid": "bb6d315",
   "headCommitOid": "bb6d3150b485cd203d265e06ca910262256e523e",
   "mergeIsRequested": false,
@@ -11,9 +10,7 @@
   "lastPushDate": "2020-03-15T12:50:20.000Z",
   "lastCommentDate": "2020-03-15T12:50:20.000Z",
   "maintainerBlessed": false,
-  "reviewLink": "https://github.com/DefinitelyTyped/DefinitelyTyped/pull/43151/files",
   "hasMergeConflict": false,
-  "authorIsOwner": false,
   "isFirstContribution": false,
   "popularityLevel": "Well-liked by everyone",
   "pkgInfo": [
@@ -47,9 +44,6 @@
       "popularityLevel": "Well-liked by everyone"
     }
   ],
-  "hasDismissedReview": false,
-  "ciResult": "pass",
-  "reviewersWithStaleReviews": [],
-  "approvalFlags": 0,
-  "isChangesRequested": false
+  "reviews": [],
+  "ciResult": "pass"
 }

--- a/src/_tests/fixtures/43160/derived.json
+++ b/src/_tests/fixtures/43160/derived.json
@@ -3,7 +3,6 @@
   "now": "2020-03-19T13:02:50.000Z",
   "pr_number": 43160,
   "author": "rikkertkoppes",
-  "dangerLevel": "ScopedAndUntested",
   "headCommitAbbrOid": "6d5d2a8",
   "headCommitOid": "6d5d2a85b41d287f97c9d331a9ff6a9824e2f1ff",
   "mergeIsRequested": false,
@@ -11,9 +10,7 @@
   "lastPushDate": "2020-03-16T08:14:50.000Z",
   "lastCommentDate": "2020-03-16T08:14:50.000Z",
   "maintainerBlessed": false,
-  "reviewLink": "https://github.com/DefinitelyTyped/DefinitelyTyped/pull/43160/files",
   "hasMergeConflict": false,
-  "authorIsOwner": false,
   "isFirstContribution": true,
   "popularityLevel": "Well-liked by everyone",
   "pkgInfo": [
@@ -36,12 +33,14 @@
       "popularityLevel": "Well-liked by everyone"
     }
   ],
-  "hasDismissedReview": false,
+  "reviews": [
+    {
+      "type": "approved",
+      "reviewer": "rustedgrail",
+      "date": "2020-03-17T14:33:47.000Z",
+      "isMaintainer": false
+    }
+  ],
   "ciResult": "fail",
-  "ciUrl": "https://github.com/DefinitelyTyped/DefinitelyTyped/commit/22c73c88cc9c09efd4c2998ec360607dd4c36c2e/checks?check_suite_id=731664306",
-  "lastReviewDate": "2020-03-17T14:33:47.000Z",
-  "firstApprovalDate": "2020-03-17T14:33:47.000Z",
-  "reviewersWithStaleReviews": [],
-  "approvalFlags": 2,
-  "isChangesRequested": false
+  "ciUrl": "https://github.com/DefinitelyTyped/DefinitelyTyped/commit/22c73c88cc9c09efd4c2998ec360607dd4c36c2e/checks?check_suite_id=731664306"
 }

--- a/src/_tests/fixtures/43175/derived.json
+++ b/src/_tests/fixtures/43175/derived.json
@@ -3,7 +3,6 @@
   "now": "2020-03-19T18:39:37.000Z",
   "pr_number": 43175,
   "author": "ankhler",
-  "dangerLevel": "ScopedAndUntested",
   "headCommitAbbrOid": "b4b3bc8",
   "headCommitOid": "b4b3bc8a617e2e0810d60e389415818d903e6362",
   "mergeIsRequested": false,
@@ -11,9 +10,7 @@
   "lastPushDate": "2020-03-17T13:51:37.000Z",
   "lastCommentDate": "2020-03-17T13:51:37.000Z",
   "maintainerBlessed": false,
-  "reviewLink": "https://github.com/DefinitelyTyped/DefinitelyTyped/pull/43175/files",
   "hasMergeConflict": false,
-  "authorIsOwner": false,
   "isFirstContribution": true,
   "popularityLevel": "Popular",
   "pkgInfo": [
@@ -42,15 +39,13 @@
       "popularityLevel": "Popular"
     }
   ],
-  "hasDismissedReview": false,
-  "ciResult": "pass",
-  "reviewersWithStaleReviews": [
+  "reviews": [
     {
-      "reviewedAbbrOid": "767a750",
+      "type": "stale",
       "reviewer": "couven92",
-      "date": "2020-03-17T13:29:17Z"
+      "date": "2020-03-17T13:29:17.000Z",
+      "abbrOid": "767a750"
     }
   ],
-  "approvalFlags": 0,
-  "isChangesRequested": false
+  "ciResult": "pass"
 }

--- a/src/_tests/fixtures/43235/derived.json
+++ b/src/_tests/fixtures/43235/derived.json
@@ -3,7 +3,6 @@
   "now": "2020-03-19T19:25:52.000Z",
   "pr_number": 43235,
   "author": "Favna",
-  "dangerLevel": "ScopedAndTested",
   "headCommitAbbrOid": "933d8d8",
   "headCommitOid": "933d8d81859cea3cb2df640bd099ef80bee3d691",
   "mergeIsRequested": false,
@@ -11,9 +10,7 @@
   "lastPushDate": "2020-03-19T14:37:52.000Z",
   "lastCommentDate": "2020-03-19T14:37:52.000Z",
   "maintainerBlessed": false,
-  "reviewLink": "https://github.com/DefinitelyTyped/DefinitelyTyped/pull/43235/files",
   "hasMergeConflict": false,
-  "authorIsOwner": false,
   "isFirstContribution": false,
   "popularityLevel": "Well-liked by everyone",
   "pkgInfo": [
@@ -38,9 +35,6 @@
       "popularityLevel": "Well-liked by everyone"
     }
   ],
-  "hasDismissedReview": false,
-  "ciResult": "pass",
-  "reviewersWithStaleReviews": [],
-  "approvalFlags": 0,
-  "isChangesRequested": false
+  "reviews": [],
+  "ciResult": "pass"
 }

--- a/src/_tests/fixtures/43314/derived.json
+++ b/src/_tests/fixtures/43314/derived.json
@@ -3,7 +3,6 @@
   "now": "2020-03-22T21:36:44.000Z",
   "pr_number": 43314,
   "author": "metonym",
-  "dangerLevel": "ScopedAndConfiguration",
   "headCommitAbbrOid": "432f23f",
   "headCommitOid": "432f23fe1b87b12fe58bb1a8958f77ee3242741e",
   "mergeIsRequested": false,
@@ -11,9 +10,7 @@
   "lastPushDate": "2020-03-22T16:48:44.000Z",
   "lastCommentDate": "2020-03-22T16:48:44.000Z",
   "maintainerBlessed": false,
-  "reviewLink": "https://github.com/DefinitelyTyped/DefinitelyTyped/pull/43314/files",
   "hasMergeConflict": false,
-  "authorIsOwner": false,
   "isFirstContribution": false,
   "popularityLevel": "Well-liked by everyone",
   "pkgInfo": [
@@ -47,9 +44,6 @@
       "popularityLevel": "Well-liked by everyone"
     }
   ],
-  "hasDismissedReview": false,
-  "ciResult": "pass",
-  "reviewersWithStaleReviews": [],
-  "approvalFlags": 0,
-  "isChangesRequested": false
+  "reviews": [],
+  "ciResult": "pass"
 }

--- a/src/_tests/fixtures/43695-duplicate-comment/derived.json
+++ b/src/_tests/fixtures/43695-duplicate-comment/derived.json
@@ -3,7 +3,6 @@
   "now": "2020-05-01T17:11:04.885Z",
   "pr_number": 43695,
   "author": "alexandercerutti",
-  "dangerLevel": "ScopedAndConfiguration",
   "headCommitAbbrOid": "3e83617",
   "headCommitOid": "3e836178b736e5512361ffda46e84a5c668d7a90",
   "mergeIsRequested": false,
@@ -12,9 +11,7 @@
   "reopenedDate": "2020-04-30T23:08:16.000Z",
   "lastCommentDate": "2020-05-01T00:19:19.000Z",
   "maintainerBlessed": false,
-  "reviewLink": "https://github.com/DefinitelyTyped/DefinitelyTyped/pull/43695/files",
   "hasMergeConflict": false,
-  "authorIsOwner": false,
   "isFirstContribution": false,
   "popularityLevel": "Well-liked by everyone",
   "pkgInfo": [
@@ -48,25 +45,19 @@
       "popularityLevel": "Well-liked by everyone"
     }
   ],
-  "hasDismissedReview": false,
-  "ciResult": "pass",
-  "reviewersWithStaleReviews": [
+  "reviews": [
     {
-      "reviewedAbbrOid": "68463fd",
+      "type": "stale",
       "reviewer": "andrewbranch",
-      "date": "2020-04-30T23:58:31Z"
+      "date": "2020-04-30T23:59:41.000Z",
+      "abbrOid": "68463fd"
     },
     {
-      "reviewedAbbrOid": "90c94f9",
-      "reviewer": "andrewbranch",
-      "date": "2020-04-30T23:07:49Z"
-    },
-    {
-      "reviewedAbbrOid": "a5285cd",
+      "type": "stale",
       "reviewer": "RyanCavanaugh",
-      "date": "2020-04-08T16:23:52Z"
+      "date": "2020-04-08T16:23:52.000Z",
+      "abbrOid": "a5285cd"
     }
   ],
-  "approvalFlags": 0,
-  "isChangesRequested": false
+  "ciResult": "pass"
 }

--- a/src/_tests/fixtures/43695-post-review/derived.json
+++ b/src/_tests/fixtures/43695-post-review/derived.json
@@ -3,7 +3,6 @@
   "now": "2020-04-30T23:13:37.659Z",
   "pr_number": 43695,
   "author": "alexandercerutti",
-  "dangerLevel": "ScopedAndConfiguration",
   "headCommitAbbrOid": "90c94f9",
   "headCommitOid": "90c94f91120c026f5f8bcc586426e8590b7b4048",
   "mergeIsRequested": false,
@@ -11,9 +10,7 @@
   "lastPushDate": "2020-04-15T15:53:29.000Z",
   "lastCommentDate": "2020-04-30T23:07:44.000Z",
   "maintainerBlessed": false,
-  "reviewLink": "https://github.com/DefinitelyTyped/DefinitelyTyped/pull/43695/files",
   "hasMergeConflict": false,
-  "authorIsOwner": false,
   "isFirstContribution": false,
   "popularityLevel": "Well-liked by everyone",
   "pkgInfo": [
@@ -47,17 +44,18 @@
       "popularityLevel": "Well-liked by everyone"
     }
   ],
-  "hasDismissedReview": false,
-  "ciResult": "pass",
-  "lastReviewDate": "2020-04-30T23:07:49.000Z",
-  "firstApprovalDate": "2020-04-30T23:07:49.000Z",
-  "reviewersWithStaleReviews": [
+  "reviews": [
     {
-      "reviewedAbbrOid": "a5285cd",
+      "type": "changereq",
+      "reviewer": "andrewbranch",
+      "date": "2020-04-30T23:07:49.000Z"
+    },
+    {
+      "type": "stale",
       "reviewer": "RyanCavanaugh",
-      "date": "2020-04-08T16:23:52Z"
+      "date": "2020-04-08T16:23:52.000Z",
+      "abbrOid": "a5285cd"
     }
   ],
-  "approvalFlags": 0,
-  "isChangesRequested": true
+  "ciResult": "pass"
 }

--- a/src/_tests/fixtures/43695/derived.json
+++ b/src/_tests/fixtures/43695/derived.json
@@ -3,7 +3,6 @@
   "now": "2020-04-08T12:29:36.999Z",
   "pr_number": 43695,
   "author": "alexandercerutti",
-  "dangerLevel": "ScopedAndConfiguration",
   "headCommitAbbrOid": "a5285cd",
   "headCommitOid": "a5285cda2722912a390770722a334e6d6e43d1ab",
   "mergeIsRequested": false,
@@ -11,9 +10,7 @@
   "lastPushDate": "2020-04-07T07:41:37.000Z",
   "lastCommentDate": "2020-04-07T07:41:37.000Z",
   "maintainerBlessed": false,
-  "reviewLink": "https://github.com/DefinitelyTyped/DefinitelyTyped/pull/43695/files",
   "hasMergeConflict": false,
-  "authorIsOwner": false,
   "isFirstContribution": false,
   "popularityLevel": "Well-liked by everyone",
   "pkgInfo": [
@@ -47,11 +44,12 @@
       "popularityLevel": "Well-liked by everyone"
     }
   ],
-  "hasDismissedReview": false,
-  "ciResult": "pass",
-  "lastReviewDate": "2020-04-08T16:23:52.000Z",
-  "firstApprovalDate": "2020-04-08T16:23:52.000Z",
-  "reviewersWithStaleReviews": [],
-  "approvalFlags": 0,
-  "isChangesRequested": true
+  "reviews": [
+    {
+      "type": "changereq",
+      "reviewer": "RyanCavanaugh",
+      "date": "2020-04-08T16:23:52.000Z"
+    }
+  ],
+  "ciResult": "pass"
 }

--- a/src/_tests/fixtures/43960/derived.json
+++ b/src/_tests/fixtures/43960/derived.json
@@ -3,7 +3,6 @@
   "now": "2020-04-29T22:09:53.999Z",
   "pr_number": 43960,
   "author": "aaltepet",
-  "dangerLevel": "ScopedAndTested",
   "headCommitAbbrOid": "129f84e",
   "headCommitOid": "129f84e4492a76e7cd5af9d946c4583a60e6eb88",
   "mergeIsRequested": false,
@@ -12,9 +11,7 @@
   "reopenedDate": "2020-04-29T20:48:52.000Z",
   "lastCommentDate": "2020-04-29T20:48:52.000Z",
   "maintainerBlessed": false,
-  "reviewLink": "https://github.com/DefinitelyTyped/DefinitelyTyped/pull/43960/files",
   "hasMergeConflict": false,
-  "authorIsOwner": false,
   "isFirstContribution": false,
   "popularityLevel": "Popular",
   "pkgInfo": [
@@ -39,11 +36,12 @@
       "popularityLevel": "Popular"
     }
   ],
-  "hasDismissedReview": false,
-  "ciResult": "pass",
-  "lastReviewDate": "2020-04-27T18:56:06.000Z",
-  "firstApprovalDate": "2020-04-27T18:56:06.000Z",
-  "reviewersWithStaleReviews": [],
-  "approvalFlags": 0,
-  "isChangesRequested": true
+  "reviews": [
+    {
+      "type": "changereq",
+      "reviewer": "andrewbranch",
+      "date": "2020-04-27T18:56:06.000Z"
+    }
+  ],
+  "ciResult": "pass"
 }

--- a/src/_tests/fixtures/44267/derived.json
+++ b/src/_tests/fixtures/44267/derived.json
@@ -3,7 +3,6 @@
   "now": "2020-04-30T22:04:05.517Z",
   "pr_number": 44267,
   "author": "ErikMartensson",
-  "dangerLevel": "ScopedAndUntested",
   "headCommitAbbrOid": "ceb74b3",
   "headCommitOid": "ceb74b3471454b2f57cbe671e130028c680ffb88",
   "mergeIsRequested": false,
@@ -11,9 +10,7 @@
   "lastPushDate": "2020-04-27T14:15:25.000Z",
   "lastCommentDate": "2020-04-27T14:15:25.000Z",
   "maintainerBlessed": false,
-  "reviewLink": "https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44267/files",
   "hasMergeConflict": false,
-  "authorIsOwner": false,
   "isFirstContribution": true,
   "popularityLevel": "Well-liked by everyone",
   "pkgInfo": [
@@ -41,11 +38,13 @@
       "popularityLevel": "Well-liked by everyone"
     }
   ],
-  "hasDismissedReview": false,
-  "ciResult": "pass",
-  "lastReviewDate": "2020-04-28T06:48:36.000Z",
-  "firstApprovalDate": "2020-04-28T06:48:36.000Z",
-  "reviewersWithStaleReviews": [],
-  "approvalFlags": 2,
-  "isChangesRequested": false
+  "reviews": [
+    {
+      "type": "approved",
+      "reviewer": "malithrw",
+      "date": "2020-04-28T06:48:36.000Z",
+      "isMaintainer": false
+    }
+  ],
+  "ciResult": "pass"
 }

--- a/src/_tests/fixtures/44282/derived.json
+++ b/src/_tests/fixtures/44282/derived.json
@@ -3,7 +3,6 @@
   "now": "2020-04-28T04:46:24.000Z",
   "pr_number": 44282,
   "author": "fishcharlie",
-  "dangerLevel": "ScopedAndTested",
   "headCommitAbbrOid": "2579430",
   "headCommitOid": "25794304acf8c1fd70712bd068beb07b0e09755e",
   "mergeIsRequested": false,
@@ -11,9 +10,7 @@
   "lastPushDate": "2020-04-27T23:58:24.000Z",
   "lastCommentDate": "2020-04-27T23:58:24.000Z",
   "maintainerBlessed": false,
-  "reviewLink": "https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44282/files",
   "hasMergeConflict": false,
-  "authorIsOwner": false,
   "isFirstContribution": true,
   "popularityLevel": "Well-liked by everyone",
   "pkgInfo": [
@@ -37,9 +34,6 @@
       "popularityLevel": "Well-liked by everyone"
     }
   ],
-  "hasDismissedReview": false,
-  "ciResult": "pass",
-  "reviewersWithStaleReviews": [],
-  "approvalFlags": 0,
-  "isChangesRequested": false
+  "reviews": [],
+  "ciResult": "pass"
 }

--- a/src/_tests/fixtures/44288/derived.json
+++ b/src/_tests/fixtures/44288/derived.json
@@ -3,7 +3,6 @@
   "now": "2020-04-28T09:34:31.000Z",
   "pr_number": 44288,
   "author": "nomatteus",
-  "dangerLevel": "ScopedAndTested",
   "headCommitAbbrOid": "05ee6f2",
   "headCommitOid": "05ee6f2784d694258f61e7a93a95e758ea29ad9d",
   "mergeIsRequested": false,
@@ -11,9 +10,7 @@
   "lastPushDate": "2020-04-28T04:46:31.000Z",
   "lastCommentDate": "2020-04-28T04:46:31.000Z",
   "maintainerBlessed": false,
-  "reviewLink": "https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44288/files",
   "hasMergeConflict": false,
-  "authorIsOwner": false,
   "isFirstContribution": true,
   "popularityLevel": "Well-liked by everyone",
   "pkgInfo": [
@@ -37,9 +34,6 @@
       "popularityLevel": "Well-liked by everyone"
     }
   ],
-  "hasDismissedReview": false,
-  "ciResult": "pass",
-  "reviewersWithStaleReviews": [],
-  "approvalFlags": 0,
-  "isChangesRequested": false
+  "reviews": [],
+  "ciResult": "pass"
 }

--- a/src/_tests/fixtures/44299-with-files/derived.json
+++ b/src/_tests/fixtures/44299-with-files/derived.json
@@ -3,7 +3,6 @@
   "now": "2020-04-29T17:19:10.716Z",
   "pr_number": 44299,
   "author": "geopic",
-  "dangerLevel": "ScopedAndConfiguration",
   "headCommitAbbrOid": "683fb3b",
   "headCommitOid": "683fb3b1298223256be3a49823686f35bd94a730",
   "mergeIsRequested": false,
@@ -11,9 +10,7 @@
   "lastPushDate": "2020-04-29T10:57:59.000Z",
   "lastCommentDate": "2020-04-29T10:57:59.000Z",
   "maintainerBlessed": false,
-  "reviewLink": "https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44299/files",
   "hasMergeConflict": false,
-  "authorIsOwner": false,
   "isFirstContribution": true,
   "popularityLevel": "Well-liked by everyone",
   "pkgInfo": [
@@ -51,9 +48,6 @@
       "popularityLevel": "Well-liked by everyone"
     }
   ],
-  "hasDismissedReview": false,
-  "ciResult": "pass",
-  "reviewersWithStaleReviews": [],
-  "approvalFlags": 0,
-  "isChangesRequested": false
+  "reviews": [],
+  "ciResult": "pass"
 }

--- a/src/_tests/fixtures/44299/derived.json
+++ b/src/_tests/fixtures/44299/derived.json
@@ -3,7 +3,6 @@
   "now": "2020-04-29T17:19:10.716Z",
   "pr_number": 44299,
   "author": "geopic",
-  "dangerLevel": "ScopedAndConfiguration",
   "headCommitAbbrOid": "683fb3b",
   "headCommitOid": "683fb3b1298223256be3a49823686f35bd94a730",
   "mergeIsRequested": false,
@@ -11,9 +10,7 @@
   "lastPushDate": "2020-04-29T10:57:59.000Z",
   "lastCommentDate": "2020-04-29T10:57:59.000Z",
   "maintainerBlessed": false,
-  "reviewLink": "https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44299/files",
   "hasMergeConflict": false,
-  "authorIsOwner": false,
   "isFirstContribution": true,
   "popularityLevel": "Well-liked by everyone",
   "pkgInfo": [
@@ -50,9 +47,6 @@
       "popularityLevel": "Well-liked by everyone"
     }
   ],
-  "hasDismissedReview": false,
-  "ciResult": "pass",
-  "reviewersWithStaleReviews": [],
-  "approvalFlags": 0,
-  "isChangesRequested": false
+  "reviews": [],
+  "ciResult": "pass"
 }

--- a/src/_tests/fixtures/44316/derived.json
+++ b/src/_tests/fixtures/44316/derived.json
@@ -3,7 +3,6 @@
   "now": "2020-05-01T15:22:22.898Z",
   "pr_number": 44316,
   "author": "mattleff",
-  "dangerLevel": "ScopedAndConfiguration",
   "headCommitAbbrOid": "55357f7",
   "headCommitOid": "55357f7d60d059b5c84a23bd92854276a8f9a419",
   "mergeIsRequested": false,
@@ -11,9 +10,7 @@
   "lastPushDate": "2020-04-29T15:19:08.000Z",
   "lastCommentDate": "2020-04-29T00:16:19.000Z",
   "maintainerBlessed": false,
-  "reviewLink": "https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44316/files",
   "hasMergeConflict": false,
-  "authorIsOwner": true,
   "isFirstContribution": false,
   "popularityLevel": "Well-liked by everyone",
   "pkgInfo": [
@@ -42,9 +39,6 @@
       "popularityLevel": "Well-liked by everyone"
     }
   ],
-  "hasDismissedReview": false,
-  "ciResult": "pass",
-  "reviewersWithStaleReviews": [],
-  "approvalFlags": 0,
-  "isChangesRequested": false
+  "reviews": [],
+  "ciResult": "pass"
 }

--- a/src/_tests/fixtures/44343-pending-travis/derived.json
+++ b/src/_tests/fixtures/44343-pending-travis/derived.json
@@ -3,7 +3,6 @@
   "now": "2020-04-29T16:19:21.000Z",
   "pr_number": 44343,
   "author": "sandersn",
-  "dangerLevel": "ScopedAndTested",
   "headCommitAbbrOid": "abd65c3",
   "headCommitOid": "abd65c3bbbf3463b41127be203c37fe64f717a7e",
   "mergeIsRequested": false,
@@ -11,9 +10,7 @@
   "lastPushDate": "2020-04-29T16:19:21.000Z",
   "lastCommentDate": "2020-04-29T16:19:21.000Z",
   "maintainerBlessed": false,
-  "reviewLink": "https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44343/files",
   "hasMergeConflict": false,
-  "authorIsOwner": false,
   "isFirstContribution": false,
   "popularityLevel": "Well-liked by everyone",
   "pkgInfo": [
@@ -33,9 +30,6 @@
       "popularityLevel": "Well-liked by everyone"
     }
   ],
-  "hasDismissedReview": false,
-  "ciResult": "unknown",
-  "reviewersWithStaleReviews": [],
-  "approvalFlags": 0,
-  "isChangesRequested": false
+  "reviews": [],
+  "ciResult": "unknown"
 }

--- a/src/_tests/fixtures/44343-pre-travis/derived.json
+++ b/src/_tests/fixtures/44343-pre-travis/derived.json
@@ -3,7 +3,6 @@
   "now": "2020-04-29T16:19:21.000Z",
   "pr_number": 44343,
   "author": "sandersn",
-  "dangerLevel": "ScopedAndTested",
   "headCommitAbbrOid": "abd65c3",
   "headCommitOid": "abd65c3bbbf3463b41127be203c37fe64f717a7e",
   "mergeIsRequested": false,
@@ -11,9 +10,7 @@
   "lastPushDate": "2020-04-29T16:19:21.000Z",
   "lastCommentDate": "2020-04-29T16:19:21.000Z",
   "maintainerBlessed": false,
-  "reviewLink": "https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44343/files",
   "hasMergeConflict": false,
-  "authorIsOwner": false,
   "isFirstContribution": false,
   "popularityLevel": "Well-liked by everyone",
   "pkgInfo": [
@@ -33,9 +30,6 @@
       "popularityLevel": "Well-liked by everyone"
     }
   ],
-  "hasDismissedReview": false,
-  "ciResult": "unknown",
-  "reviewersWithStaleReviews": [],
-  "approvalFlags": 0,
-  "isChangesRequested": false
+  "reviews": [],
+  "ciResult": "unknown"
 }

--- a/src/_tests/fixtures/44343/derived.json
+++ b/src/_tests/fixtures/44343/derived.json
@@ -3,7 +3,6 @@
   "now": "2020-04-29T21:07:21.000Z",
   "pr_number": 44343,
   "author": "sandersn",
-  "dangerLevel": "ScopedAndTested",
   "headCommitAbbrOid": "abd65c3",
   "headCommitOid": "abd65c3bbbf3463b41127be203c37fe64f717a7e",
   "mergeIsRequested": false,
@@ -11,9 +10,7 @@
   "lastPushDate": "2020-04-29T16:19:21.000Z",
   "lastCommentDate": "2020-04-29T16:19:21.000Z",
   "maintainerBlessed": false,
-  "reviewLink": "https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44343/files",
   "hasMergeConflict": false,
-  "authorIsOwner": false,
   "isFirstContribution": false,
   "popularityLevel": "Well-liked by everyone",
   "pkgInfo": [
@@ -33,9 +30,6 @@
       "popularityLevel": "Well-liked by everyone"
     }
   ],
-  "hasDismissedReview": false,
-  "ciResult": "unknown",
-  "reviewersWithStaleReviews": [],
-  "approvalFlags": 0,
-  "isChangesRequested": false
+  "reviews": [],
+  "ciResult": "unknown"
 }

--- a/src/_tests/fixtures/44411/derived.json
+++ b/src/_tests/fixtures/44411/derived.json
@@ -3,7 +3,6 @@
   "now": "2020-05-01T16:17:25.774Z",
   "pr_number": 44411,
   "author": "peterblazejewicz",
-  "dangerLevel": "ScopedAndConfiguration",
   "headCommitAbbrOid": "d0d51a0",
   "headCommitOid": "d0d51a062525a6a4b83b297cd0e75adb4d5628f6",
   "mergeIsRequested": false,
@@ -11,9 +10,7 @@
   "lastPushDate": "2020-05-01T10:24:23.000Z",
   "lastCommentDate": "2020-05-01T10:24:23.000Z",
   "maintainerBlessed": false,
-  "reviewLink": "https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44411/files",
   "hasMergeConflict": false,
-  "authorIsOwner": false,
   "isFirstContribution": false,
   "popularityLevel": "Well-liked by everyone",
   "pkgInfo": [
@@ -58,9 +55,6 @@
       "popularityLevel": "Well-liked by everyone"
     }
   ],
-  "hasDismissedReview": false,
-  "ciResult": "pass",
-  "reviewersWithStaleReviews": [],
-  "approvalFlags": 0,
-  "isChangesRequested": false
+  "reviews": [],
+  "ciResult": "pass"
 }

--- a/src/_tests/fixtures/44424-1-travis-instantly-finished/derived.json
+++ b/src/_tests/fixtures/44424-1-travis-instantly-finished/derived.json
@@ -3,7 +3,6 @@
   "now": "2020-05-01T19:27:22.014Z",
   "pr_number": 44424,
   "author": "tomer-openfin",
-  "dangerLevel": "ScopedAndConfiguration",
   "headCommitAbbrOid": "af63694",
   "headCommitOid": "af636941dac21c0752befa1617297dfdac3e0a52",
   "mergeIsRequested": false,
@@ -11,9 +10,7 @@
   "lastPushDate": "2020-05-01T19:20:22.000Z",
   "lastCommentDate": "2020-05-01T19:20:22.000Z",
   "maintainerBlessed": false,
-  "reviewLink": "https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44424/files",
   "hasMergeConflict": false,
-  "authorIsOwner": true,
   "isFirstContribution": false,
   "popularityLevel": "Well-liked by everyone",
   "pkgInfo": [
@@ -436,9 +433,6 @@
       "popularityLevel": "Well-liked by everyone"
     }
   ],
-  "hasDismissedReview": false,
-  "ciResult": "pass",
-  "reviewersWithStaleReviews": [],
-  "approvalFlags": 0,
-  "isChangesRequested": false
+  "reviews": [],
+  "ciResult": "pass"
 }

--- a/src/_tests/fixtures/44424-2-after-travis-second/derived.json
+++ b/src/_tests/fixtures/44424-2-after-travis-second/derived.json
@@ -3,7 +3,6 @@
   "now": "2020-05-01T19:26:47.547Z",
   "pr_number": 44424,
   "author": "tomer-openfin",
-  "dangerLevel": "ScopedAndConfiguration",
   "headCommitAbbrOid": "af63694",
   "headCommitOid": "af636941dac21c0752befa1617297dfdac3e0a52",
   "mergeIsRequested": false,
@@ -11,9 +10,7 @@
   "lastPushDate": "2020-05-01T19:20:22.000Z",
   "lastCommentDate": "2020-05-01T19:20:22.000Z",
   "maintainerBlessed": false,
-  "reviewLink": "https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44424/files",
   "hasMergeConflict": false,
-  "authorIsOwner": true,
   "isFirstContribution": false,
   "popularityLevel": "Well-liked by everyone",
   "pkgInfo": [
@@ -436,9 +433,6 @@
       "popularityLevel": "Well-liked by everyone"
     }
   ],
-  "hasDismissedReview": false,
-  "ciResult": "unknown",
-  "reviewersWithStaleReviews": [],
-  "approvalFlags": 0,
-  "isChangesRequested": false
+  "reviews": [],
+  "ciResult": "unknown"
 }

--- a/src/_tests/fixtures/44437/derived.json
+++ b/src/_tests/fixtures/44437/derived.json
@@ -3,7 +3,6 @@
   "now": "2020-05-02T15:44:09.276Z",
   "pr_number": 44437,
   "author": "johnnyreilly",
-  "dangerLevel": "ScopedAndTested",
   "headCommitAbbrOid": "eb92456",
   "headCommitOid": "eb92456861d4537c6e96dd7865e715aa4812aae0",
   "mergeIsRequested": false,
@@ -11,9 +10,7 @@
   "lastPushDate": "2020-05-02T12:17:06.000Z",
   "lastCommentDate": "2020-05-02T12:17:06.000Z",
   "maintainerBlessed": false,
-  "reviewLink": "https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44437/files",
   "hasMergeConflict": false,
-  "authorIsOwner": false,
   "isFirstContribution": false,
   "popularityLevel": "Popular",
   "pkgInfo": [
@@ -43,11 +40,13 @@
       "popularityLevel": "Popular"
     }
   ],
-  "hasDismissedReview": false,
-  "ciResult": "pass",
-  "lastReviewDate": "2020-05-02T12:17:22.000Z",
-  "firstApprovalDate": "2020-05-02T12:17:22.000Z",
-  "reviewersWithStaleReviews": [],
-  "approvalFlags": 2,
-  "isChangesRequested": false
+  "reviews": [
+    {
+      "type": "approved",
+      "reviewer": "kamontat",
+      "date": "2020-05-02T12:17:22.000Z",
+      "isMaintainer": false
+    }
+  ],
+  "ciResult": "pass"
 }

--- a/src/_tests/fixtures/44439/derived.json
+++ b/src/_tests/fixtures/44439/derived.json
@@ -3,7 +3,6 @@
   "now": "2020-05-02T14:37:15.529Z",
   "pr_number": 44439,
   "author": "ivandevp",
-  "dangerLevel": "Infrastructure",
   "headCommitAbbrOid": "f8b1612",
   "headCommitOid": "f8b161266a38186c3d7ab715ea63f68d5ef542ed",
   "mergeIsRequested": false,
@@ -11,9 +10,7 @@
   "lastPushDate": "2020-05-02T13:54:02.000Z",
   "lastCommentDate": "2020-05-02T14:36:15.000Z",
   "maintainerBlessed": false,
-  "reviewLink": "https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44439/files",
   "hasMergeConflict": false,
-  "authorIsOwner": false,
   "isFirstContribution": true,
   "popularityLevel": "Well-liked by everyone",
   "pkgInfo": [
@@ -52,9 +49,6 @@
       "popularityLevel": "Well-liked by everyone"
     }
   ],
-  "hasDismissedReview": false,
-  "ciResult": "pass",
-  "reviewersWithStaleReviews": [],
-  "approvalFlags": 0,
-  "isChangesRequested": false
+  "reviews": [],
+  "ciResult": "pass"
 }

--- a/src/_tests/fixtures/44631/derived.json
+++ b/src/_tests/fixtures/44631/derived.json
@@ -3,7 +3,6 @@
   "now": "2020-05-15T15:43:58.396Z",
   "pr_number": 44631,
   "author": "mAAdhaTTah",
-  "dangerLevel": "ScopedAndTested",
   "headCommitAbbrOid": "96d6582",
   "headCommitOid": "96d6582f60431d273c179dcf6816426b4f1e37ac",
   "mergeIsRequested": false,
@@ -11,9 +10,7 @@
   "lastPushDate": "2020-05-10T21:26:25.000Z",
   "lastCommentDate": "2020-05-10T21:26:25.000Z",
   "maintainerBlessed": false,
-  "reviewLink": "https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44631/files",
   "hasMergeConflict": true,
-  "authorIsOwner": false,
   "isFirstContribution": false,
   "popularityLevel": "Well-liked by everyone",
   "pkgInfo": [
@@ -38,11 +35,13 @@
       "popularityLevel": "Well-liked by everyone"
     }
   ],
-  "hasDismissedReview": false,
-  "ciResult": "pass",
-  "lastReviewDate": "2020-05-15T15:41:39.000Z",
-  "firstApprovalDate": "2020-05-15T15:41:39.000Z",
-  "reviewersWithStaleReviews": [],
-  "approvalFlags": 4,
-  "isChangesRequested": false
+  "reviews": [
+    {
+      "type": "approved",
+      "reviewer": "sandersn",
+      "date": "2020-05-15T15:41:39.000Z",
+      "isMaintainer": true
+    }
+  ],
+  "ciResult": "pass"
 }

--- a/src/_tests/fixtures/44857/derived.json
+++ b/src/_tests/fixtures/44857/derived.json
@@ -3,7 +3,6 @@
   "now": "2020-08-30T10:52:28.076Z",
   "pr_number": 44857,
   "author": "ExE-Boss",
-  "dangerLevel": "ScopedAndTested",
   "headCommitAbbrOid": "4aff18f",
   "headCommitOid": "4aff18f9b99fdfc26209485631ba429f5d3d29ba",
   "mergeIsRequested": false,
@@ -11,9 +10,7 @@
   "lastPushDate": "2020-07-28T16:54:29.000Z",
   "lastCommentDate": "2020-07-29T16:31:48.000Z",
   "maintainerBlessed": false,
-  "reviewLink": "https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44857/files",
   "hasMergeConflict": false,
-  "authorIsOwner": true,
   "isFirstContribution": false,
   "popularityLevel": "Critical",
   "pkgInfo": [
@@ -151,15 +148,13 @@
       "popularityLevel": "Critical"
     }
   ],
-  "hasDismissedReview": false,
-  "ciResult": "pass",
-  "reviewersWithStaleReviews": [
+  "reviews": [
     {
-      "reviewedAbbrOid": "b0cfd18",
+      "type": "stale",
       "reviewer": "SimonSchick",
-      "date": "2020-05-19T23:20:53Z"
+      "date": "2020-05-19T23:20:53.000Z",
+      "abbrOid": "b0cfd18"
     }
   ],
-  "approvalFlags": 0,
-  "isChangesRequested": false
+  "ciResult": "pass"
 }

--- a/src/_tests/fixtures/44989-3days/derived.json
+++ b/src/_tests/fixtures/44989-3days/derived.json
@@ -3,7 +3,6 @@
   "now": "2020-05-26T16:28:19.013Z",
   "pr_number": 44989,
   "author": "petr-motejlek",
-  "dangerLevel": "ScopedAndTested",
   "headCommitAbbrOid": "9ca6086",
   "headCommitOid": "9ca60862ea56c9ff8d6b0f26c28b7e0bdaef4b34",
   "mergeIsRequested": false,
@@ -11,9 +10,7 @@
   "lastPushDate": "2020-05-23T08:41:39.000Z",
   "lastCommentDate": "2020-05-23T08:45:20.000Z",
   "maintainerBlessed": false,
-  "reviewLink": "https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44989/files",
   "hasMergeConflict": false,
-  "authorIsOwner": false,
   "isFirstContribution": false,
   "popularityLevel": "Popular",
   "pkgInfo": [
@@ -65,11 +62,13 @@
       "popularityLevel": "Popular"
     }
   ],
-  "hasDismissedReview": false,
-  "ciResult": "pass",
-  "lastReviewDate": "2020-05-23T10:05:48.000Z",
-  "firstApprovalDate": "2020-05-23T10:05:48.000Z",
-  "reviewersWithStaleReviews": [],
-  "approvalFlags": 2,
-  "isChangesRequested": false
+  "reviews": [
+    {
+      "type": "approved",
+      "reviewer": "Nicholaiii",
+      "date": "2020-05-23T10:05:48.000Z",
+      "isMaintainer": false
+    }
+  ],
+  "ciResult": "pass"
 }

--- a/src/_tests/fixtures/44989-5days/derived.json
+++ b/src/_tests/fixtures/44989-5days/derived.json
@@ -3,7 +3,6 @@
   "now": "2020-05-28T16:28:19.013Z",
   "pr_number": 44989,
   "author": "petr-motejlek",
-  "dangerLevel": "ScopedAndTested",
   "headCommitAbbrOid": "9ca6086",
   "headCommitOid": "9ca60862ea56c9ff8d6b0f26c28b7e0bdaef4b34",
   "mergeIsRequested": false,
@@ -11,9 +10,7 @@
   "lastPushDate": "2020-05-23T08:41:39.000Z",
   "lastCommentDate": "2020-05-23T08:45:20.000Z",
   "maintainerBlessed": false,
-  "reviewLink": "https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44989/files",
   "hasMergeConflict": false,
-  "authorIsOwner": false,
   "isFirstContribution": false,
   "popularityLevel": "Popular",
   "pkgInfo": [
@@ -65,11 +62,13 @@
       "popularityLevel": "Popular"
     }
   ],
-  "hasDismissedReview": false,
-  "ciResult": "pass",
-  "lastReviewDate": "2020-05-23T10:05:48.000Z",
-  "firstApprovalDate": "2020-05-23T10:05:48.000Z",
-  "reviewersWithStaleReviews": [],
-  "approvalFlags": 2,
-  "isChangesRequested": false
+  "reviews": [
+    {
+      "type": "approved",
+      "reviewer": "Nicholaiii",
+      "date": "2020-05-23T10:05:48.000Z",
+      "isMaintainer": false
+    }
+  ],
+  "ciResult": "pass"
 }

--- a/src/_tests/fixtures/44989-6days/derived.json
+++ b/src/_tests/fixtures/44989-6days/derived.json
@@ -3,7 +3,6 @@
   "now": "2020-05-29T16:28:19.013Z",
   "pr_number": 44989,
   "author": "petr-motejlek",
-  "dangerLevel": "ScopedAndTested",
   "headCommitAbbrOid": "9ca6086",
   "headCommitOid": "9ca60862ea56c9ff8d6b0f26c28b7e0bdaef4b34",
   "mergeIsRequested": false,
@@ -11,9 +10,7 @@
   "lastPushDate": "2020-05-23T08:41:39.000Z",
   "lastCommentDate": "2020-05-23T08:45:20.000Z",
   "maintainerBlessed": false,
-  "reviewLink": "https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44989/files",
   "hasMergeConflict": false,
-  "authorIsOwner": false,
   "isFirstContribution": false,
   "popularityLevel": "Popular",
   "pkgInfo": [
@@ -65,11 +62,13 @@
       "popularityLevel": "Popular"
     }
   ],
-  "hasDismissedReview": false,
-  "ciResult": "pass",
-  "lastReviewDate": "2020-05-23T10:05:48.000Z",
-  "firstApprovalDate": "2020-05-23T10:05:48.000Z",
-  "reviewersWithStaleReviews": [],
-  "approvalFlags": 2,
-  "isChangesRequested": false
+  "reviews": [
+    {
+      "type": "approved",
+      "reviewer": "Nicholaiii",
+      "date": "2020-05-23T10:05:48.000Z",
+      "isMaintainer": false
+    }
+  ],
+  "ciResult": "pass"
 }

--- a/src/_tests/fixtures/44989-9days/derived.json
+++ b/src/_tests/fixtures/44989-9days/derived.json
@@ -3,7 +3,6 @@
   "now": "2020-06-01T16:28:19.013Z",
   "pr_number": 44989,
   "author": "petr-motejlek",
-  "dangerLevel": "ScopedAndTested",
   "headCommitAbbrOid": "9ca6086",
   "headCommitOid": "9ca60862ea56c9ff8d6b0f26c28b7e0bdaef4b34",
   "mergeIsRequested": false,
@@ -11,9 +10,7 @@
   "lastPushDate": "2020-05-23T08:41:39.000Z",
   "lastCommentDate": "2020-05-23T08:45:20.000Z",
   "maintainerBlessed": false,
-  "reviewLink": "https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44989/files",
   "hasMergeConflict": false,
-  "authorIsOwner": false,
   "isFirstContribution": false,
   "popularityLevel": "Popular",
   "pkgInfo": [
@@ -65,11 +62,13 @@
       "popularityLevel": "Popular"
     }
   ],
-  "hasDismissedReview": false,
-  "ciResult": "pass",
-  "lastReviewDate": "2020-05-23T10:05:48.000Z",
-  "firstApprovalDate": "2020-05-23T10:05:48.000Z",
-  "reviewersWithStaleReviews": [],
-  "approvalFlags": 2,
-  "isChangesRequested": false
+  "reviews": [
+    {
+      "type": "approved",
+      "reviewer": "Nicholaiii",
+      "date": "2020-05-23T10:05:48.000Z",
+      "isMaintainer": false
+    }
+  ],
+  "ciResult": "pass"
 }

--- a/src/_tests/fixtures/45137/derived.json
+++ b/src/_tests/fixtures/45137/derived.json
@@ -3,7 +3,6 @@
   "now": "2020-05-29T11:17:01.368Z",
   "pr_number": 45137,
   "author": "lirbank",
-  "dangerLevel": "ScopedAndUntested",
   "headCommitAbbrOid": "22c73c8",
   "headCommitOid": "22c73c88cc9c09efd4c2998ec360607dd4c36c2e",
   "mergeIsRequested": false,
@@ -11,9 +10,7 @@
   "lastPushDate": "2020-05-29T04:38:59.000Z",
   "lastCommentDate": "2020-05-29T04:43:45.000Z",
   "maintainerBlessed": false,
-  "reviewLink": "https://github.com/DefinitelyTyped/DefinitelyTyped/pull/45137/files",
   "hasMergeConflict": false,
-  "authorIsOwner": true,
   "isFirstContribution": false,
   "popularityLevel": "Popular",
   "pkgInfo": [
@@ -64,11 +61,13 @@
       "popularityLevel": "Popular"
     }
   ],
-  "hasDismissedReview": false,
-  "ciResult": "pass",
-  "lastReviewDate": "2020-05-29T07:13:24.000Z",
-  "firstApprovalDate": "2020-05-29T07:13:24.000Z",
-  "reviewersWithStaleReviews": [],
-  "approvalFlags": 2,
-  "isChangesRequested": false
+  "reviews": [
+    {
+      "type": "approved",
+      "reviewer": "LinusU",
+      "date": "2020-05-29T07:13:24.000Z",
+      "isMaintainer": false
+    }
+  ],
+  "ciResult": "pass"
 }

--- a/src/_tests/fixtures/45627/derived.json
+++ b/src/_tests/fixtures/45627/derived.json
@@ -3,7 +3,6 @@
   "now": "2020-07-06T08:47:17.001Z",
   "pr_number": 45627,
   "author": "spamshaker",
-  "dangerLevel": "ScopedAndUntested",
   "headCommitAbbrOid": "15facc1",
   "headCommitOid": "15facc177c957646a1ace95abe5e71326007c721",
   "mergeIsRequested": true,
@@ -11,9 +10,7 @@
   "lastPushDate": "2020-06-21T09:33:06.000Z",
   "lastCommentDate": "2020-07-06T08:36:06.000Z",
   "maintainerBlessed": true,
-  "reviewLink": "https://github.com/DefinitelyTyped/DefinitelyTyped/pull/45627/files",
   "hasMergeConflict": false,
-  "authorIsOwner": false,
   "isFirstContribution": false,
   "popularityLevel": "Critical",
   "pkgInfo": [
@@ -55,11 +52,13 @@
       "popularityLevel": "Critical"
     }
   ],
-  "hasDismissedReview": false,
-  "ciResult": "pass",
-  "lastReviewDate": "2020-07-03T17:33:39.000Z",
-  "firstApprovalDate": "2020-07-03T17:33:39.000Z",
-  "reviewersWithStaleReviews": [],
-  "approvalFlags": 2,
-  "isChangesRequested": false
+  "reviews": [
+    {
+      "type": "approved",
+      "reviewer": "ofhouse",
+      "date": "2020-07-03T17:33:39.000Z",
+      "isMaintainer": false
+    }
+  ],
+  "ciResult": "pass"
 }

--- a/src/_tests/fixtures/45836/derived.json
+++ b/src/_tests/fixtures/45836/derived.json
@@ -3,7 +3,6 @@
   "now": "2020-07-08T18:57:14.868Z",
   "pr_number": 45836,
   "author": "mmorearty",
-  "dangerLevel": "MultiplePackagesEdited",
   "headCommitAbbrOid": "6c7735e",
   "headCommitOid": "6c7735e2b8f39640cb73e40ae04cb6642a8ab2cd",
   "mergeIsRequested": true,
@@ -11,9 +10,7 @@
   "lastPushDate": "2020-07-01T23:06:38.000Z",
   "lastCommentDate": "2020-07-08T18:13:23.000Z",
   "maintainerBlessed": false,
-  "reviewLink": "https://github.com/DefinitelyTyped/DefinitelyTyped/pull/45836/files",
   "hasMergeConflict": false,
-  "authorIsOwner": true,
   "isFirstContribution": false,
   "popularityLevel": "Well-liked by everyone",
   "pkgInfo": [
@@ -61,11 +58,13 @@
       "popularityLevel": "Well-liked by everyone"
     }
   ],
-  "hasDismissedReview": false,
-  "ciResult": "pass",
-  "lastReviewDate": "2020-07-03T22:31:28.000Z",
-  "firstApprovalDate": "2020-07-03T22:31:28.000Z",
-  "reviewersWithStaleReviews": [],
-  "approvalFlags": 2,
-  "isChangesRequested": false
+  "reviews": [
+    {
+      "type": "approved",
+      "reviewer": "timjb",
+      "date": "2020-07-03T22:31:28.000Z",
+      "isMaintainer": false
+    }
+  ],
+  "ciResult": "pass"
 }

--- a/src/_tests/fixtures/45836/mutations.json
+++ b/src/_tests/fixtures/45836/mutations.json
@@ -4,7 +4,8 @@
     "variables": {
       "input": {
         "labelIds": [
-          "MDU6TGFiZWwzOTU2NzkwNTk="
+          "MDU6TGFiZWwzOTU2NzkwNTk=",
+          "MDU6TGFiZWw3OTg3Mzc0Nzg="
         ],
         "labelableId": "MDExOlB1bGxSZXF1ZXN0NDQzMDQ3Njgy"
       }

--- a/src/_tests/fixtures/45836/result.json
+++ b/src/_tests/fixtures/45836/result.json
@@ -16,7 +16,7 @@
     "Critical package": false,
     "Edits Infrastructure": false,
     "Edits multiple packages": true,
-    "Author is Owner": true,
+    "Author is Owner": false,
     "No Other Owners": false,
     "Too Many Owners": false,
     "Merge:Auto": false,

--- a/src/_tests/fixtures/45884/derived.json
+++ b/src/_tests/fixtures/45884/derived.json
@@ -3,7 +3,6 @@
   "now": "2020-07-06T06:52:24.860Z",
   "pr_number": 45884,
   "author": "sgratzl",
-  "dangerLevel": "ScopedAndUntested",
   "headCommitAbbrOid": "1dcf44a",
   "headCommitOid": "1dcf44a05908783324ca99231837267af495cdb7",
   "mergeIsRequested": false,
@@ -11,9 +10,7 @@
   "lastPushDate": "2020-07-04T08:33:11.000Z",
   "lastCommentDate": "2020-07-04T08:40:23.000Z",
   "maintainerBlessed": true,
-  "reviewLink": "https://github.com/DefinitelyTyped/DefinitelyTyped/pull/45884/files",
   "hasMergeConflict": false,
-  "authorIsOwner": false,
   "isFirstContribution": true,
   "popularityLevel": "Well-liked by everyone",
   "pkgInfo": [
@@ -42,11 +39,13 @@
       "popularityLevel": "Well-liked by everyone"
     }
   ],
-  "hasDismissedReview": false,
-  "ciResult": "pass",
-  "lastReviewDate": "2020-07-04T11:08:20.000Z",
-  "firstApprovalDate": "2020-07-04T11:08:20.000Z",
-  "reviewersWithStaleReviews": [],
-  "approvalFlags": 2,
-  "isChangesRequested": false
+  "reviews": [
+    {
+      "type": "approved",
+      "reviewer": "Veckodag",
+      "date": "2020-07-04T11:08:20.000Z",
+      "isMaintainer": false
+    }
+  ],
+  "ciResult": "pass"
 }

--- a/src/_tests/fixtures/45888/derived.json
+++ b/src/_tests/fixtures/45888/derived.json
@@ -3,7 +3,6 @@
   "now": "2020-07-06T07:40:37.670Z",
   "pr_number": 45888,
   "author": "gstvds",
-  "dangerLevel": "ScopedAndUntested",
   "headCommitAbbrOid": "8a7a2fc",
   "headCommitOid": "8a7a2fc1cdbfe1d3a7af7d1f7a346977fdf47b0d",
   "mergeIsRequested": false,
@@ -11,9 +10,7 @@
   "lastPushDate": "2020-07-04T18:01:47.000Z",
   "lastCommentDate": "2020-07-04T18:01:47.000Z",
   "maintainerBlessed": true,
-  "reviewLink": "https://github.com/DefinitelyTyped/DefinitelyTyped/pull/45888/files",
   "hasMergeConflict": false,
-  "authorIsOwner": false,
   "isFirstContribution": true,
   "popularityLevel": "Well-liked by everyone",
   "pkgInfo": [
@@ -36,11 +33,13 @@
       "popularityLevel": "Well-liked by everyone"
     }
   ],
-  "hasDismissedReview": false,
-  "ciResult": "pass",
-  "lastReviewDate": "2020-07-06T05:28:20.000Z",
-  "firstApprovalDate": "2020-07-06T05:28:20.000Z",
-  "reviewersWithStaleReviews": [],
-  "approvalFlags": 1,
-  "isChangesRequested": false
+  "reviews": [
+    {
+      "type": "approved",
+      "reviewer": "brendonhc",
+      "date": "2020-07-06T05:28:20.000Z",
+      "isMaintainer": false
+    }
+  ],
+  "ciResult": "pass"
 }

--- a/src/_tests/fixtures/45890/derived.json
+++ b/src/_tests/fixtures/45890/derived.json
@@ -3,7 +3,6 @@
   "now": "2020-07-06T08:21:55.751Z",
   "pr_number": 45890,
   "author": "dimkirt",
-  "dangerLevel": "ScopedAndConfiguration",
   "headCommitAbbrOid": "146c312",
   "headCommitOid": "146c312eac4c4ac8931b4ec6b2762457f8f4b6e6",
   "mergeIsRequested": false,
@@ -11,9 +10,7 @@
   "lastPushDate": "2020-07-04T22:02:07.000Z",
   "lastCommentDate": "2020-07-04T22:04:02.000Z",
   "maintainerBlessed": false,
-  "reviewLink": "https://github.com/DefinitelyTyped/DefinitelyTyped/pull/45890/files",
   "hasMergeConflict": false,
-  "authorIsOwner": false,
   "isFirstContribution": true,
   "popularityLevel": "Well-liked by everyone",
   "pkgInfo": [
@@ -47,11 +44,13 @@
       "popularityLevel": "Well-liked by everyone"
     }
   ],
-  "hasDismissedReview": false,
-  "ciResult": "pass",
-  "lastReviewDate": "2020-07-05T08:20:29.000Z",
-  "firstApprovalDate": "2020-07-05T08:20:29.000Z",
-  "reviewersWithStaleReviews": [],
-  "approvalFlags": 1,
-  "isChangesRequested": false
+  "reviews": [
+    {
+      "type": "approved",
+      "reviewer": "peterblazejewicz",
+      "date": "2020-07-05T08:20:29.000Z",
+      "isMaintainer": false
+    }
+  ],
+  "ciResult": "pass"
 }

--- a/src/_tests/fixtures/45946/derived.json
+++ b/src/_tests/fixtures/45946/derived.json
@@ -3,7 +3,6 @@
   "now": "2020-07-11T01:46:16.667Z",
   "pr_number": 45946,
   "author": "rubensworks",
-  "dangerLevel": "Infrastructure",
   "headCommitAbbrOid": "a5eb1f1",
   "headCommitOid": "a5eb1f19e7a31387e7d7c79b3acc483b0e60b32e",
   "mergeIsRequested": false,
@@ -11,9 +10,7 @@
   "lastPushDate": "2020-07-08T06:31:29.000Z",
   "lastCommentDate": "2020-07-10T14:00:47.000Z",
   "maintainerBlessed": false,
-  "reviewLink": "https://github.com/DefinitelyTyped/DefinitelyTyped/pull/45946/files",
   "hasMergeConflict": false,
-  "authorIsOwner": true,
   "isFirstContribution": false,
   "popularityLevel": "Well-liked by everyone",
   "pkgInfo": [
@@ -62,9 +59,6 @@
       "popularityLevel": "Well-liked by everyone"
     }
   ],
-  "hasDismissedReview": false,
-  "ciResult": "pass",
-  "reviewersWithStaleReviews": [],
-  "approvalFlags": 0,
-  "isChangesRequested": false
+  "reviews": [],
+  "ciResult": "pass"
 }

--- a/src/_tests/fixtures/45946/mutations.json
+++ b/src/_tests/fixtures/45946/mutations.json
@@ -1,5 +1,16 @@
 [
   {
+    "query": "mutation($input: RemoveLabelsFromLabelableInput!) { removeLabelsFromLabelable(input: $input) { clientMutationId } }",
+    "variables": {
+      "input": {
+        "labelIds": [
+          "MDU6TGFiZWw3OTg3Mzc0Nzg="
+        ],
+        "labelableId": "MDExOlB1bGxSZXF1ZXN0NDQ2MDIxMjkw"
+      }
+    }
+  },
+  {
     "query": "mutation($input: MoveProjectCardInput!) { moveProjectCard(input: $input) { clientMutationId } }",
     "variables": {
       "input": {

--- a/src/_tests/fixtures/45946/result.json
+++ b/src/_tests/fixtures/45946/result.json
@@ -16,7 +16,7 @@
     "Critical package": false,
     "Edits Infrastructure": true,
     "Edits multiple packages": false,
-    "Author is Owner": true,
+    "Author is Owner": false,
     "No Other Owners": true,
     "Too Many Owners": false,
     "Merge:Auto": false,

--- a/src/_tests/fixtures/45999/derived.json
+++ b/src/_tests/fixtures/45999/derived.json
@@ -3,7 +3,6 @@
   "now": "2020-07-11T02:37:12.780Z",
   "pr_number": 45999,
   "author": "alexpyzhianov",
-  "dangerLevel": "ScopedAndTested",
   "headCommitAbbrOid": "381a2a9",
   "headCommitOid": "381a2a9d17d14e111f7d002c866debfcac6724e8",
   "mergeIsRequested": false,
@@ -11,9 +10,7 @@
   "lastPushDate": "2020-07-10T13:10:49.000Z",
   "lastCommentDate": "2020-07-10T14:38:56.000Z",
   "maintainerBlessed": true,
-  "reviewLink": "https://github.com/DefinitelyTyped/DefinitelyTyped/pull/45999/files",
   "hasMergeConflict": false,
-  "authorIsOwner": false,
   "isFirstContribution": false,
   "popularityLevel": "Critical",
   "pkgInfo": [
@@ -59,11 +56,19 @@
       "popularityLevel": "Critical"
     }
   ],
-  "hasDismissedReview": false,
-  "ciResult": "pass",
-  "lastReviewDate": "2020-07-10T14:49:32.000Z",
-  "firstApprovalDate": "2020-07-10T13:34:29.000Z",
-  "reviewersWithStaleReviews": [],
-  "approvalFlags": 2,
-  "isChangesRequested": false
+  "reviews": [
+    {
+      "type": "approved",
+      "reviewer": "ferdaber",
+      "date": "2020-07-10T14:49:32.000Z",
+      "isMaintainer": false
+    },
+    {
+      "type": "approved",
+      "reviewer": "eps1lon",
+      "date": "2020-07-10T13:34:29.000Z",
+      "isMaintainer": false
+    }
+  ],
+  "ciResult": "pass"
 }

--- a/src/_tests/fixtures/46008/derived.json
+++ b/src/_tests/fixtures/46008/derived.json
@@ -3,7 +3,6 @@
   "now": "2020-07-11T02:09:32.239Z",
   "pr_number": 46008,
   "author": "risingBirdSong",
-  "dangerLevel": "ScopedAndUntested",
   "headCommitAbbrOid": "3e19cb9",
   "headCommitOid": "3e19cb9cae4689fb736fd6682f7f76d8efafcaa2",
   "mergeIsRequested": false,
@@ -11,9 +10,7 @@
   "lastPushDate": "2020-07-10T00:44:49.000Z",
   "lastCommentDate": "2020-07-10T18:58:06.000Z",
   "maintainerBlessed": true,
-  "reviewLink": "https://github.com/DefinitelyTyped/DefinitelyTyped/pull/46008/files",
   "hasMergeConflict": false,
-  "authorIsOwner": false,
   "isFirstContribution": true,
   "popularityLevel": "Well-liked by everyone",
   "pkgInfo": [
@@ -34,11 +31,13 @@
       "popularityLevel": "Well-liked by everyone"
     }
   ],
-  "hasDismissedReview": false,
-  "ciResult": "pass",
-  "lastReviewDate": "2020-07-10T18:53:03.000Z",
-  "firstApprovalDate": "2020-07-10T18:53:03.000Z",
-  "reviewersWithStaleReviews": [],
-  "approvalFlags": 2,
-  "isChangesRequested": false
+  "reviews": [
+    {
+      "type": "approved",
+      "reviewer": "Zalastax",
+      "date": "2020-07-10T18:53:03.000Z",
+      "isMaintainer": false
+    }
+  ],
+  "ciResult": "pass"
 }

--- a/src/_tests/fixtures/46019/derived.json
+++ b/src/_tests/fixtures/46019/derived.json
@@ -3,7 +3,6 @@
   "now": "2020-07-12T04:13:43.404Z",
   "pr_number": 46019,
   "author": "peterblazejewicz",
-  "dangerLevel": "ScopedAndConfiguration",
   "headCommitAbbrOid": "ceca9f7",
   "headCommitOid": "ceca9f768be945932c692d7dd48fa14b6ff38096",
   "mergeIsRequested": false,
@@ -11,9 +10,7 @@
   "lastPushDate": "2020-07-11T20:43:23.000Z",
   "lastCommentDate": "2020-07-11T20:43:23.000Z",
   "maintainerBlessed": false,
-  "reviewLink": "https://github.com/DefinitelyTyped/DefinitelyTyped/pull/46019/files",
   "hasMergeConflict": false,
-  "authorIsOwner": false,
   "isFirstContribution": false,
   "popularityLevel": "Well-liked by everyone",
   "pkgInfo": [
@@ -47,11 +44,13 @@
       "popularityLevel": "Well-liked by everyone"
     }
   ],
-  "hasDismissedReview": false,
-  "ciResult": "pass",
-  "lastReviewDate": "2020-07-12T02:01:31.000Z",
-  "firstApprovalDate": "2020-07-12T02:01:31.000Z",
-  "reviewersWithStaleReviews": [],
-  "approvalFlags": 4,
-  "isChangesRequested": false
+  "reviews": [
+    {
+      "type": "approved",
+      "reviewer": "weswigham",
+      "date": "2020-07-12T02:01:31.000Z",
+      "isMaintainer": true
+    }
+  ],
+  "ciResult": "pass"
 }

--- a/src/_tests/fixtures/46120/derived.json
+++ b/src/_tests/fixtures/46120/derived.json
@@ -3,7 +3,6 @@
   "now": "2020-07-20T11:47:54.872Z",
   "pr_number": 46120,
   "author": "reubenrybnik",
-  "dangerLevel": "ScopedAndTested",
   "headCommitAbbrOid": "5ef8fe2",
   "headCommitOid": "5ef8fe2907257beac41e27c3dc2399a087eddb67",
   "mergeIsRequested": false,
@@ -11,9 +10,7 @@
   "lastPushDate": "2020-07-17T14:12:06.000Z",
   "lastCommentDate": "2020-07-19T22:33:41.000Z",
   "maintainerBlessed": false,
-  "reviewLink": "https://github.com/DefinitelyTyped/DefinitelyTyped/pull/46120/files",
   "hasMergeConflict": false,
-  "authorIsOwner": true,
   "isFirstContribution": false,
   "popularityLevel": "Popular",
   "pkgInfo": [
@@ -45,11 +42,13 @@
       "popularityLevel": "Popular"
     }
   ],
-  "hasDismissedReview": false,
-  "ciResult": "pass",
-  "lastReviewDate": "2020-07-19T20:19:03.000Z",
-  "firstApprovalDate": "2020-07-19T20:19:03.000Z",
-  "reviewersWithStaleReviews": [],
-  "approvalFlags": 2,
-  "isChangesRequested": false
+  "reviews": [
+    {
+      "type": "approved",
+      "reviewer": "jgonggrijp",
+      "date": "2020-07-19T20:19:03.000Z",
+      "isMaintainer": false
+    }
+  ],
+  "ciResult": "pass"
 }

--- a/src/_tests/fixtures/46191/derived.json
+++ b/src/_tests/fixtures/46191/derived.json
@@ -3,7 +3,6 @@
   "now": "2020-07-20T22:17:53.067Z",
   "pr_number": 46191,
   "author": "jordanoverbye",
-  "dangerLevel": "ScopedAndUntested",
   "headCommitAbbrOid": "3cc81db",
   "headCommitOid": "3cc81dbde57a1b0eda6f69f539fa49b8d420adff",
   "mergeIsRequested": false,
@@ -11,9 +10,7 @@
   "lastPushDate": "2020-07-20T06:54:57.000Z",
   "lastCommentDate": "2020-07-20T06:54:57.000Z",
   "maintainerBlessed": false,
-  "reviewLink": "https://github.com/DefinitelyTyped/DefinitelyTyped/pull/46191/files",
   "hasMergeConflict": false,
-  "authorIsOwner": false,
   "isFirstContribution": true,
   "popularityLevel": "Well-liked by everyone",
   "pkgInfo": [
@@ -43,10 +40,7 @@
       "popularityLevel": "Well-liked by everyone"
     }
   ],
-  "hasDismissedReview": false,
+  "reviews": [],
   "ciResult": "fail",
-  "ciUrl": "https://github.com/DefinitelyTyped/DefinitelyTyped/commit/3cc81dbde57a1b0eda6f69f539fa49b8d420adff/checks?check_suite_id=938074936",
-  "reviewersWithStaleReviews": [],
-  "approvalFlags": 0,
-  "isChangesRequested": false
+  "ciUrl": "https://github.com/DefinitelyTyped/DefinitelyTyped/commit/3cc81dbde57a1b0eda6f69f539fa49b8d420adff/checks?check_suite_id=938074936"
 }

--- a/src/_tests/fixtures/46196/derived.json
+++ b/src/_tests/fixtures/46196/derived.json
@@ -3,7 +3,6 @@
   "now": "2020-07-20T22:18:56.331Z",
   "pr_number": 46196,
   "author": "bytetyde",
-  "dangerLevel": "ScopedAndTested",
   "headCommitAbbrOid": "2f300d2",
   "headCommitOid": "2f300d234e09e9e34c88e884f6466f2d6d0db399",
   "mergeIsRequested": false,
@@ -11,9 +10,7 @@
   "lastPushDate": "2020-07-20T12:12:39.000Z",
   "lastCommentDate": "2020-07-20T12:12:39.000Z",
   "maintainerBlessed": false,
-  "reviewLink": "https://github.com/DefinitelyTyped/DefinitelyTyped/pull/46196/files",
   "hasMergeConflict": false,
-  "authorIsOwner": false,
   "isFirstContribution": true,
   "popularityLevel": "Well-liked by everyone",
   "pkgInfo": [
@@ -45,9 +42,6 @@
       "popularityLevel": "Well-liked by everyone"
     }
   ],
-  "hasDismissedReview": false,
-  "ciResult": "pass",
-  "reviewersWithStaleReviews": [],
-  "approvalFlags": 0,
-  "isChangesRequested": false
+  "reviews": [],
+  "ciResult": "pass"
 }

--- a/src/_tests/fixtures/46279/derived.json
+++ b/src/_tests/fixtures/46279/derived.json
@@ -3,7 +3,6 @@
   "now": "2020-07-23T18:40:42.000Z",
   "pr_number": 46279,
   "author": "pzingg",
-  "dangerLevel": "ScopedAndUntested",
   "headCommitAbbrOid": "8032238",
   "headCommitOid": "80322389c71c13e0fca466b744b35b742a3ee161",
   "mergeIsRequested": false,
@@ -11,9 +10,7 @@
   "lastPushDate": "2020-07-23T01:03:50.000Z",
   "lastCommentDate": "2020-07-23T01:03:50.000Z",
   "maintainerBlessed": true,
-  "reviewLink": "https://github.com/DefinitelyTyped/DefinitelyTyped/pull/46279/files",
   "hasMergeConflict": false,
-  "authorIsOwner": true,
   "isFirstContribution": false,
   "popularityLevel": "Well-liked by everyone",
   "pkgInfo": [
@@ -33,9 +30,6 @@
       "popularityLevel": "Well-liked by everyone"
     }
   ],
-  "hasDismissedReview": false,
-  "ciResult": "pass",
-  "reviewersWithStaleReviews": [],
-  "approvalFlags": 0,
-  "isChangesRequested": false
+  "reviews": [],
+  "ciResult": "pass"
 }

--- a/src/_tests/fixtures/46804/derived.json
+++ b/src/_tests/fixtures/46804/derived.json
@@ -3,7 +3,6 @@
   "now": "2020-08-25T19:30:48.988Z",
   "pr_number": 46804,
   "author": "ETHANTALJAFFE",
-  "dangerLevel": "ScopedAndUntested",
   "headCommitAbbrOid": "3e3524f",
   "headCommitOid": "3e3524f41de19cd97d5c32a531eab3f0e9206f75",
   "mergeIsRequested": false,
@@ -11,9 +10,7 @@
   "lastPushDate": "2020-08-15T20:29:40.000Z",
   "lastCommentDate": "2020-08-15T20:29:40.000Z",
   "maintainerBlessed": true,
-  "reviewLink": "https://github.com/DefinitelyTyped/DefinitelyTyped/pull/46804/files",
   "hasMergeConflict": false,
-  "authorIsOwner": false,
   "isFirstContribution": true,
   "popularityLevel": "Well-liked by everyone",
   "pkgInfo": [
@@ -35,9 +32,6 @@
       "popularityLevel": "Well-liked by everyone"
     }
   ],
-  "hasDismissedReview": false,
-  "ciResult": "pass",
-  "reviewersWithStaleReviews": [],
-  "approvalFlags": 0,
-  "isChangesRequested": false
+  "reviews": [],
+  "ciResult": "pass"
 }

--- a/src/_tests/fixtures/46879/derived.json
+++ b/src/_tests/fixtures/46879/derived.json
@@ -3,7 +3,6 @@
   "now": "2020-08-18T12:34:56.000Z",
   "pr_number": 46879,
   "author": "Chaldron",
-  "dangerLevel": "ScopedAndTested",
   "headCommitAbbrOid": "2586d74",
   "headCommitOid": "2586d74ca0dc553be5f3afc0135468b17b240d70",
   "mergeIsRequested": false,
@@ -11,9 +10,7 @@
   "lastPushDate": "2020-08-11T18:21:13.000Z",
   "lastCommentDate": "2020-08-11T18:21:13.000Z",
   "maintainerBlessed": false,
-  "reviewLink": "https://github.com/DefinitelyTyped/DefinitelyTyped/pull/46879/files",
   "hasMergeConflict": false,
-  "authorIsOwner": false,
   "isFirstContribution": false,
   "popularityLevel": "Popular",
   "pkgInfo": [
@@ -42,9 +39,6 @@
       "popularityLevel": "Popular"
     }
   ],
-  "hasDismissedReview": false,
-  "ciResult": "pass",
-  "reviewersWithStaleReviews": [],
-  "approvalFlags": 0,
-  "isChangesRequested": false
+  "reviews": [],
+  "ciResult": "pass"
 }

--- a/src/_tests/fixtures/47017/derived.json
+++ b/src/_tests/fixtures/47017/derived.json
@@ -3,7 +3,6 @@
   "now": "2020-08-27T20:15:58.001Z",
   "pr_number": 47017,
   "author": "mastermatt",
-  "dangerLevel": "MultiplePackagesEdited",
   "headCommitAbbrOid": "dbe687d",
   "headCommitOid": "dbe687d30362e4f887e88048a3646c13c0c4d907",
   "mergeIsRequested": false,
@@ -11,9 +10,7 @@
   "lastPushDate": "2020-08-25T05:47:26.000Z",
   "lastCommentDate": "2020-08-25T05:54:37.000Z",
   "maintainerBlessed": true,
-  "reviewLink": "https://github.com/DefinitelyTyped/DefinitelyTyped/pull/47017/files",
   "hasMergeConflict": false,
-  "authorIsOwner": false,
   "isFirstContribution": false,
   "popularityLevel": "Critical",
   "pkgInfo": [
@@ -67,9 +64,6 @@
       "popularityLevel": "Critical"
     }
   ],
-  "hasDismissedReview": false,
-  "ciResult": "pass",
-  "reviewersWithStaleReviews": [],
-  "approvalFlags": 0,
-  "isChangesRequested": false
+  "reviews": [],
+  "ciResult": "pass"
 }

--- a/src/_tests/fixtures/48216/derived.json
+++ b/src/_tests/fixtures/48216/derived.json
@@ -3,7 +3,6 @@
   "now": "2020-09-27T19:02:30.338Z",
   "pr_number": 48216,
   "author": "jablko",
-  "dangerLevel": "ScopedAndTested",
   "headCommitAbbrOid": "3f689bf",
   "headCommitOid": "3f689bfb9d310612cdaf7c52c7ead41d1181b52f",
   "mergeIsRequested": false,
@@ -12,9 +11,7 @@
   "reopenedDate": "2020-09-27T19:01:23.000Z",
   "lastCommentDate": "2020-09-27T17:23:58.000Z",
   "maintainerBlessed": false,
-  "reviewLink": "https://github.com/DefinitelyTyped/DefinitelyTyped/pull/48216/files",
   "hasMergeConflict": false,
-  "authorIsOwner": false,
   "isFirstContribution": false,
   "popularityLevel": "Well-liked by everyone",
   "pkgInfo": [
@@ -39,9 +36,6 @@
       "popularityLevel": "Well-liked by everyone"
     }
   ],
-  "hasDismissedReview": false,
-  "ciResult": "pass",
-  "reviewersWithStaleReviews": [],
-  "approvalFlags": 0,
-  "isChangesRequested": false
+  "reviews": [],
+  "ciResult": "pass"
 }

--- a/src/_tests/fixtures/48236/derived.json
+++ b/src/_tests/fixtures/48236/derived.json
@@ -3,7 +3,6 @@
   "now": "2020-10-05T00:43:22.594Z",
   "pr_number": 48236,
   "author": "jablko",
-  "dangerLevel": "ScopedAndTested",
   "headCommitAbbrOid": "b4d71f6",
   "headCommitOid": "b4d71f672f0f204a514002348ebc2025d18866ca",
   "mergeIsRequested": true,
@@ -12,9 +11,7 @@
   "reopenedDate": "2020-09-27T19:03:37.000Z",
   "lastCommentDate": "2020-10-02T18:45:57.000Z",
   "maintainerBlessed": false,
-  "reviewLink": "https://github.com/DefinitelyTyped/DefinitelyTyped/pull/48236/files",
   "hasMergeConflict": false,
-  "authorIsOwner": false,
   "isFirstContribution": false,
   "popularityLevel": "Well-liked by everyone",
   "pkgInfo": [
@@ -38,11 +35,19 @@
       "popularityLevel": "Well-liked by everyone"
     }
   ],
-  "hasDismissedReview": false,
-  "ciResult": "pass",
-  "lastReviewDate": "2020-10-02T19:13:08.000Z",
-  "firstApprovalDate": "2020-09-30T00:07:50.000Z",
-  "reviewersWithStaleReviews": [],
-  "approvalFlags": 1,
-  "isChangesRequested": false
+  "reviews": [
+    {
+      "type": "approved",
+      "reviewer": "peterblazejewicz",
+      "date": "2020-10-02T19:13:08.000Z",
+      "isMaintainer": false
+    },
+    {
+      "type": "approved",
+      "reviewer": "amcasey",
+      "date": "2020-09-30T00:07:50.000Z",
+      "isMaintainer": false
+    }
+  ],
+  "ciResult": "pass"
 }

--- a/src/scripts/daily.ts
+++ b/src/scripts/daily.ts
@@ -46,6 +46,8 @@ const start = async function () {
 
   const deleteObject = async (id: string, shoulda?: string) => {
     if (shoulda) {
+        // don't automatically delete these, eg, PRs that were created
+        // during the scan would end up here.
         return console.log(`  Should delete "${id}" (${shoulda})`);
     }
     const mutation = createMutation(deleteProjectCard, { input: { cardId: id }});

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -51,6 +51,15 @@ export function forEachReverse<T, U>(arr: readonly T[] | null | undefined, actio
     return undefined;
 }
 
+export function earliestDate(...dates: (Date | undefined)[]) {
+    return dates.reduce((d1,d2) => d1 && d2 && d2.getTime() < d1.getTime() ? d2 : d1 || d2,
+                        undefined);
+}
+export function latestDate(...dates: (Date | undefined)[]) {
+    return dates.reduce((d1,d2) => d1 && d2 && d2.getTime() > d1.getTime() ? d2 : d1 || d2,
+                        undefined);
+}
+
 export function daysSince(date: Date, now: Date | string): number {
     return Math.floor(moment(now).diff(moment(date), "days"));
 }


### PR DESCRIPTION
* The code for a `dangerLevel` of `MultiplePackagesEdited` was broken:
  it used `noNulls` over a list of booleans, which means that
  `MultiplePackagesEdited` corresponded with just having multiple
  packages (not taking into account tests or criticals).  This changes
  the code to use just a simple count of packages for now.

  I tried to fix it, but that exposes a problem with `dangerLevel` in
  general: it is sometimes used as an indicator for a single package
  literally (eg, allow all owners to request a merge if it starts with
  "Scoped") and sometimes as a generic danger situation.  This is likely
  my fault since pretty much any use of it confused me (since it's
  defined as a hard-to-remember combination of different things).

  For the same reason, I think that it'd be best to try to remove it and
  use the information directly.  Some of the following changes are going
  in this direction.  I will revisit the issues around it when this is
  done (eg #206 / #155).

* Use an extended `editsInfra` field instead of `dangerLevel ===
  "Infrastructure"`.

* Working toward the above, move the `getDangerLevel` computation (and
  the `dangerLevel` field, and the `DangerLevel` type) to
  `ExtendedPrInfo` since there are no more uses of it in `pr-info`.  The
  next step is to split it into fields that express the relevant parts
  instead of a single level value.

* Move `authorIsOwner` from a `PrInfo` field to a computed
  `ExtendedPrInfo` one.  It's meaning is also changed: previously, it
  would be on if the author is an owner of *any* package, and now it's
  on if the author is an owner of *all* packages (if more than one).
  This currently affects only the corresponding label.  Two
  tests (45836, 45946) updated for this.

* Aggregate all review info into a single `getReviews` (much revised
  from `analyzeReviews`) that returns a `review: ReviewInfo[]`, holding
  all of the relevant information.  Remove all of the other fields, and
  add the ones that are needed into the `ExtendedPrInfo`.

  There are some minor diffeences --- for example, previously all stale
  reviews were kept, and now it's only one review kind per person so at
  most one stale review.  These differences only affect the derived
  information, but no test changes.

* Note that the computation of `approvalFlags` moved to `extendPrInfo`
  (in `compute-pr-actions`), where it can be changed to adapt it to
  address #178.