### PR TITLE
Require only owner approval to remove files

### DIFF
--- a/src/_tests/fixtures/38979/derived.json
+++ b/src/_tests/fixtures/38979/derived.json
@@ -298,13 +298,11 @@
         },
         {
           "path": "types/es-abstract/tsconfig.json",
-          "kind": "package-meta",
-          "suspect": "couldn't fetch contents"
+          "kind": "package-meta-ok"
         },
         {
           "path": "types/es-abstract/tslint.json",
-          "kind": "package-meta",
-          "suspect": "couldn't fetch contents"
+          "kind": "package-meta-ok"
         }
       ],
       "owners": [

--- a/src/_tests/fixtures/38979/mutations.json
+++ b/src/_tests/fixtures/38979/mutations.json
@@ -16,7 +16,8 @@
     "variables": {
       "input": {
         "labelIds": [
-          "MDU6TGFiZWw2NDY3ODg4ODg="
+          "MDU6TGFiZWw2NDY3ODg4ODg=",
+          "MDU6TGFiZWwyMTU0ODE2NTQ5"
         ],
         "labelableId": "MDExOlB1bGxSZXF1ZXN0MzI1ODk5Njc0"
       }
@@ -36,7 +37,7 @@
     "variables": {
       "input": {
         "id": "MDEyOklzc3VlQ29tbWVudDYyNzA5NzAxMg==",
-        "body": "@ExE-Boss Thank you for submitting this PR!\n\n***This is a live comment which I will keep updated.***\n\n## 1 package in this PR\n\n* `es-abstract` [on npm](https://www.npmjs.com/package/es-abstract), [on unpkg](https://unpkg.com/browse/es-abstract@latest/)\n  - Config files to check:\n    - [`es-abstract/tsconfig.json`](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/38979/files/222334139e52fc16369464cfb5dc95c82f71192f#diff-abcd3ac52c6c4c77c7fa2a0e5bc09313ca1cbfd335f929838b0a4e3a607774cc): couldn't fetch contents\n    - [`es-abstract/tslint.json`](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/38979/files/222334139e52fc16369464cfb5dc95c82f71192f#diff-1eda518cd7bfbcd5fa96a7f844b631954cbc9db9ff168fc3731abb874369a4f6): couldn't fetch contents\n\n## Code Reviews\n\nBecause this is a widely-used package, a DT maintainer will need to review it before it can be merged.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ A DT maintainer needs to approve changes which affect module config files\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n## Inactive\n\nThis PR has been inactive for 129 days — it is *still* unreviewed!\n\n----------------------\n... diagnostics scrubbed ...\n<!--typescript_bot_welcome-->"
+        "body": "@ExE-Boss Thank you for submitting this PR!\n\n***This is a live comment which I will keep updated.***\n\n## 1 package in this PR\n\n* `es-abstract` [on npm](https://www.npmjs.com/package/es-abstract), [on unpkg](https://unpkg.com/browse/es-abstract@latest/)\n\n## Code Reviews\n\nBecause this is a widely-used package, a DT maintainer will need to review it before it can be merged.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ Most recent commit is approved by a DT maintainer\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n## Inactive\n\nThis PR has been inactive for 129 days — it is *still* unreviewed!\n\n----------------------\n... diagnostics scrubbed ...\n<!--typescript_bot_welcome-->"
       }
     }
   },

--- a/src/_tests/fixtures/38979/result.json
+++ b/src/_tests/fixtures/38979/result.json
@@ -4,13 +4,12 @@
   "labels": [
     "Critical package",
     "Other Approved",
-    "Check Config",
     "Unreviewed"
   ],
   "responseComments": [
     {
       "tag": "welcome",
-      "status": "@ExE-Boss Thank you for submitting this PR!\n\n***This is a live comment which I will keep updated.***\n\n## 1 package in this PR\n\n* `es-abstract` [on npm](https://www.npmjs.com/package/es-abstract), [on unpkg](https://unpkg.com/browse/es-abstract@latest/)\n  - Config files to check:\n    - [`es-abstract/tsconfig.json`](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/38979/files/222334139e52fc16369464cfb5dc95c82f71192f#diff-abcd3ac52c6c4c77c7fa2a0e5bc09313ca1cbfd335f929838b0a4e3a607774cc): couldn't fetch contents\n    - [`es-abstract/tslint.json`](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/38979/files/222334139e52fc16369464cfb5dc95c82f71192f#diff-1eda518cd7bfbcd5fa96a7f844b631954cbc9db9ff168fc3731abb874369a4f6): couldn't fetch contents\n\n## Code Reviews\n\nBecause this is a widely-used package, a DT maintainer will need to review it before it can be merged.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ A DT maintainer needs to approve changes which affect module config files\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n## Inactive\n\nThis PR has been inactive for 129 days — it is *still* unreviewed!\n\n----------------------\n... diagnostics scrubbed ..."
+      "status": "@ExE-Boss Thank you for submitting this PR!\n\n***This is a live comment which I will keep updated.***\n\n## 1 package in this PR\n\n* `es-abstract` [on npm](https://www.npmjs.com/package/es-abstract), [on unpkg](https://unpkg.com/browse/es-abstract@latest/)\n\n## Code Reviews\n\nBecause this is a widely-used package, a DT maintainer will need to review it before it can be merged.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ Most recent commit is approved by a DT maintainer\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n## Inactive\n\nThis PR has been inactive for 129 days — it is *still* unreviewed!\n\n----------------------\n... diagnostics scrubbed ..."
     },
     {
       "tag": "pinging-reviewers",

--- a/src/_tests/fixtures/43151/derived.json
+++ b/src/_tests/fixtures/43151/derived.json
@@ -26,13 +26,11 @@
         },
         {
           "path": "types/gaze/tsconfig.json",
-          "kind": "package-meta",
-          "suspect": "couldn't fetch contents"
+          "kind": "package-meta-ok"
         },
         {
           "path": "types/gaze/tslint.json",
-          "kind": "package-meta",
-          "suspect": "couldn't fetch contents"
+          "kind": "package-meta-ok"
         }
       ],
       "owners": [],

--- a/src/_tests/fixtures/43151/mutations.json
+++ b/src/_tests/fixtures/43151/mutations.json
@@ -1,16 +1,5 @@
 [
   {
-    "query": "mutation($input: AddLabelsToLabelableInput!) { addLabelsToLabelable(input: $input) { clientMutationId } }",
-    "variables": {
-      "input": {
-        "labelIds": [
-          "MDU6TGFiZWwyMTU0ODE2NTQ5"
-        ],
-        "labelableId": "MDExOlB1bGxSZXF1ZXN0Mzg4Njk0NDU5"
-      }
-    }
-  },
-  {
     "query": "mutation($input: RemoveLabelsFromLabelableInput!) { removeLabelsFromLabelable(input: $input) { clientMutationId } }",
     "variables": {
       "input": {
@@ -35,7 +24,7 @@
     "variables": {
       "input": {
         "subjectId": "MDExOlB1bGxSZXF1ZXN0Mzg4Njk0NDU5",
-        "body": "@adamzerella Thank you for submitting this PR!\n\n***This is a live comment which I will keep updated.***\n\n## 1 package in this PR\n\n* `gaze` (*new!*) [on npm](https://www.npmjs.com/package/gaze), [on unpkg](https://unpkg.com/browse/gaze@latest/)\n  - 1 added owner: ✎@adamzerella\n  - Config files to check:\n    - [`gaze/tsconfig.json`](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/43151/files/bb6d3150b485cd203d265e06ca910262256e523e#diff-75a1852febb3e488c3c078da451a82e5a8609bd59ef44ddd0656bbb96150c1a0): couldn't fetch contents\n    - [`gaze/tslint.json`](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/43151/files/bb6d3150b485cd203d265e06ca910262256e523e#diff-a0512397f95f6b7994f9713c8ceb6144061e7cf0d81618a2a9a90cceda075f80): couldn't fetch contents\n\n## Code Reviews\n\nThis PR adds a new definition, so it needs to be reviewed by a DT maintainer before it can be merged.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ Only a DT maintainer can approve changes when there are new packages added\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n----------------------\n... diagnostics scrubbed ...\n<!--typescript_bot_welcome-->"
+        "body": "@adamzerella Thank you for submitting this PR!\n\n***This is a live comment which I will keep updated.***\n\n## 1 package in this PR\n\n* `gaze` (*new!*) [on npm](https://www.npmjs.com/package/gaze), [on unpkg](https://unpkg.com/browse/gaze@latest/)\n  - 1 added owner: ✎@adamzerella\n\n## Code Reviews\n\nThis PR adds a new definition, so it needs to be reviewed by a DT maintainer before it can be merged.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ Only a DT maintainer can approve changes when there are new packages added\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n----------------------\n... diagnostics scrubbed ...\n<!--typescript_bot_welcome-->"
       }
     }
   },

--- a/src/_tests/fixtures/43151/result.json
+++ b/src/_tests/fixtures/43151/result.json
@@ -2,13 +2,12 @@
   "pr_number": 43151,
   "targetColumn": "Needs Maintainer Action",
   "labels": [
-    "New Definition",
-    "Check Config"
+    "New Definition"
   ],
   "responseComments": [
     {
       "tag": "welcome",
-      "status": "@adamzerella Thank you for submitting this PR!\n\n***This is a live comment which I will keep updated.***\n\n## 1 package in this PR\n\n* `gaze` (*new!*) [on npm](https://www.npmjs.com/package/gaze), [on unpkg](https://unpkg.com/browse/gaze@latest/)\n  - 1 added owner: ✎@adamzerella\n  - Config files to check:\n    - [`gaze/tsconfig.json`](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/43151/files/bb6d3150b485cd203d265e06ca910262256e523e#diff-75a1852febb3e488c3c078da451a82e5a8609bd59ef44ddd0656bbb96150c1a0): couldn't fetch contents\n    - [`gaze/tslint.json`](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/43151/files/bb6d3150b485cd203d265e06ca910262256e523e#diff-a0512397f95f6b7994f9713c8ceb6144061e7cf0d81618a2a9a90cceda075f80): couldn't fetch contents\n\n## Code Reviews\n\nThis PR adds a new definition, so it needs to be reviewed by a DT maintainer before it can be merged.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ Only a DT maintainer can approve changes when there are new packages added\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n----------------------\n... diagnostics scrubbed ..."
+      "status": "@adamzerella Thank you for submitting this PR!\n\n***This is a live comment which I will keep updated.***\n\n## 1 package in this PR\n\n* `gaze` (*new!*) [on npm](https://www.npmjs.com/package/gaze), [on unpkg](https://unpkg.com/browse/gaze@latest/)\n  - 1 added owner: ✎@adamzerella\n\n## Code Reviews\n\nThis PR adds a new definition, so it needs to be reviewed by a DT maintainer before it can be merged.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ Only a DT maintainer can approve changes when there are new packages added\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n----------------------\n... diagnostics scrubbed ..."
     },
     {
       "tag": "pinging-reviewers-others",

--- a/src/_tests/fixtures/43314/derived.json
+++ b/src/_tests/fixtures/43314/derived.json
@@ -26,13 +26,11 @@
         },
         {
           "path": "types/carbon__icon-helpers/tsconfig.json",
-          "kind": "package-meta",
-          "suspect": "couldn't fetch contents"
+          "kind": "package-meta-ok"
         },
         {
           "path": "types/carbon__icon-helpers/tslint.json",
-          "kind": "package-meta",
-          "suspect": "couldn't fetch contents"
+          "kind": "package-meta-ok"
         }
       ],
       "owners": [],

--- a/src/_tests/fixtures/43314/mutations.json
+++ b/src/_tests/fixtures/43314/mutations.json
@@ -1,16 +1,5 @@
 [
   {
-    "query": "mutation($input: AddLabelsToLabelableInput!) { addLabelsToLabelable(input: $input) { clientMutationId } }",
-    "variables": {
-      "input": {
-        "labelIds": [
-          "MDU6TGFiZWwyMTU0ODE2NTQ5"
-        ],
-        "labelableId": "MDExOlB1bGxSZXF1ZXN0MzkyMDM2NjA4"
-      }
-    }
-  },
-  {
     "query": "mutation($input: MoveProjectCardInput!) { moveProjectCard(input: $input) { clientMutationId } }",
     "variables": {
       "input": {
@@ -24,7 +13,7 @@
     "variables": {
       "input": {
         "id": "MDEyOklzc3VlQ29tbWVudDYwMjIzODI3OQ==",
-        "body": "@metonym Thank you for submitting this PR!\n\n***This is a live comment which I will keep updated.***\n\n## 1 package in this PR\n\n* `carbon__icon-helpers` (*new!*) [on npm](https://www.npmjs.com/package/@carbon/icon-helpers), [on unpkg](https://unpkg.com/browse/@carbon/icon-helpers@latest/)\n  - 1 added owner: ✎@metonym\n  - Config files to check:\n    - [`carbon__icon-helpers/tsconfig.json`](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/43314/files/432f23fe1b87b12fe58bb1a8958f77ee3242741e#diff-b85b46e7b1a183dc24eae51fb57ec188fd779236bfc818bea60bf6ac573d7be5): couldn't fetch contents\n    - [`carbon__icon-helpers/tslint.json`](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/43314/files/432f23fe1b87b12fe58bb1a8958f77ee3242741e#diff-9f7808ddcec9553672dd10ae54a269326e3346253364745d3f187e0b2b95b27b): couldn't fetch contents\n\n## Code Reviews\n\nThis PR adds a new definition, so it needs to be reviewed by a DT maintainer before it can be merged.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ Only a DT maintainer can approve changes when there are new packages added\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n----------------------\n... diagnostics scrubbed ...\n<!--typescript_bot_welcome-->"
+        "body": "@metonym Thank you for submitting this PR!\n\n***This is a live comment which I will keep updated.***\n\n## 1 package in this PR\n\n* `carbon__icon-helpers` (*new!*) [on npm](https://www.npmjs.com/package/@carbon/icon-helpers), [on unpkg](https://unpkg.com/browse/@carbon/icon-helpers@latest/)\n  - 1 added owner: ✎@metonym\n\n## Code Reviews\n\nThis PR adds a new definition, so it needs to be reviewed by a DT maintainer before it can be merged.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ Only a DT maintainer can approve changes when there are new packages added\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n----------------------\n... diagnostics scrubbed ...\n<!--typescript_bot_welcome-->"
       }
     }
   },

--- a/src/_tests/fixtures/43314/result.json
+++ b/src/_tests/fixtures/43314/result.json
@@ -2,13 +2,12 @@
   "pr_number": 43314,
   "targetColumn": "Needs Maintainer Action",
   "labels": [
-    "New Definition",
-    "Check Config"
+    "New Definition"
   ],
   "responseComments": [
     {
       "tag": "welcome",
-      "status": "@metonym Thank you for submitting this PR!\n\n***This is a live comment which I will keep updated.***\n\n## 1 package in this PR\n\n* `carbon__icon-helpers` (*new!*) [on npm](https://www.npmjs.com/package/@carbon/icon-helpers), [on unpkg](https://unpkg.com/browse/@carbon/icon-helpers@latest/)\n  - 1 added owner: ✎@metonym\n  - Config files to check:\n    - [`carbon__icon-helpers/tsconfig.json`](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/43314/files/432f23fe1b87b12fe58bb1a8958f77ee3242741e#diff-b85b46e7b1a183dc24eae51fb57ec188fd779236bfc818bea60bf6ac573d7be5): couldn't fetch contents\n    - [`carbon__icon-helpers/tslint.json`](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/43314/files/432f23fe1b87b12fe58bb1a8958f77ee3242741e#diff-9f7808ddcec9553672dd10ae54a269326e3346253364745d3f187e0b2b95b27b): couldn't fetch contents\n\n## Code Reviews\n\nThis PR adds a new definition, so it needs to be reviewed by a DT maintainer before it can be merged.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ Only a DT maintainer can approve changes when there are new packages added\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n----------------------\n... diagnostics scrubbed ..."
+      "status": "@metonym Thank you for submitting this PR!\n\n***This is a live comment which I will keep updated.***\n\n## 1 package in this PR\n\n* `carbon__icon-helpers` (*new!*) [on npm](https://www.npmjs.com/package/@carbon/icon-helpers), [on unpkg](https://unpkg.com/browse/@carbon/icon-helpers@latest/)\n  - 1 added owner: ✎@metonym\n\n## Code Reviews\n\nThis PR adds a new definition, so it needs to be reviewed by a DT maintainer before it can be merged.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ Only a DT maintainer can approve changes when there are new packages added\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n----------------------\n... diagnostics scrubbed ..."
     },
     {
       "tag": "pinging-reviewers-others",

--- a/src/_tests/fixtures/43695-duplicate-comment/derived.json
+++ b/src/_tests/fixtures/43695-duplicate-comment/derived.json
@@ -26,13 +26,11 @@
         },
         {
           "path": "types/accedo__accedo-one/tsconfig.json",
-          "kind": "package-meta",
-          "suspect": "couldn't fetch contents"
+          "kind": "package-meta-ok"
         },
         {
           "path": "types/accedo__accedo-one/tslint.json",
-          "kind": "package-meta",
-          "suspect": "couldn't fetch contents"
+          "kind": "package-meta-ok"
         }
       ],
       "owners": [],

--- a/src/_tests/fixtures/43695-duplicate-comment/mutations.json
+++ b/src/_tests/fixtures/43695-duplicate-comment/mutations.json
@@ -15,7 +15,8 @@
     "variables": {
       "input": {
         "labelIds": [
-          "MDU6TGFiZWwyMTU0ODU3ODAw"
+          "MDU6TGFiZWwyMTU0ODU3ODAw",
+          "MDU6TGFiZWwyMTU0ODE2NTQ5"
         ],
         "labelableId": "MDExOlB1bGxSZXF1ZXN0NDAwMTAwMTk2"
       }
@@ -35,7 +36,7 @@
     "variables": {
       "input": {
         "id": "MDEyOklzc3VlQ29tbWVudDYxMDIzNDI3MA==",
-        "body": "@alexandercerutti Thank you for submitting this PR!\n\n***This is a live comment which I will keep updated.***\n\n## 1 package in this PR\n\n* `accedo__accedo-one` (*new!*) [on npm](https://www.npmjs.com/package/@accedo/accedo-one), [on unpkg](https://unpkg.com/browse/@accedo/accedo-one@latest/)\n  - 1 added owner: ✎@alexandercerutti\n  - Config files to check:\n    - [`accedo__accedo-one/tsconfig.json`](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/43695/files/3e836178b736e5512361ffda46e84a5c668d7a90#diff-9f409d2973c0c7c01b0c410e0e89f3ca15cfae8ffaa27caf2170925ae36d298b): couldn't fetch contents\n    - [`accedo__accedo-one/tslint.json`](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/43695/files/3e836178b736e5512361ffda46e84a5c668d7a90#diff-4413d8770def1e851a87a519d27ff32bc17eee42f2c9a26c9a0d59dc710e09ba): couldn't fetch contents\n\n## Code Reviews\n\nThis PR adds a new definition, so it needs to be reviewed by a DT maintainer before it can be merged.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ Only a DT maintainer can approve changes when there are new packages added\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n## Inactive\n\nThis PR has been inactive for 24 days — it is *still* unreviewed!\n\n----------------------\n... diagnostics scrubbed ...\n<!--typescript_bot_welcome-->"
+        "body": "@alexandercerutti Thank you for submitting this PR!\n\n***This is a live comment which I will keep updated.***\n\n## 1 package in this PR\n\n* `accedo__accedo-one` (*new!*) [on npm](https://www.npmjs.com/package/@accedo/accedo-one), [on unpkg](https://unpkg.com/browse/@accedo/accedo-one@latest/)\n  - 1 added owner: ✎@alexandercerutti\n\n## Code Reviews\n\nThis PR adds a new definition, so it needs to be reviewed by a DT maintainer before it can be merged.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ Only a DT maintainer can approve changes when there are new packages added\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n## Inactive\n\nThis PR has been inactive for 24 days — it is *still* unreviewed!\n\n----------------------\n... diagnostics scrubbed ...\n<!--typescript_bot_welcome-->"
       }
     }
   },

--- a/src/_tests/fixtures/43695-duplicate-comment/result.json
+++ b/src/_tests/fixtures/43695-duplicate-comment/result.json
@@ -3,13 +3,12 @@
   "targetColumn": "Needs Maintainer Action",
   "labels": [
     "New Definition",
-    "Check Config",
     "Unreviewed"
   ],
   "responseComments": [
     {
       "tag": "welcome",
-      "status": "@alexandercerutti Thank you for submitting this PR!\n\n***This is a live comment which I will keep updated.***\n\n## 1 package in this PR\n\n* `accedo__accedo-one` (*new!*) [on npm](https://www.npmjs.com/package/@accedo/accedo-one), [on unpkg](https://unpkg.com/browse/@accedo/accedo-one@latest/)\n  - 1 added owner: ✎@alexandercerutti\n  - Config files to check:\n    - [`accedo__accedo-one/tsconfig.json`](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/43695/files/3e836178b736e5512361ffda46e84a5c668d7a90#diff-9f409d2973c0c7c01b0c410e0e89f3ca15cfae8ffaa27caf2170925ae36d298b): couldn't fetch contents\n    - [`accedo__accedo-one/tslint.json`](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/43695/files/3e836178b736e5512361ffda46e84a5c668d7a90#diff-4413d8770def1e851a87a519d27ff32bc17eee42f2c9a26c9a0d59dc710e09ba): couldn't fetch contents\n\n## Code Reviews\n\nThis PR adds a new definition, so it needs to be reviewed by a DT maintainer before it can be merged.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ Only a DT maintainer can approve changes when there are new packages added\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n## Inactive\n\nThis PR has been inactive for 24 days — it is *still* unreviewed!\n\n----------------------\n... diagnostics scrubbed ..."
+      "status": "@alexandercerutti Thank you for submitting this PR!\n\n***This is a live comment which I will keep updated.***\n\n## 1 package in this PR\n\n* `accedo__accedo-one` (*new!*) [on npm](https://www.npmjs.com/package/@accedo/accedo-one), [on unpkg](https://unpkg.com/browse/@accedo/accedo-one@latest/)\n  - 1 added owner: ✎@alexandercerutti\n\n## Code Reviews\n\nThis PR adds a new definition, so it needs to be reviewed by a DT maintainer before it can be merged.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ Only a DT maintainer can approve changes when there are new packages added\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n## Inactive\n\nThis PR has been inactive for 24 days — it is *still* unreviewed!\n\n----------------------\n... diagnostics scrubbed ..."
     },
     {
       "tag": "pinging-reviewers-others",

--- a/src/_tests/fixtures/43695-post-review/derived.json
+++ b/src/_tests/fixtures/43695-post-review/derived.json
@@ -26,13 +26,11 @@
         },
         {
           "path": "types/accedo__accedo-one/tsconfig.json",
-          "kind": "package-meta",
-          "suspect": "couldn't fetch contents"
+          "kind": "package-meta-ok"
         },
         {
           "path": "types/accedo__accedo-one/tslint.json",
-          "kind": "package-meta",
-          "suspect": "couldn't fetch contents"
+          "kind": "package-meta-ok"
         }
       ],
       "owners": [],

--- a/src/_tests/fixtures/43695-post-review/mutations.json
+++ b/src/_tests/fixtures/43695-post-review/mutations.json
@@ -1,16 +1,5 @@
 [
   {
-    "query": "mutation($input: AddLabelsToLabelableInput!) { addLabelsToLabelable(input: $input) { clientMutationId } }",
-    "variables": {
-      "input": {
-        "labelIds": [
-          "MDU6TGFiZWwyMTU0ODE2NTQ5"
-        ],
-        "labelableId": "MDExOlB1bGxSZXF1ZXN0NDAwMTAwMTk2"
-      }
-    }
-  },
-  {
     "query": "mutation($input: MoveProjectCardInput!) { moveProjectCard(input: $input) { clientMutationId } }",
     "variables": {
       "input": {
@@ -24,7 +13,7 @@
     "variables": {
       "input": {
         "id": "MDEyOklzc3VlQ29tbWVudDYxMDIzNDI3MA==",
-        "body": "@alexandercerutti Thank you for submitting this PR!\n\n***This is a live comment which I will keep updated.***\n\n## 1 package in this PR\n\n* `accedo__accedo-one` (*new!*) [on npm](https://www.npmjs.com/package/@accedo/accedo-one), [on unpkg](https://unpkg.com/browse/@accedo/accedo-one@latest/)\n  - 1 added owner: ✎@alexandercerutti\n  - Config files to check:\n    - [`accedo__accedo-one/tsconfig.json`](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/43695/files/90c94f91120c026f5f8bcc586426e8590b7b4048#diff-9f409d2973c0c7c01b0c410e0e89f3ca15cfae8ffaa27caf2170925ae36d298b): couldn't fetch contents\n    - [`accedo__accedo-one/tslint.json`](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/43695/files/90c94f91120c026f5f8bcc586426e8590b7b4048#diff-4413d8770def1e851a87a519d27ff32bc17eee42f2c9a26c9a0d59dc710e09ba): couldn't fetch contents\n\n## Code Reviews\n\nThis PR adds a new definition, so it needs to be reviewed by a DT maintainer before it can be merged.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ Only a DT maintainer can approve changes when there are new packages added\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n----------------------\n... diagnostics scrubbed ...\n<!--typescript_bot_welcome-->"
+        "body": "@alexandercerutti Thank you for submitting this PR!\n\n***This is a live comment which I will keep updated.***\n\n## 1 package in this PR\n\n* `accedo__accedo-one` (*new!*) [on npm](https://www.npmjs.com/package/@accedo/accedo-one), [on unpkg](https://unpkg.com/browse/@accedo/accedo-one@latest/)\n  - 1 added owner: ✎@alexandercerutti\n\n## Code Reviews\n\nThis PR adds a new definition, so it needs to be reviewed by a DT maintainer before it can be merged.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ Only a DT maintainer can approve changes when there are new packages added\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n----------------------\n... diagnostics scrubbed ...\n<!--typescript_bot_welcome-->"
       }
     }
   },

--- a/src/_tests/fixtures/43695-post-review/result.json
+++ b/src/_tests/fixtures/43695-post-review/result.json
@@ -3,13 +3,12 @@
   "targetColumn": "Needs Author Action",
   "labels": [
     "Revision needed",
-    "New Definition",
-    "Check Config"
+    "New Definition"
   ],
   "responseComments": [
     {
       "tag": "welcome",
-      "status": "@alexandercerutti Thank you for submitting this PR!\n\n***This is a live comment which I will keep updated.***\n\n## 1 package in this PR\n\n* `accedo__accedo-one` (*new!*) [on npm](https://www.npmjs.com/package/@accedo/accedo-one), [on unpkg](https://unpkg.com/browse/@accedo/accedo-one@latest/)\n  - 1 added owner: ✎@alexandercerutti\n  - Config files to check:\n    - [`accedo__accedo-one/tsconfig.json`](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/43695/files/90c94f91120c026f5f8bcc586426e8590b7b4048#diff-9f409d2973c0c7c01b0c410e0e89f3ca15cfae8ffaa27caf2170925ae36d298b): couldn't fetch contents\n    - [`accedo__accedo-one/tslint.json`](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/43695/files/90c94f91120c026f5f8bcc586426e8590b7b4048#diff-4413d8770def1e851a87a519d27ff32bc17eee42f2c9a26c9a0d59dc710e09ba): couldn't fetch contents\n\n## Code Reviews\n\nThis PR adds a new definition, so it needs to be reviewed by a DT maintainer before it can be merged.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ Only a DT maintainer can approve changes when there are new packages added\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n----------------------\n... diagnostics scrubbed ..."
+      "status": "@alexandercerutti Thank you for submitting this PR!\n\n***This is a live comment which I will keep updated.***\n\n## 1 package in this PR\n\n* `accedo__accedo-one` (*new!*) [on npm](https://www.npmjs.com/package/@accedo/accedo-one), [on unpkg](https://unpkg.com/browse/@accedo/accedo-one@latest/)\n  - 1 added owner: ✎@alexandercerutti\n\n## Code Reviews\n\nThis PR adds a new definition, so it needs to be reviewed by a DT maintainer before it can be merged.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ Only a DT maintainer can approve changes when there are new packages added\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n----------------------\n... diagnostics scrubbed ..."
     },
     {
       "tag": "reviewer-complaint-90c94f9",

--- a/src/_tests/fixtures/43695/derived.json
+++ b/src/_tests/fixtures/43695/derived.json
@@ -26,13 +26,11 @@
         },
         {
           "path": "types/accedo__accedo-one/tsconfig.json",
-          "kind": "package-meta",
-          "suspect": "couldn't fetch contents"
+          "kind": "package-meta-ok"
         },
         {
           "path": "types/accedo__accedo-one/tslint.json",
-          "kind": "package-meta",
-          "suspect": "couldn't fetch contents"
+          "kind": "package-meta-ok"
         }
       ],
       "owners": [],

--- a/src/_tests/fixtures/43695/mutations.json
+++ b/src/_tests/fixtures/43695/mutations.json
@@ -1,16 +1,5 @@
 [
   {
-    "query": "mutation($input: AddLabelsToLabelableInput!) { addLabelsToLabelable(input: $input) { clientMutationId } }",
-    "variables": {
-      "input": {
-        "labelIds": [
-          "MDU6TGFiZWwyMTU0ODE2NTQ5"
-        ],
-        "labelableId": "MDExOlB1bGxSZXF1ZXN0NDAwMTAwMTk2"
-      }
-    }
-  },
-  {
     "query": "mutation($input: MoveProjectCardInput!) { moveProjectCard(input: $input) { clientMutationId } }",
     "variables": {
       "input": {
@@ -24,7 +13,7 @@
     "variables": {
       "input": {
         "id": "MDEyOklzc3VlQ29tbWVudDYxMDIzNDI3MA==",
-        "body": "@alexandercerutti Thank you for submitting this PR!\n\n***This is a live comment which I will keep updated.***\n\n## 1 package in this PR\n\n* `accedo__accedo-one` (*new!*) [on npm](https://www.npmjs.com/package/@accedo/accedo-one), [on unpkg](https://unpkg.com/browse/@accedo/accedo-one@latest/)\n  - 1 added owner: ✎@alexandercerutti\n  - Config files to check:\n    - [`accedo__accedo-one/tsconfig.json`](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/43695/files/a5285cda2722912a390770722a334e6d6e43d1ab#diff-9f409d2973c0c7c01b0c410e0e89f3ca15cfae8ffaa27caf2170925ae36d298b): couldn't fetch contents\n    - [`accedo__accedo-one/tslint.json`](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/43695/files/a5285cda2722912a390770722a334e6d6e43d1ab#diff-4413d8770def1e851a87a519d27ff32bc17eee42f2c9a26c9a0d59dc710e09ba): couldn't fetch contents\n\n## Code Reviews\n\nThis PR adds a new definition, so it needs to be reviewed by a DT maintainer before it can be merged.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ Only a DT maintainer can approve changes when there are new packages added\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n----------------------\n... diagnostics scrubbed ...\n<!--typescript_bot_welcome-->"
+        "body": "@alexandercerutti Thank you for submitting this PR!\n\n***This is a live comment which I will keep updated.***\n\n## 1 package in this PR\n\n* `accedo__accedo-one` (*new!*) [on npm](https://www.npmjs.com/package/@accedo/accedo-one), [on unpkg](https://unpkg.com/browse/@accedo/accedo-one@latest/)\n  - 1 added owner: ✎@alexandercerutti\n\n## Code Reviews\n\nThis PR adds a new definition, so it needs to be reviewed by a DT maintainer before it can be merged.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ Only a DT maintainer can approve changes when there are new packages added\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n----------------------\n... diagnostics scrubbed ...\n<!--typescript_bot_welcome-->"
       }
     }
   },

--- a/src/_tests/fixtures/43695/result.json
+++ b/src/_tests/fixtures/43695/result.json
@@ -3,13 +3,12 @@
   "targetColumn": "Needs Author Action",
   "labels": [
     "Revision needed",
-    "New Definition",
-    "Check Config"
+    "New Definition"
   ],
   "responseComments": [
     {
       "tag": "welcome",
-      "status": "@alexandercerutti Thank you for submitting this PR!\n\n***This is a live comment which I will keep updated.***\n\n## 1 package in this PR\n\n* `accedo__accedo-one` (*new!*) [on npm](https://www.npmjs.com/package/@accedo/accedo-one), [on unpkg](https://unpkg.com/browse/@accedo/accedo-one@latest/)\n  - 1 added owner: ✎@alexandercerutti\n  - Config files to check:\n    - [`accedo__accedo-one/tsconfig.json`](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/43695/files/a5285cda2722912a390770722a334e6d6e43d1ab#diff-9f409d2973c0c7c01b0c410e0e89f3ca15cfae8ffaa27caf2170925ae36d298b): couldn't fetch contents\n    - [`accedo__accedo-one/tslint.json`](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/43695/files/a5285cda2722912a390770722a334e6d6e43d1ab#diff-4413d8770def1e851a87a519d27ff32bc17eee42f2c9a26c9a0d59dc710e09ba): couldn't fetch contents\n\n## Code Reviews\n\nThis PR adds a new definition, so it needs to be reviewed by a DT maintainer before it can be merged.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ Only a DT maintainer can approve changes when there are new packages added\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n----------------------\n... diagnostics scrubbed ..."
+      "status": "@alexandercerutti Thank you for submitting this PR!\n\n***This is a live comment which I will keep updated.***\n\n## 1 package in this PR\n\n* `accedo__accedo-one` (*new!*) [on npm](https://www.npmjs.com/package/@accedo/accedo-one), [on unpkg](https://unpkg.com/browse/@accedo/accedo-one@latest/)\n  - 1 added owner: ✎@alexandercerutti\n\n## Code Reviews\n\nThis PR adds a new definition, so it needs to be reviewed by a DT maintainer before it can be merged.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ Only a DT maintainer can approve changes when there are new packages added\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n----------------------\n... diagnostics scrubbed ..."
     },
     {
       "tag": "reviewer-complaint-a5285cd",

--- a/src/_tests/fixtures/44299-with-files/derived.json
+++ b/src/_tests/fixtures/44299-with-files/derived.json
@@ -26,13 +26,11 @@
         },
         {
           "path": "types/hcaptcha__vue-hcaptcha/package.json",
-          "kind": "package-meta",
-          "suspect": "couldn't fetch contents"
+          "kind": "package-meta-ok"
         },
         {
           "path": "types/hcaptcha__vue-hcaptcha/tsconfig.json",
-          "kind": "package-meta",
-          "suspect": "couldn't fetch contents"
+          "kind": "package-meta-ok"
         },
         {
           "path": "types/hcaptcha__vue-hcaptcha/tslint.json",

--- a/src/_tests/fixtures/44299-with-files/mutations.json
+++ b/src/_tests/fixtures/44299-with-files/mutations.json
@@ -1,16 +1,5 @@
 [
   {
-    "query": "mutation($input: AddLabelsToLabelableInput!) { addLabelsToLabelable(input: $input) { clientMutationId } }",
-    "variables": {
-      "input": {
-        "labelIds": [
-          "MDU6TGFiZWwyMTU0ODE2NTQ5"
-        ],
-        "labelableId": "MDExOlB1bGxSZXF1ZXN0NDEwMjE2Nzgz"
-      }
-    }
-  },
-  {
     "query": "mutation($input: MoveProjectCardInput!) { moveProjectCard(input: $input) { clientMutationId } }",
     "variables": {
       "input": {
@@ -24,7 +13,7 @@
     "variables": {
       "input": {
         "id": "MDEyOklzc3VlQ29tbWVudDYyMDcwMjk5OQ==",
-        "body": "@geopic Thank you for submitting this PR! I see this is your first time submitting to DefinitelyTyped 👋 — I'm the local bot who will help you through the process of getting things through.\n\n***This is a live comment which I will keep updated.***\n\n## 1 package in this PR\n\n* `hcaptcha__vue-hcaptcha` (*new!*) [on npm](https://www.npmjs.com/package/@hcaptcha/vue-hcaptcha), [on unpkg](https://unpkg.com/browse/@hcaptcha/vue-hcaptcha@latest/)\n  - 1 added owner: ✎@geopic\n  - Config files to check:\n    - [`hcaptcha__vue-hcaptcha/package.json`](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44299/files/683fb3b1298223256be3a49823686f35bd94a730#diff-7f6b3c89357f5b55cbe423c5b8d87644a735796ed0ba5d4be803a615d304a83b): couldn't fetch contents\n    - [`hcaptcha__vue-hcaptcha/tsconfig.json`](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44299/files/683fb3b1298223256be3a49823686f35bd94a730#diff-6ded07af09e0936a1c143bb0fbfaca37e9df9668ecc22d402a833077e66abe54): couldn't fetch contents\n\n## Code Reviews\n\nThis PR adds a new definition, so it needs to be reviewed by a DT maintainer before it can be merged.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ Only a DT maintainer can approve changes when there are new packages added\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n----------------------\n... diagnostics scrubbed ...\n<!--typescript_bot_welcome-->"
+        "body": "@geopic Thank you for submitting this PR! I see this is your first time submitting to DefinitelyTyped 👋 — I'm the local bot who will help you through the process of getting things through.\n\n***This is a live comment which I will keep updated.***\n\n## 1 package in this PR\n\n* `hcaptcha__vue-hcaptcha` (*new!*) [on npm](https://www.npmjs.com/package/@hcaptcha/vue-hcaptcha), [on unpkg](https://unpkg.com/browse/@hcaptcha/vue-hcaptcha@latest/)\n  - 1 added owner: ✎@geopic\n\n## Code Reviews\n\nThis PR adds a new definition, so it needs to be reviewed by a DT maintainer before it can be merged.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ Only a DT maintainer can approve changes when there are new packages added\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n----------------------\n... diagnostics scrubbed ...\n<!--typescript_bot_welcome-->"
       }
     }
   },

--- a/src/_tests/fixtures/44299-with-files/result.json
+++ b/src/_tests/fixtures/44299-with-files/result.json
@@ -2,13 +2,12 @@
   "pr_number": 44299,
   "targetColumn": "Needs Maintainer Action",
   "labels": [
-    "New Definition",
-    "Check Config"
+    "New Definition"
   ],
   "responseComments": [
     {
       "tag": "welcome",
-      "status": "@geopic Thank you for submitting this PR! I see this is your first time submitting to DefinitelyTyped 👋 — I'm the local bot who will help you through the process of getting things through.\n\n***This is a live comment which I will keep updated.***\n\n## 1 package in this PR\n\n* `hcaptcha__vue-hcaptcha` (*new!*) [on npm](https://www.npmjs.com/package/@hcaptcha/vue-hcaptcha), [on unpkg](https://unpkg.com/browse/@hcaptcha/vue-hcaptcha@latest/)\n  - 1 added owner: ✎@geopic\n  - Config files to check:\n    - [`hcaptcha__vue-hcaptcha/package.json`](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44299/files/683fb3b1298223256be3a49823686f35bd94a730#diff-7f6b3c89357f5b55cbe423c5b8d87644a735796ed0ba5d4be803a615d304a83b): couldn't fetch contents\n    - [`hcaptcha__vue-hcaptcha/tsconfig.json`](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44299/files/683fb3b1298223256be3a49823686f35bd94a730#diff-6ded07af09e0936a1c143bb0fbfaca37e9df9668ecc22d402a833077e66abe54): couldn't fetch contents\n\n## Code Reviews\n\nThis PR adds a new definition, so it needs to be reviewed by a DT maintainer before it can be merged.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ Only a DT maintainer can approve changes when there are new packages added\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n----------------------\n... diagnostics scrubbed ..."
+      "status": "@geopic Thank you for submitting this PR! I see this is your first time submitting to DefinitelyTyped 👋 — I'm the local bot who will help you through the process of getting things through.\n\n***This is a live comment which I will keep updated.***\n\n## 1 package in this PR\n\n* `hcaptcha__vue-hcaptcha` (*new!*) [on npm](https://www.npmjs.com/package/@hcaptcha/vue-hcaptcha), [on unpkg](https://unpkg.com/browse/@hcaptcha/vue-hcaptcha@latest/)\n  - 1 added owner: ✎@geopic\n\n## Code Reviews\n\nThis PR adds a new definition, so it needs to be reviewed by a DT maintainer before it can be merged.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ Only a DT maintainer can approve changes when there are new packages added\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n----------------------\n... diagnostics scrubbed ..."
     },
     {
       "tag": "pinging-reviewers-others",

--- a/src/_tests/fixtures/44299/derived.json
+++ b/src/_tests/fixtures/44299/derived.json
@@ -26,18 +26,15 @@
         },
         {
           "path": "types/hcaptcha__vue-hcaptcha/package.json",
-          "kind": "package-meta",
-          "suspect": "couldn't fetch contents"
+          "kind": "package-meta-ok"
         },
         {
           "path": "types/hcaptcha__vue-hcaptcha/tsconfig.json",
-          "kind": "package-meta",
-          "suspect": "couldn't fetch contents"
+          "kind": "package-meta-ok"
         },
         {
           "path": "types/hcaptcha__vue-hcaptcha/tslint.json",
-          "kind": "package-meta",
-          "suspect": "couldn't fetch contents"
+          "kind": "package-meta-ok"
         }
       ],
       "owners": [],

--- a/src/_tests/fixtures/44299/mutations.json
+++ b/src/_tests/fixtures/44299/mutations.json
@@ -1,16 +1,5 @@
 [
   {
-    "query": "mutation($input: AddLabelsToLabelableInput!) { addLabelsToLabelable(input: $input) { clientMutationId } }",
-    "variables": {
-      "input": {
-        "labelIds": [
-          "MDU6TGFiZWwyMTU0ODE2NTQ5"
-        ],
-        "labelableId": "MDExOlB1bGxSZXF1ZXN0NDEwMjE2Nzgz"
-      }
-    }
-  },
-  {
     "query": "mutation($input: MoveProjectCardInput!) { moveProjectCard(input: $input) { clientMutationId } }",
     "variables": {
       "input": {
@@ -24,7 +13,7 @@
     "variables": {
       "input": {
         "id": "MDEyOklzc3VlQ29tbWVudDYyMDcwMjk5OQ==",
-        "body": "@geopic Thank you for submitting this PR! I see this is your first time submitting to DefinitelyTyped 👋 — I'm the local bot who will help you through the process of getting things through.\n\n***This is a live comment which I will keep updated.***\n\n## 1 package in this PR\n\n* `hcaptcha__vue-hcaptcha` (*new!*) [on npm](https://www.npmjs.com/package/@hcaptcha/vue-hcaptcha), [on unpkg](https://unpkg.com/browse/@hcaptcha/vue-hcaptcha@latest/)\n  - 1 added owner: ✎@geopic\n  - Config files to check:\n    - [`hcaptcha__vue-hcaptcha/package.json`](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44299/files/683fb3b1298223256be3a49823686f35bd94a730#diff-7f6b3c89357f5b55cbe423c5b8d87644a735796ed0ba5d4be803a615d304a83b): couldn't fetch contents\n    - [`hcaptcha__vue-hcaptcha/tsconfig.json`](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44299/files/683fb3b1298223256be3a49823686f35bd94a730#diff-6ded07af09e0936a1c143bb0fbfaca37e9df9668ecc22d402a833077e66abe54): couldn't fetch contents\n    - [`hcaptcha__vue-hcaptcha/tslint.json`](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44299/files/683fb3b1298223256be3a49823686f35bd94a730#diff-c441c94ec5219d4722929ccb738301643b5eef17a151184505f387fdbec13408): couldn't fetch contents\n\n## Code Reviews\n\nThis PR adds a new definition, so it needs to be reviewed by a DT maintainer before it can be merged.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ Only a DT maintainer can approve changes when there are new packages added\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n----------------------\n... diagnostics scrubbed ...\n<!--typescript_bot_welcome-->"
+        "body": "@geopic Thank you for submitting this PR! I see this is your first time submitting to DefinitelyTyped 👋 — I'm the local bot who will help you through the process of getting things through.\n\n***This is a live comment which I will keep updated.***\n\n## 1 package in this PR\n\n* `hcaptcha__vue-hcaptcha` (*new!*) [on npm](https://www.npmjs.com/package/@hcaptcha/vue-hcaptcha), [on unpkg](https://unpkg.com/browse/@hcaptcha/vue-hcaptcha@latest/)\n  - 1 added owner: ✎@geopic\n\n## Code Reviews\n\nThis PR adds a new definition, so it needs to be reviewed by a DT maintainer before it can be merged.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ Only a DT maintainer can approve changes when there are new packages added\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n----------------------\n... diagnostics scrubbed ...\n<!--typescript_bot_welcome-->"
       }
     }
   },

--- a/src/_tests/fixtures/44299/result.json
+++ b/src/_tests/fixtures/44299/result.json
@@ -2,13 +2,12 @@
   "pr_number": 44299,
   "targetColumn": "Needs Maintainer Action",
   "labels": [
-    "New Definition",
-    "Check Config"
+    "New Definition"
   ],
   "responseComments": [
     {
       "tag": "welcome",
-      "status": "@geopic Thank you for submitting this PR! I see this is your first time submitting to DefinitelyTyped 👋 — I'm the local bot who will help you through the process of getting things through.\n\n***This is a live comment which I will keep updated.***\n\n## 1 package in this PR\n\n* `hcaptcha__vue-hcaptcha` (*new!*) [on npm](https://www.npmjs.com/package/@hcaptcha/vue-hcaptcha), [on unpkg](https://unpkg.com/browse/@hcaptcha/vue-hcaptcha@latest/)\n  - 1 added owner: ✎@geopic\n  - Config files to check:\n    - [`hcaptcha__vue-hcaptcha/package.json`](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44299/files/683fb3b1298223256be3a49823686f35bd94a730#diff-7f6b3c89357f5b55cbe423c5b8d87644a735796ed0ba5d4be803a615d304a83b): couldn't fetch contents\n    - [`hcaptcha__vue-hcaptcha/tsconfig.json`](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44299/files/683fb3b1298223256be3a49823686f35bd94a730#diff-6ded07af09e0936a1c143bb0fbfaca37e9df9668ecc22d402a833077e66abe54): couldn't fetch contents\n    - [`hcaptcha__vue-hcaptcha/tslint.json`](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44299/files/683fb3b1298223256be3a49823686f35bd94a730#diff-c441c94ec5219d4722929ccb738301643b5eef17a151184505f387fdbec13408): couldn't fetch contents\n\n## Code Reviews\n\nThis PR adds a new definition, so it needs to be reviewed by a DT maintainer before it can be merged.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ Only a DT maintainer can approve changes when there are new packages added\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n----------------------\n... diagnostics scrubbed ..."
+      "status": "@geopic Thank you for submitting this PR! I see this is your first time submitting to DefinitelyTyped 👋 — I'm the local bot who will help you through the process of getting things through.\n\n***This is a live comment which I will keep updated.***\n\n## 1 package in this PR\n\n* `hcaptcha__vue-hcaptcha` (*new!*) [on npm](https://www.npmjs.com/package/@hcaptcha/vue-hcaptcha), [on unpkg](https://unpkg.com/browse/@hcaptcha/vue-hcaptcha@latest/)\n  - 1 added owner: ✎@geopic\n\n## Code Reviews\n\nThis PR adds a new definition, so it needs to be reviewed by a DT maintainer before it can be merged.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ Only a DT maintainer can approve changes when there are new packages added\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n----------------------\n... diagnostics scrubbed ..."
     },
     {
       "tag": "pinging-reviewers-others",

--- a/src/_tests/fixtures/44316/derived.json
+++ b/src/_tests/fixtures/44316/derived.json
@@ -22,8 +22,7 @@
         },
         {
           "path": "types/vimeo/tsconfig.json",
-          "kind": "package-meta",
-          "suspect": "couldn't fetch contents"
+          "kind": "package-meta-ok"
         },
         {
           "path": "types/vimeo/vimeo-tests.ts",

--- a/src/_tests/fixtures/44316/mutations.json
+++ b/src/_tests/fixtures/44316/mutations.json
@@ -1,10 +1,12 @@
 [
   {
-    "query": "mutation($input: MoveProjectCardInput!) { moveProjectCard(input: $input) { clientMutationId } }",
+    "query": "mutation($input: RemoveLabelsFromLabelableInput!) { removeLabelsFromLabelable(input: $input) { clientMutationId } }",
     "variables": {
       "input": {
-        "cardId": "MDExOlByb2plY3RDYXJkMzcyMDMzMzU=",
-        "columnId": "MDEzOlByb2plY3RDb2x1bW45ODY3MDA2"
+        "labelIds": [
+          "MDU6TGFiZWwyMTU0ODE2NTQ5"
+        ],
+        "labelableId": "MDExOlB1bGxSZXF1ZXN0NDEwMzk4NzAw"
       }
     }
   },
@@ -13,7 +15,7 @@
     "variables": {
       "input": {
         "id": "MDEyOklzc3VlQ29tbWVudDYyMDg5MzUyMA==",
-        "body": "@mattleff Thank you for submitting this PR!\n\n***This is a live comment which I will keep updated.***\n\n## 1 package in this PR\n\n* `vimeo` [on npm](https://www.npmjs.com/package/vimeo), [on unpkg](https://unpkg.com/browse/vimeo@latest/) (author is owner)\n  - Config files to check:\n    - [`vimeo/tsconfig.json`](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44316/files/55357f7d60d059b5c84a23bd92854276a8f9a419#diff-2b7f4c3a0b1cb5a892e62dacc9c3d0caa20601673c8d00380be51ba66708f2d1): couldn't fetch contents\n\n## Code Reviews\n\nThere aren't any other owners of this package, so a DT maintainer will review it.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ A DT maintainer can merge changes when there are no other reviewers\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n----------------------\n... diagnostics scrubbed ...\n<!--typescript_bot_welcome-->"
+        "body": "@mattleff Thank you for submitting this PR!\n\n***This is a live comment which I will keep updated.***\n\n## 1 package in this PR\n\n* `vimeo` [on npm](https://www.npmjs.com/package/vimeo), [on unpkg](https://unpkg.com/browse/vimeo@latest/) (author is owner)\n\n## Code Reviews\n\nBecause you edited one package and updated the tests (👏), I can help you merge this PR once someone else signs off on it.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ Most recent commit is approved by type definition owners, DT maintainers or others\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n----------------------\n... diagnostics scrubbed ...\n<!--typescript_bot_welcome-->"
       }
     }
   },

--- a/src/_tests/fixtures/44316/result.json
+++ b/src/_tests/fixtures/44316/result.json
@@ -1,15 +1,14 @@
 {
   "pr_number": 44316,
-  "targetColumn": "Needs Maintainer Action",
+  "targetColumn": "Waiting for Code Reviews",
   "labels": [
     "Author is Owner",
-    "No Other Owners",
-    "Check Config"
+    "No Other Owners"
   ],
   "responseComments": [
     {
       "tag": "welcome",
-      "status": "@mattleff Thank you for submitting this PR!\n\n***This is a live comment which I will keep updated.***\n\n## 1 package in this PR\n\n* `vimeo` [on npm](https://www.npmjs.com/package/vimeo), [on unpkg](https://unpkg.com/browse/vimeo@latest/) (author is owner)\n  - Config files to check:\n    - [`vimeo/tsconfig.json`](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44316/files/55357f7d60d059b5c84a23bd92854276a8f9a419#diff-2b7f4c3a0b1cb5a892e62dacc9c3d0caa20601673c8d00380be51ba66708f2d1): couldn't fetch contents\n\n## Code Reviews\n\nThere aren't any other owners of this package, so a DT maintainer will review it.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ A DT maintainer can merge changes when there are no other reviewers\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n----------------------\n... diagnostics scrubbed ..."
+      "status": "@mattleff Thank you for submitting this PR!\n\n***This is a live comment which I will keep updated.***\n\n## 1 package in this PR\n\n* `vimeo` [on npm](https://www.npmjs.com/package/vimeo), [on unpkg](https://unpkg.com/browse/vimeo@latest/) (author is owner)\n\n## Code Reviews\n\nBecause you edited one package and updated the tests (👏), I can help you merge this PR once someone else signs off on it.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ Most recent commit is approved by type definition owners, DT maintainers or others\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n----------------------\n... diagnostics scrubbed ..."
     },
     {
       "tag": "pinging-reviewers-others",

--- a/src/_tests/fixtures/44411/derived.json
+++ b/src/_tests/fixtures/44411/derived.json
@@ -34,13 +34,11 @@
         },
         {
           "path": "types/jest-image-snapshot/v2/tsconfig.json",
-          "kind": "package-meta",
-          "suspect": "couldn't fetch contents"
+          "kind": "package-meta-ok"
         },
         {
           "path": "types/jest-image-snapshot/v2/tslint.json",
-          "kind": "package-meta",
-          "suspect": "couldn't fetch contents"
+          "kind": "package-meta-ok"
         }
       ],
       "owners": [

--- a/src/_tests/fixtures/44411/mutations.json
+++ b/src/_tests/fixtures/44411/mutations.json
@@ -11,11 +11,13 @@
     }
   },
   {
-    "query": "mutation($input: MoveProjectCardInput!) { moveProjectCard(input: $input) { clientMutationId } }",
+    "query": "mutation($input: RemoveLabelsFromLabelableInput!) { removeLabelsFromLabelable(input: $input) { clientMutationId } }",
     "variables": {
       "input": {
-        "cardId": "MDExOlByb2plY3RDYXJkMzczNjg0NDA=",
-        "columnId": "MDEzOlByb2plY3RDb2x1bW43NTUyOTIy"
+        "labelIds": [
+          "MDU6TGFiZWwyMTU0ODE2NTQ5"
+        ],
+        "labelableId": "MDExOlB1bGxSZXF1ZXN0NDEyMDc3MDI1"
       }
     }
   },
@@ -24,7 +26,7 @@
     "variables": {
       "input": {
         "id": "MDEyOklzc3VlQ29tbWVudDYyMjMzMzI3Ng==",
-        "body": "@peterblazejewicz Thank you for submitting this PR!\n\n***This is a live comment which I will keep updated.***\n\n## 1 package in this PR\n\n* `jest-image-snapshot` [on npm](https://www.npmjs.com/package/jest-image-snapshot), [on unpkg](https://unpkg.com/browse/jest-image-snapshot@latest/)\n  - 1 added owner: ✎@peterblazejewicz\n  - Config files to check:\n    - [`jest-image-snapshot/v2/tsconfig.json`](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44411/files/d0d51a062525a6a4b83b297cd0e75adb4d5628f6#diff-1f4726d9a1e26e3aece8d2702af9d5d3edb1e32180192e2298b02147509485dc): couldn't fetch contents\n    - [`jest-image-snapshot/v2/tslint.json`](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44411/files/d0d51a062525a6a4b83b297cd0e75adb4d5628f6#diff-651efbe7a0eea62a82aef2b62fa707b7e8b8ea105e561e291b401f8b5b910b1b): couldn't fetch contents\n\n## Code Reviews\n\nBecause this PR edits the configuration file, it can be merged once it's reviewed by a DT maintainer.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ A DT maintainer needs to approve changes which affect module config files\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n----------------------\n... diagnostics scrubbed ...\n<!--typescript_bot_welcome-->"
+        "body": "@peterblazejewicz Thank you for submitting this PR!\n\n***This is a live comment which I will keep updated.***\n\n## 1 package in this PR\n\n* `jest-image-snapshot` [on npm](https://www.npmjs.com/package/jest-image-snapshot), [on unpkg](https://unpkg.com/browse/jest-image-snapshot@latest/)\n  - 1 added owner: ✎@peterblazejewicz\n\n## Code Reviews\n\nBecause you edited one package and updated the tests (👏), I can help you merge this PR once someone else signs off on it.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ Most recent commit is approved by type definition owners, DT maintainers or others\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n----------------------\n... diagnostics scrubbed ...\n<!--typescript_bot_welcome-->"
       }
     }
   }

--- a/src/_tests/fixtures/44411/result.json
+++ b/src/_tests/fixtures/44411/result.json
@@ -1,14 +1,13 @@
 {
   "pr_number": 44411,
-  "targetColumn": "Needs Maintainer Review",
+  "targetColumn": "Waiting for Code Reviews",
   "labels": [
-    "Edits Owners",
-    "Check Config"
+    "Edits Owners"
   ],
   "responseComments": [
     {
       "tag": "welcome",
-      "status": "@peterblazejewicz Thank you for submitting this PR!\n\n***This is a live comment which I will keep updated.***\n\n## 1 package in this PR\n\n* `jest-image-snapshot` [on npm](https://www.npmjs.com/package/jest-image-snapshot), [on unpkg](https://unpkg.com/browse/jest-image-snapshot@latest/)\n  - 1 added owner: ✎@peterblazejewicz\n  - Config files to check:\n    - [`jest-image-snapshot/v2/tsconfig.json`](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44411/files/d0d51a062525a6a4b83b297cd0e75adb4d5628f6#diff-1f4726d9a1e26e3aece8d2702af9d5d3edb1e32180192e2298b02147509485dc): couldn't fetch contents\n    - [`jest-image-snapshot/v2/tslint.json`](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44411/files/d0d51a062525a6a4b83b297cd0e75adb4d5628f6#diff-651efbe7a0eea62a82aef2b62fa707b7e8b8ea105e561e291b401f8b5b910b1b): couldn't fetch contents\n\n## Code Reviews\n\nBecause this PR edits the configuration file, it can be merged once it's reviewed by a DT maintainer.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ A DT maintainer needs to approve changes which affect module config files\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n----------------------\n... diagnostics scrubbed ..."
+      "status": "@peterblazejewicz Thank you for submitting this PR!\n\n***This is a live comment which I will keep updated.***\n\n## 1 package in this PR\n\n* `jest-image-snapshot` [on npm](https://www.npmjs.com/package/jest-image-snapshot), [on unpkg](https://unpkg.com/browse/jest-image-snapshot@latest/)\n  - 1 added owner: ✎@peterblazejewicz\n\n## Code Reviews\n\nBecause you edited one package and updated the tests (👏), I can help you merge this PR once someone else signs off on it.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ Most recent commit is approved by type definition owners, DT maintainers or others\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n----------------------\n... diagnostics scrubbed ..."
     },
     {
       "tag": "pinging-reviewers",

--- a/src/_tests/fixtures/44424-1-travis-instantly-finished/derived.json
+++ b/src/_tests/fixtures/44424-1-travis-instantly-finished/derived.json
@@ -18,8 +18,7 @@
       "files": [
         {
           "path": "types/openfin/OTHER_FILES.txt",
-          "kind": "package-meta",
-          "suspect": "couldn't fetch contents"
+          "kind": "package-meta-ok"
         },
         {
           "path": "types/openfin/_v2/api/application/application.d.ts",
@@ -171,13 +170,11 @@
         },
         {
           "path": "types/openfin/tslint.json",
-          "kind": "package-meta",
-          "suspect": "couldn't fetch contents"
+          "kind": "package-meta-ok"
         },
         {
           "path": "types/openfin/v49/OTHER_FILES.txt",
-          "kind": "package-meta",
-          "suspect": "couldn't fetch contents"
+          "kind": "package-meta-ok"
         },
         {
           "path": "types/openfin/v49/_v2/api/application/application.d.ts",

--- a/src/_tests/fixtures/44424-1-travis-instantly-finished/mutations.json
+++ b/src/_tests/fixtures/44424-1-travis-instantly-finished/mutations.json
@@ -1,10 +1,12 @@
 [
   {
-    "query": "mutation($input: MoveProjectCardInput!) { moveProjectCard(input: $input) { clientMutationId } }",
+    "query": "mutation($input: RemoveLabelsFromLabelableInput!) { removeLabelsFromLabelable(input: $input) { clientMutationId } }",
     "variables": {
       "input": {
-        "cardId": "MDExOlByb2plY3RDYXJkMzczOTYzMTI=",
-        "columnId": "MDEzOlByb2plY3RDb2x1bW43NTUyOTIy"
+        "labelIds": [
+          "MDU6TGFiZWwyMTU0ODE2NTQ5"
+        ],
+        "labelableId": "MDExOlB1bGxSZXF1ZXN0NDEyMjY1MDE2"
       }
     }
   },
@@ -13,7 +15,7 @@
     "variables": {
       "input": {
         "id": "MDEyOklzc3VlQ29tbWVudDYyMjUyNzAxNQ==",
-        "body": "@tomer-openfin Thank you for submitting this PR!\n\n***This is a live comment which I will keep updated.***\n\n## 1 package in this PR\n\n* `openfin` [on npm](https://www.npmjs.com/package/openfin), [on unpkg](https://unpkg.com/browse/openfin@latest/) (author is owner)\n  - Config files to check:\n    - [`openfin/OTHER_FILES.txt`](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44424/files/af636941dac21c0752befa1617297dfdac3e0a52#diff-004d79898182f654ce84ac7deed9a38f3c41c438de9af7a5e1edf9c5cfa0fcb4): couldn't fetch contents\n    - [`openfin/tslint.json`](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44424/files/af636941dac21c0752befa1617297dfdac3e0a52#diff-59b1ab6d62c34c8b064f27d3f16a88e20e60adde2ed7bf0d3529a59fa0c8ed03): couldn't fetch contents\n    - [`openfin/v49/OTHER_FILES.txt`](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44424/files/af636941dac21c0752befa1617297dfdac3e0a52#diff-90b0a88e7d7d6ab8f4246471243a6fbc2699361d94c22ab900ff93b9e190893c): couldn't fetch contents\n\n## Code Reviews\n\nBecause this PR edits the configuration file, it can be merged once it's reviewed by a DT maintainer.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ A DT maintainer needs to approve changes which affect module config files\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n----------------------\n... diagnostics scrubbed ...\n<!--typescript_bot_welcome-->"
+        "body": "@tomer-openfin Thank you for submitting this PR!\n\n***This is a live comment which I will keep updated.***\n\n## 1 package in this PR\n\n* `openfin` [on npm](https://www.npmjs.com/package/openfin), [on unpkg](https://unpkg.com/browse/openfin@latest/) (author is owner)\n\n## Code Reviews\n\nBecause you edited one package and updated the tests (👏), I can help you merge this PR once someone else signs off on it.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ Most recent commit is approved by type definition owners, DT maintainers or others\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n----------------------\n... diagnostics scrubbed ...\n<!--typescript_bot_welcome-->"
       }
     }
   }

--- a/src/_tests/fixtures/44424-1-travis-instantly-finished/result.json
+++ b/src/_tests/fixtures/44424-1-travis-instantly-finished/result.json
@@ -1,14 +1,13 @@
 {
   "pr_number": 44424,
-  "targetColumn": "Needs Maintainer Review",
+  "targetColumn": "Waiting for Code Reviews",
   "labels": [
-    "Author is Owner",
-    "Check Config"
+    "Author is Owner"
   ],
   "responseComments": [
     {
       "tag": "welcome",
-      "status": "@tomer-openfin Thank you for submitting this PR!\n\n***This is a live comment which I will keep updated.***\n\n## 1 package in this PR\n\n* `openfin` [on npm](https://www.npmjs.com/package/openfin), [on unpkg](https://unpkg.com/browse/openfin@latest/) (author is owner)\n  - Config files to check:\n    - [`openfin/OTHER_FILES.txt`](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44424/files/af636941dac21c0752befa1617297dfdac3e0a52#diff-004d79898182f654ce84ac7deed9a38f3c41c438de9af7a5e1edf9c5cfa0fcb4): couldn't fetch contents\n    - [`openfin/tslint.json`](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44424/files/af636941dac21c0752befa1617297dfdac3e0a52#diff-59b1ab6d62c34c8b064f27d3f16a88e20e60adde2ed7bf0d3529a59fa0c8ed03): couldn't fetch contents\n    - [`openfin/v49/OTHER_FILES.txt`](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44424/files/af636941dac21c0752befa1617297dfdac3e0a52#diff-90b0a88e7d7d6ab8f4246471243a6fbc2699361d94c22ab900ff93b9e190893c): couldn't fetch contents\n\n## Code Reviews\n\nBecause this PR edits the configuration file, it can be merged once it's reviewed by a DT maintainer.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ A DT maintainer needs to approve changes which affect module config files\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n----------------------\n... diagnostics scrubbed ..."
+      "status": "@tomer-openfin Thank you for submitting this PR!\n\n***This is a live comment which I will keep updated.***\n\n## 1 package in this PR\n\n* `openfin` [on npm](https://www.npmjs.com/package/openfin), [on unpkg](https://unpkg.com/browse/openfin@latest/) (author is owner)\n\n## Code Reviews\n\nBecause you edited one package and updated the tests (👏), I can help you merge this PR once someone else signs off on it.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ Most recent commit is approved by type definition owners, DT maintainers or others\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n----------------------\n... diagnostics scrubbed ..."
     },
     {
       "tag": "pinging-reviewers",

--- a/src/_tests/fixtures/44424-2-after-travis-second/derived.json
+++ b/src/_tests/fixtures/44424-2-after-travis-second/derived.json
@@ -18,8 +18,7 @@
       "files": [
         {
           "path": "types/openfin/OTHER_FILES.txt",
-          "kind": "package-meta",
-          "suspect": "couldn't fetch contents"
+          "kind": "package-meta-ok"
         },
         {
           "path": "types/openfin/_v2/api/application/application.d.ts",
@@ -171,13 +170,11 @@
         },
         {
           "path": "types/openfin/tslint.json",
-          "kind": "package-meta",
-          "suspect": "couldn't fetch contents"
+          "kind": "package-meta-ok"
         },
         {
           "path": "types/openfin/v49/OTHER_FILES.txt",
-          "kind": "package-meta",
-          "suspect": "couldn't fetch contents"
+          "kind": "package-meta-ok"
         },
         {
           "path": "types/openfin/v49/_v2/api/application/application.d.ts",

--- a/src/_tests/fixtures/44424-2-after-travis-second/mutations.json
+++ b/src/_tests/fixtures/44424-2-after-travis-second/mutations.json
@@ -1,10 +1,21 @@
 [
   {
+    "query": "mutation($input: RemoveLabelsFromLabelableInput!) { removeLabelsFromLabelable(input: $input) { clientMutationId } }",
+    "variables": {
+      "input": {
+        "labelIds": [
+          "MDU6TGFiZWwyMTU0ODE2NTQ5"
+        ],
+        "labelableId": "MDExOlB1bGxSZXF1ZXN0NDEyMjY1MDE2"
+      }
+    }
+  },
+  {
     "query": "mutation($input: UpdateIssueCommentInput!) { updateIssueComment(input: $input) { clientMutationId } }",
     "variables": {
       "input": {
         "id": "MDEyOklzc3VlQ29tbWVudDYyMjUyNzAxNQ==",
-        "body": "@tomer-openfin Thank you for submitting this PR!\n\n***This is a live comment which I will keep updated.***\n\n## 1 package in this PR\n\n* `openfin` [on npm](https://www.npmjs.com/package/openfin), [on unpkg](https://unpkg.com/browse/openfin@latest/) (author is owner)\n  - Config files to check:\n    - [`openfin/OTHER_FILES.txt`](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44424/files/af636941dac21c0752befa1617297dfdac3e0a52#diff-004d79898182f654ce84ac7deed9a38f3c41c438de9af7a5e1edf9c5cfa0fcb4): couldn't fetch contents\n    - [`openfin/tslint.json`](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44424/files/af636941dac21c0752befa1617297dfdac3e0a52#diff-59b1ab6d62c34c8b064f27d3f16a88e20e60adde2ed7bf0d3529a59fa0c8ed03): couldn't fetch contents\n    - [`openfin/v49/OTHER_FILES.txt`](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44424/files/af636941dac21c0752befa1617297dfdac3e0a52#diff-90b0a88e7d7d6ab8f4246471243a6fbc2699361d94c22ab900ff93b9e190893c): couldn't fetch contents\n\n## Code Reviews\n\nBecause this PR edits the configuration file, it can be merged once it's reviewed by a DT maintainer.\n\n## Status\n\n * ✅ No merge conflicts\n * ❌ Continuous integration tests have finished\n * ❌ A DT maintainer needs to approve changes which affect module config files\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n----------------------\n... diagnostics scrubbed ...\n<!--typescript_bot_welcome-->"
+        "body": "@tomer-openfin Thank you for submitting this PR!\n\n***This is a live comment which I will keep updated.***\n\n## 1 package in this PR\n\n* `openfin` [on npm](https://www.npmjs.com/package/openfin), [on unpkg](https://unpkg.com/browse/openfin@latest/) (author is owner)\n\n## Code Reviews\n\nBecause you edited one package and updated the tests (👏), I can help you merge this PR once someone else signs off on it.\n\n## Status\n\n * ✅ No merge conflicts\n * ❌ Continuous integration tests have finished\n * ❌ Most recent commit is approved by type definition owners, DT maintainers or others\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n----------------------\n... diagnostics scrubbed ...\n<!--typescript_bot_welcome-->"
       }
     }
   }

--- a/src/_tests/fixtures/44424-2-after-travis-second/result.json
+++ b/src/_tests/fixtures/44424-2-after-travis-second/result.json
@@ -2,13 +2,12 @@
   "pr_number": 44424,
   "targetColumn": "Waiting for Code Reviews",
   "labels": [
-    "Author is Owner",
-    "Check Config"
+    "Author is Owner"
   ],
   "responseComments": [
     {
       "tag": "welcome",
-      "status": "@tomer-openfin Thank you for submitting this PR!\n\n***This is a live comment which I will keep updated.***\n\n## 1 package in this PR\n\n* `openfin` [on npm](https://www.npmjs.com/package/openfin), [on unpkg](https://unpkg.com/browse/openfin@latest/) (author is owner)\n  - Config files to check:\n    - [`openfin/OTHER_FILES.txt`](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44424/files/af636941dac21c0752befa1617297dfdac3e0a52#diff-004d79898182f654ce84ac7deed9a38f3c41c438de9af7a5e1edf9c5cfa0fcb4): couldn't fetch contents\n    - [`openfin/tslint.json`](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44424/files/af636941dac21c0752befa1617297dfdac3e0a52#diff-59b1ab6d62c34c8b064f27d3f16a88e20e60adde2ed7bf0d3529a59fa0c8ed03): couldn't fetch contents\n    - [`openfin/v49/OTHER_FILES.txt`](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44424/files/af636941dac21c0752befa1617297dfdac3e0a52#diff-90b0a88e7d7d6ab8f4246471243a6fbc2699361d94c22ab900ff93b9e190893c): couldn't fetch contents\n\n## Code Reviews\n\nBecause this PR edits the configuration file, it can be merged once it's reviewed by a DT maintainer.\n\n## Status\n\n * ✅ No merge conflicts\n * ❌ Continuous integration tests have finished\n * ❌ A DT maintainer needs to approve changes which affect module config files\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n----------------------\n... diagnostics scrubbed ..."
+      "status": "@tomer-openfin Thank you for submitting this PR!\n\n***This is a live comment which I will keep updated.***\n\n## 1 package in this PR\n\n* `openfin` [on npm](https://www.npmjs.com/package/openfin), [on unpkg](https://unpkg.com/browse/openfin@latest/) (author is owner)\n\n## Code Reviews\n\nBecause you edited one package and updated the tests (👏), I can help you merge this PR once someone else signs off on it.\n\n## Status\n\n * ✅ No merge conflicts\n * ❌ Continuous integration tests have finished\n * ❌ Most recent commit is approved by type definition owners, DT maintainers or others\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n----------------------\n... diagnostics scrubbed ..."
     },
     {
       "tag": "pinging-reviewers",

--- a/src/_tests/fixtures/45890/derived.json
+++ b/src/_tests/fixtures/45890/derived.json
@@ -26,13 +26,11 @@
         },
         {
           "path": "types/greek-utils/tsconfig.json",
-          "kind": "package-meta",
-          "suspect": "couldn't fetch contents"
+          "kind": "package-meta-ok"
         },
         {
           "path": "types/greek-utils/tslint.json",
-          "kind": "package-meta",
-          "suspect": "couldn't fetch contents"
+          "kind": "package-meta-ok"
         }
       ],
       "owners": [],

--- a/src/_tests/fixtures/45890/mutations.json
+++ b/src/_tests/fixtures/45890/mutations.json
@@ -1,16 +1,5 @@
 [
   {
-    "query": "mutation($input: AddLabelsToLabelableInput!) { addLabelsToLabelable(input: $input) { clientMutationId } }",
-    "variables": {
-      "input": {
-        "labelIds": [
-          "MDU6TGFiZWwyMTU0ODE2NTQ5"
-        ],
-        "labelableId": "MDExOlB1bGxSZXF1ZXN0NDQ0MzI2NjIy"
-      }
-    }
-  },
-  {
     "query": "mutation($input: MoveProjectCardInput!) { moveProjectCard(input: $input) { clientMutationId } }",
     "variables": {
       "input": {
@@ -24,7 +13,7 @@
     "variables": {
       "input": {
         "id": "MDEyOklzc3VlQ29tbWVudDY1MzgxMDQ1NA==",
-        "body": "@dimkirt Thank you for submitting this PR! I see this is your first time submitting to DefinitelyTyped 👋 — I'm the local bot who will help you through the process of getting things through.\n\n***This is a live comment which I will keep updated.***\n\n## 1 package in this PR\n\n* `greek-utils` (*new!*) [on npm](https://www.npmjs.com/package/greek-utils), [on unpkg](https://unpkg.com/browse/greek-utils@latest/)\n  - 1 added owner: ✎@dimkirt\n  - Config files to check:\n    - [`greek-utils/tsconfig.json`](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/45890/files/146c312eac4c4ac8931b4ec6b2762457f8f4b6e6#diff-8580e62e675e57ce0e41bc84092e01b449be703b016d9bf5378c75fb02e5adc3): couldn't fetch contents\n    - [`greek-utils/tslint.json`](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/45890/files/146c312eac4c4ac8931b4ec6b2762457f8f4b6e6#diff-1beeab429f4237a976a64069a8a9b4eee96b609637784407d8975647ca13c8a5): couldn't fetch contents\n\n## Code Reviews\n\nThis PR adds a new definition, so it needs to be reviewed by a DT maintainer before it can be merged.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ Only a DT maintainer can approve changes when there are new packages added\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n----------------------\n... diagnostics scrubbed ...\n<!--typescript_bot_welcome-->"
+        "body": "@dimkirt Thank you for submitting this PR! I see this is your first time submitting to DefinitelyTyped 👋 — I'm the local bot who will help you through the process of getting things through.\n\n***This is a live comment which I will keep updated.***\n\n## 1 package in this PR\n\n* `greek-utils` (*new!*) [on npm](https://www.npmjs.com/package/greek-utils), [on unpkg](https://unpkg.com/browse/greek-utils@latest/)\n  - 1 added owner: ✎@dimkirt\n\n## Code Reviews\n\nThis PR adds a new definition, so it needs to be reviewed by a DT maintainer before it can be merged.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ Only a DT maintainer can approve changes when there are new packages added\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n----------------------\n... diagnostics scrubbed ...\n<!--typescript_bot_welcome-->"
       }
     }
   },

--- a/src/_tests/fixtures/45890/result.json
+++ b/src/_tests/fixtures/45890/result.json
@@ -3,13 +3,12 @@
   "targetColumn": "Needs Maintainer Action",
   "labels": [
     "Other Approved",
-    "New Definition",
-    "Check Config"
+    "New Definition"
   ],
   "responseComments": [
     {
       "tag": "welcome",
-      "status": "@dimkirt Thank you for submitting this PR! I see this is your first time submitting to DefinitelyTyped 👋 — I'm the local bot who will help you through the process of getting things through.\n\n***This is a live comment which I will keep updated.***\n\n## 1 package in this PR\n\n* `greek-utils` (*new!*) [on npm](https://www.npmjs.com/package/greek-utils), [on unpkg](https://unpkg.com/browse/greek-utils@latest/)\n  - 1 added owner: ✎@dimkirt\n  - Config files to check:\n    - [`greek-utils/tsconfig.json`](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/45890/files/146c312eac4c4ac8931b4ec6b2762457f8f4b6e6#diff-8580e62e675e57ce0e41bc84092e01b449be703b016d9bf5378c75fb02e5adc3): couldn't fetch contents\n    - [`greek-utils/tslint.json`](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/45890/files/146c312eac4c4ac8931b4ec6b2762457f8f4b6e6#diff-1beeab429f4237a976a64069a8a9b4eee96b609637784407d8975647ca13c8a5): couldn't fetch contents\n\n## Code Reviews\n\nThis PR adds a new definition, so it needs to be reviewed by a DT maintainer before it can be merged.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ Only a DT maintainer can approve changes when there are new packages added\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n----------------------\n... diagnostics scrubbed ..."
+      "status": "@dimkirt Thank you for submitting this PR! I see this is your first time submitting to DefinitelyTyped 👋 — I'm the local bot who will help you through the process of getting things through.\n\n***This is a live comment which I will keep updated.***\n\n## 1 package in this PR\n\n* `greek-utils` (*new!*) [on npm](https://www.npmjs.com/package/greek-utils), [on unpkg](https://unpkg.com/browse/greek-utils@latest/)\n  - 1 added owner: ✎@dimkirt\n\n## Code Reviews\n\nThis PR adds a new definition, so it needs to be reviewed by a DT maintainer before it can be merged.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ Only a DT maintainer can approve changes when there are new packages added\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n----------------------\n... diagnostics scrubbed ..."
     },
     {
       "tag": "pinging-reviewers-others",

--- a/src/_tests/fixtures/45946/derived.json
+++ b/src/_tests/fixtures/45946/derived.json
@@ -40,13 +40,11 @@
         },
         {
           "path": "types/asynciterator/tsconfig.json",
-          "kind": "package-meta",
-          "suspect": "couldn't fetch contents"
+          "kind": "package-meta-ok"
         },
         {
           "path": "types/asynciterator/tslint.json",
-          "kind": "package-meta",
-          "suspect": "couldn't fetch contents"
+          "kind": "package-meta-ok"
         }
       ],
       "owners": [

--- a/src/_tests/fixtures/45946/mutations.json
+++ b/src/_tests/fixtures/45946/mutations.json
@@ -1,16 +1,5 @@
 [
   {
-    "query": "mutation($input: AddLabelsToLabelableInput!) { addLabelsToLabelable(input: $input) { clientMutationId } }",
-    "variables": {
-      "input": {
-        "labelIds": [
-          "MDU6TGFiZWwyMTU0ODE2NTQ5"
-        ],
-        "labelableId": "MDExOlB1bGxSZXF1ZXN0NDQ2MDIxMjkw"
-      }
-    }
-  },
-  {
     "query": "mutation($input: RemoveLabelsFromLabelableInput!) { removeLabelsFromLabelable(input: $input) { clientMutationId } }",
     "variables": {
       "input": {
@@ -35,7 +24,7 @@
     "variables": {
       "input": {
         "id": "MDEyOklzc3VlQ29tbWVudDY1NTMxNzQwNQ==",
-        "body": "@rubensworks Thank you for submitting this PR!\n\n***This is a live comment which I will keep updated.***\n\nThis PR touches some part of DefinitelyTyped infrastructure, so a DT maintainer will need to review it. This is rare — did you mean to do this?\n\n## 1 package in this PR\n\n* `asynciterator` (*probably deleted!*) [on npm](https://www.npmjs.com/package/asynciterator), [on unpkg](https://unpkg.com/browse/asynciterator@latest/) (author is owner)\n  - Config files to check:\n    - [`asynciterator/tsconfig.json`](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/45946/files/a5eb1f19e7a31387e7d7c79b3acc483b0e60b32e#diff-be20504719e5f1036e683d4ddaab8bf2b1c609ea12aa30786497768f575095ad): couldn't fetch contents\n    - [`asynciterator/tslint.json`](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/45946/files/a5eb1f19e7a31387e7d7c79b3acc483b0e60b32e#diff-e3a26c4ba64c5ed587d2b797151728488e274f4be74c1558722a8a32cf7a31c9): couldn't fetch contents\n\n## Code Reviews\n\nThere aren't any other owners of this package, so a DT maintainer will review it.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ A DT maintainer needs to approve changes which affect DT infrastructure ([`notNeededPackages.json`](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/45946/files/a5eb1f19e7a31387e7d7c79b3acc483b0e60b32e#diff-a275c2eae7b8f788a52327e76809026ee1bc5ea614393806c8f3cbab07202621))\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n----------------------\n... diagnostics scrubbed ...\n<!--typescript_bot_welcome-->"
+        "body": "@rubensworks Thank you for submitting this PR!\n\n***This is a live comment which I will keep updated.***\n\nThis PR touches some part of DefinitelyTyped infrastructure, so a DT maintainer will need to review it. This is rare — did you mean to do this?\n\n## 1 package in this PR\n\n* `asynciterator` (*probably deleted!*) [on npm](https://www.npmjs.com/package/asynciterator), [on unpkg](https://unpkg.com/browse/asynciterator@latest/) (author is owner)\n\n## Code Reviews\n\nThere aren't any other owners of this package, so a DT maintainer will review it.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ A DT maintainer needs to approve changes which affect DT infrastructure ([`notNeededPackages.json`](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/45946/files/a5eb1f19e7a31387e7d7c79b3acc483b0e60b32e#diff-a275c2eae7b8f788a52327e76809026ee1bc5ea614393806c8f3cbab07202621))\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n----------------------\n... diagnostics scrubbed ...\n<!--typescript_bot_welcome-->"
       }
     }
   },

--- a/src/_tests/fixtures/45946/result.json
+++ b/src/_tests/fixtures/45946/result.json
@@ -3,13 +3,12 @@
   "targetColumn": "Needs Maintainer Action",
   "labels": [
     "Edits Infrastructure",
-    "No Other Owners",
-    "Check Config"
+    "No Other Owners"
   ],
   "responseComments": [
     {
       "tag": "welcome",
-      "status": "@rubensworks Thank you for submitting this PR!\n\n***This is a live comment which I will keep updated.***\n\nThis PR touches some part of DefinitelyTyped infrastructure, so a DT maintainer will need to review it. This is rare — did you mean to do this?\n\n## 1 package in this PR\n\n* `asynciterator` (*probably deleted!*) [on npm](https://www.npmjs.com/package/asynciterator), [on unpkg](https://unpkg.com/browse/asynciterator@latest/) (author is owner)\n  - Config files to check:\n    - [`asynciterator/tsconfig.json`](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/45946/files/a5eb1f19e7a31387e7d7c79b3acc483b0e60b32e#diff-be20504719e5f1036e683d4ddaab8bf2b1c609ea12aa30786497768f575095ad): couldn't fetch contents\n    - [`asynciterator/tslint.json`](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/45946/files/a5eb1f19e7a31387e7d7c79b3acc483b0e60b32e#diff-e3a26c4ba64c5ed587d2b797151728488e274f4be74c1558722a8a32cf7a31c9): couldn't fetch contents\n\n## Code Reviews\n\nThere aren't any other owners of this package, so a DT maintainer will review it.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ A DT maintainer needs to approve changes which affect DT infrastructure ([`notNeededPackages.json`](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/45946/files/a5eb1f19e7a31387e7d7c79b3acc483b0e60b32e#diff-a275c2eae7b8f788a52327e76809026ee1bc5ea614393806c8f3cbab07202621))\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n----------------------\n... diagnostics scrubbed ..."
+      "status": "@rubensworks Thank you for submitting this PR!\n\n***This is a live comment which I will keep updated.***\n\nThis PR touches some part of DefinitelyTyped infrastructure, so a DT maintainer will need to review it. This is rare — did you mean to do this?\n\n## 1 package in this PR\n\n* `asynciterator` (*probably deleted!*) [on npm](https://www.npmjs.com/package/asynciterator), [on unpkg](https://unpkg.com/browse/asynciterator@latest/) (author is owner)\n\n## Code Reviews\n\nThere aren't any other owners of this package, so a DT maintainer will review it.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ A DT maintainer needs to approve changes which affect DT infrastructure ([`notNeededPackages.json`](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/45946/files/a5eb1f19e7a31387e7d7c79b3acc483b0e60b32e#diff-a275c2eae7b8f788a52327e76809026ee1bc5ea614393806c8f3cbab07202621))\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n----------------------\n... diagnostics scrubbed ..."
     },
     {
       "tag": "pinging-reviewers-others",

--- a/src/_tests/fixtures/46019/derived.json
+++ b/src/_tests/fixtures/46019/derived.json
@@ -27,8 +27,7 @@
         },
         {
           "path": "types/is-secret/tsconfig.json",
-          "kind": "package-meta",
-          "suspect": "couldn't fetch contents"
+          "kind": "package-meta-ok"
         },
         {
           "path": "types/is-secret/tslint.json",

--- a/src/_tests/fixtures/46019/mutations.json
+++ b/src/_tests/fixtures/46019/mutations.json
@@ -1,21 +1,10 @@
 [
   {
-    "query": "mutation($input: AddLabelsToLabelableInput!) { addLabelsToLabelable(input: $input) { clientMutationId } }",
-    "variables": {
-      "input": {
-        "labelIds": [
-          "MDU6TGFiZWwyMTU0ODE2NTQ5"
-        ],
-        "labelableId": "MDExOlB1bGxSZXF1ZXN0NDQ3ODE1MDgx"
-      }
-    }
-  },
-  {
     "query": "mutation($input: UpdateIssueCommentInput!) { updateIssueComment(input: $input) { clientMutationId } }",
     "variables": {
       "input": {
         "id": "MDEyOklzc3VlQ29tbWVudDY1NzEyNjg3Mg==",
-        "body": "@peterblazejewicz Thank you for submitting this PR!\n\n***This is a live comment which I will keep updated.***\n\n## 1 package in this PR\n\n* `is-secret` (*new!*) [on npm](https://www.npmjs.com/package/is-secret), [on unpkg](https://unpkg.com/browse/is-secret@latest/)\n  - 2 added owners: @wrumsby, ✎@peterblazejewicz\n  - Config files to check:\n    - [`is-secret/tsconfig.json`](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/46019/files/ceca9f768be945932c692d7dd48fa14b6ff38096#diff-d5cb28ac6bc4842869aa49fee16653bddadedda2f36bf881ddd3ed7cdc6cce6b): couldn't fetch contents\n\n## Code Reviews\n\nThis PR adds a new definition, so it needs to be reviewed by a DT maintainer before it can be merged.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ✅ Only a DT maintainer can approve changes when there are new packages added\n\nAll of the items on the list are green. **To merge, you need to post a comment including the string \"Ready to merge\"** to bring in your changes.\n\n----------------------\n... diagnostics scrubbed ...\n<!--typescript_bot_welcome-->"
+        "body": "@peterblazejewicz Thank you for submitting this PR!\n\n***This is a live comment which I will keep updated.***\n\n## 1 package in this PR\n\n* `is-secret` (*new!*) [on npm](https://www.npmjs.com/package/is-secret), [on unpkg](https://unpkg.com/browse/is-secret@latest/)\n  - 2 added owners: @wrumsby, ✎@peterblazejewicz\n\n## Code Reviews\n\nThis PR adds a new definition, so it needs to be reviewed by a DT maintainer before it can be merged.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ✅ Only a DT maintainer can approve changes when there are new packages added\n\nAll of the items on the list are green. **To merge, you need to post a comment including the string \"Ready to merge\"** to bring in your changes.\n\n----------------------\n... diagnostics scrubbed ...\n<!--typescript_bot_welcome-->"
       }
     }
   },

--- a/src/_tests/fixtures/46019/result.json
+++ b/src/_tests/fixtures/46019/result.json
@@ -4,13 +4,12 @@
   "labels": [
     "Maintainer Approved",
     "New Definition",
-    "Check Config",
     "Self Merge"
   ],
   "responseComments": [
     {
       "tag": "welcome",
-      "status": "@peterblazejewicz Thank you for submitting this PR!\n\n***This is a live comment which I will keep updated.***\n\n## 1 package in this PR\n\n* `is-secret` (*new!*) [on npm](https://www.npmjs.com/package/is-secret), [on unpkg](https://unpkg.com/browse/is-secret@latest/)\n  - 2 added owners: @wrumsby, ✎@peterblazejewicz\n  - Config files to check:\n    - [`is-secret/tsconfig.json`](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/46019/files/ceca9f768be945932c692d7dd48fa14b6ff38096#diff-d5cb28ac6bc4842869aa49fee16653bddadedda2f36bf881ddd3ed7cdc6cce6b): couldn't fetch contents\n\n## Code Reviews\n\nThis PR adds a new definition, so it needs to be reviewed by a DT maintainer before it can be merged.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ✅ Only a DT maintainer can approve changes when there are new packages added\n\nAll of the items on the list are green. **To merge, you need to post a comment including the string \"Ready to merge\"** to bring in your changes.\n\n----------------------\n... diagnostics scrubbed ..."
+      "status": "@peterblazejewicz Thank you for submitting this PR!\n\n***This is a live comment which I will keep updated.***\n\n## 1 package in this PR\n\n* `is-secret` (*new!*) [on npm](https://www.npmjs.com/package/is-secret), [on unpkg](https://unpkg.com/browse/is-secret@latest/)\n  - 2 added owners: @wrumsby, ✎@peterblazejewicz\n\n## Code Reviews\n\nThis PR adds a new definition, so it needs to be reviewed by a DT maintainer before it can be merged.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ✅ Only a DT maintainer can approve changes when there are new packages added\n\nAll of the items on the list are green. **To merge, you need to post a comment including the string \"Ready to merge\"** to bring in your changes.\n\n----------------------\n... diagnostics scrubbed ..."
     },
     {
       "tag": "merge-offer",

--- a/src/pr-info.ts
+++ b/src/pr-info.ts
@@ -382,7 +382,10 @@ const configSuspicious = <ConfigSuspicious>(async (path, getContents) => {
     const basename = path.replace(/.*\//, "");
     if (!(basename in configSuspicious)) return `edited`;
     const text = await getContents();
-    if (text === undefined) return `couldn't fetch contents`;
+    // Removing tslint.json, tsconfig.json, package.json and
+    // OTHER_FILES.txt is checked by the CI. Specifics are in my commit
+    // message.
+    if (text === undefined) return undefined;
     const tester = configSuspicious[basename];
     let suspect: string | undefined;
     if (tester.length <= 1) {


### PR DESCRIPTION
This affects the [`configSuspicious` files](https://github.com/DefinitelyTyped/dt-mergebot/blob/a2890148fe904c360c9bf4bf32f689e9aa96aec1/src/pr-info.ts#L373-L400): `tslint.json`, `tsconfig.json`, `package.json` and `OTHER_FILES.txt`.
- `tslint.json` and `tsconfig.json`: Can't be removed, already forbidden by the CI.
- `package.json`: Checked by the CI and removing it is equivalent to [edits that are considered okay](https://github.com/DefinitelyTyped/dt-mergebot/pull/199).
- `OTHER_FILES.txt`: Checked by the CI. It [can't be empty](https://github.com/DefinitelyTyped/dt-mergebot/blob/a2890148fe904c360c9bf4bf32f689e9aa96aec1/src/pr-info.ts#L375) so the only option may be to remove it, if there [aren't any other files](https://github.com/microsoft/DefinitelyTyped-tools/blob/8d847f117b22dd08076906e4d0d278558cf3d709/packages/definitions-parser/src/lib/definition-parser.ts#L670).

So the effect of this change is to require only owner approval instead of maintainer approval to remove `package.json` or `OTHER_FILES.txt`.