### PR TITLE
More refactoring work

### DIFF
--- a/PR-Trigger/index.js
+++ b/PR-Trigger/index.js
@@ -12,8 +12,6 @@ const prHandlers = new Map();
 
 /** @type {import("@azure/functions").AzureFunction} */
 const httpTrigger = async function (context, _req) {
-    context.log(process.version)
-
     /** @type {import("@azure/functions").HttpRequest} */
     const req = _req;
 
@@ -22,7 +20,7 @@ const httpTrigger = async function (context, _req) {
         throw new Error("Set either BOT_AUTH_TOKEN or AUTH_TOKEN to a valid auth token");
     }
 
-    context.log("HTTP trigger function received a request.");
+    context.log(`[${process.version}] HTTP trigger function received a request.`);
 
     const event = req.headers["x-github-event"];
 

--- a/src/_tests/fixtures/45946/mutations.json
+++ b/src/_tests/fixtures/45946/mutations.json
@@ -1,5 +1,16 @@
 [
   {
+    "query": "mutation($input: AddLabelsToLabelableInput!) { addLabelsToLabelable(input: $input) { clientMutationId } }",
+    "variables": {
+      "input": {
+        "labelIds": [
+          "MDU6TGFiZWwyMTU0ODE2NTQ5"
+        ],
+        "labelableId": "MDExOlB1bGxSZXF1ZXN0NDQ2MDIxMjkw"
+      }
+    }
+  },
+  {
     "query": "mutation($input: RemoveLabelsFromLabelableInput!) { removeLabelsFromLabelable(input: $input) { clientMutationId } }",
     "variables": {
       "input": {

--- a/src/_tests/fixtures/45946/result.json
+++ b/src/_tests/fixtures/45946/result.json
@@ -21,7 +21,7 @@
     "Too Many Owners": false,
     "Merge:Auto": false,
     "Untested Change": false,
-    "Config Edit": false,
+    "Config Edit": true,
     "Abandoned": false
   },
   "responseComments": [


### PR DESCRIPTION
* Combine the `process.version` output into the HTTP message, to reduce
  log lines.

* Get rid of `dangerLevel` values:
  - `Infrastructure`: replaced earlier by `editsInfra`
  - `MultiplePackagesEdited`: replaced by `hasMultiplePackages`
  - `ScopedAndConfiguration`: replaced by `editsConfig`
    (This leads to a minor test change, showing the `Config Edit` label
    together with `Edits Infrastructure`; the previous single
    `dangerLevel` value meant that it could not show both.)
  - `ScopedAndTested`: replaced by `hasTests`, and `requireMaintainer`
    that replaces `!== "ScopedAndTested"`
  - `ScopedAndUntested`: all actual uses replaced by `!hasTests`

* Split `getApproval` into `getApproverKind` + `getApproval`.