### PR TITLE
Get monthly download count for the month up to the `lastPushDate`

### DIFF
--- a/src/_tests/fixturedActions.test.ts
+++ b/src/_tests/fixturedActions.test.ts
@@ -37,7 +37,7 @@ async function testFixture(dir: string) {
   const derived = await deriveStateForPR(
     response,
     (expr: string) => Promise.resolve(files[expr] as string),
-    (name: string) => name in downloads ? downloads[name] : 0,
+    (name: string, _until?: Date) => name in downloads ? downloads[name] : 0,
     () => new Date(readJSON(derivedPath).now)
   );
 

--- a/src/commands/create-fixture.ts
+++ b/src/commands/create-fixture.ts
@@ -70,8 +70,8 @@ export default async function main(directory: string, overwriteInfo: boolean) {
     writeFileSync(downloadsJSONPath, "{}"); // one-time initialization of an empty storage
     return getDownloadsAndWriteToFile;
   }
-  async function getDownloadsAndWriteToFile(packageName: string) {
-    downloadsFetched[packageName] = await getMonthlyDownloadCount(packageName);
+  async function getDownloadsAndWriteToFile(packageName: string, until?: Date) {
+      downloadsFetched[packageName] = await getMonthlyDownloadCount(packageName, until);
     writeFileSync(downloadsJSONPath, JSON.stringify(downloadsFetched, null, "  "));
     return downloadsFetched[packageName];
   }

--- a/src/pr-info.ts
+++ b/src/pr-info.ts
@@ -194,15 +194,7 @@ export async function deriveStateForPR(
     const headCommit = getHeadCommit(prInfo);
     if (headCommit == null) return botError(prInfo.number, "No head commit found");
 
-    const pkgInfoEtc = await getPackageInfosEtc(
-        noNulls(prInfo.files?.nodes).map(f => f.path).sort(),
-        headCommit.oid, fetchFile, getDownloads);
-    if (pkgInfoEtc instanceof Error) return botError(prInfo.number, pkgInfoEtc.message);
-    const { pkgInfo, popularityLevel } = pkgInfoEtc;
-    if (!pkgInfo.some(p => p.name)) return botNoPackages(prInfo.number);
-
     const author = prInfo.author.login;
-
     const isFirstContribution = prInfo.authorAssociation === CommentAuthorAssociation.FIRST_TIME_CONTRIBUTOR;
 
     const createdDate = new Date(prInfo.createdAt);
@@ -210,6 +202,14 @@ export async function deriveStateForPR(
     const lastCommentDate = getLastCommentishActivityDate(prInfo.timelineItems, prInfo.reviews) || lastPushDate;
     const lastBlessing = getLastMaintainerBlessingDate(prInfo.timelineItems);
     const reopenedDate = getReopenedDate(prInfo.timelineItems);
+
+    const pkgInfoEtc = await getPackageInfosEtc(
+        noNulls(prInfo.files?.nodes).map(f => f.path).sort(),
+        headCommit.oid, fetchFile, async name => await getDownloads(name, lastPushDate));
+    if (pkgInfoEtc instanceof Error) return botError(prInfo.number, pkgInfoEtc.message);
+    const { pkgInfo, popularityLevel } = pkgInfoEtc;
+    if (!pkgInfo.some(p => p.name)) return botNoPackages(prInfo.number);
+
     const now = getNow().toISOString();
     const reviews = getReviews(prInfo, isOwner);
     const latestReview = latestDate(...reviews.map(r => r.date));

--- a/src/util/npm.ts
+++ b/src/util/npm.ts
@@ -1,7 +1,13 @@
 import { fetchText } from "./io";
 
-export async function getMonthlyDownloadCount(packageName: string): Promise<number> {
-    const url = `https://api.npmjs.org/downloads/point/last-month/@types/${packageName}`;
+const DAY = 1000 * 60 * 60 * 24;
+const toDateStr = (d: Date, days: number) =>
+    (new Date(d.getTime() - days * DAY)).toISOString().replace(/T.*$/, "");
+
+export async function getMonthlyDownloadCount(packageName: string, until?: Date): Promise<number> {
+    // use the month up to a week before the given date, in case it takes npm some time to update the numbers
+    const range = !until ? "last-month" : `${toDateStr(until, 37)}:${toDateStr(until, 7)}`;
+    const url = `https://api.npmjs.org/downloads/point/${range}/@types/${packageName}`;
     const result = JSON.parse(await fetchText(url)) as { downloads?: number };
     // For a package not on NPM, just return 0.
     return result.downloads === undefined ?  0 : result.downloads;


### PR DESCRIPTION
Actually, use the month up to a week before `lastPushDate`, in case it
takes npm some time to update the numbers.

This should make the download numbers stable, avoiding the wobble seen
in DefinitelyTyped/DefinitelyTyped#46778.

Fixes #209.