### PR TITLE
Move tslint.json advice from PULL_REQUEST_TEMPLATE.md

### DIFF
--- a/src/_tests/fixtures/49841/derived.json
+++ b/src/_tests/fixtures/49841/derived.json
@@ -27,7 +27,7 @@
         {
           "path": "types/react-native-sha1/tsconfig.json",
           "kind": "package-meta",
-          "suspect": "not the required form"
+          "suspect": "not [the required form](https://github.com/DefinitelyTyped/DefinitelyTyped#tsconfigjson)"
         },
         {
           "path": "types/react-native-sha1/tslint.json",

--- a/src/urls.ts
+++ b/src/urls.ts
@@ -4,5 +4,6 @@ export const testingEditedPackages = `${baseURL}#testing`;
 export const testingNewPackages = `${baseURL}#testing`;
 export const definitionOwners = `${baseURL}#definition-owners`;
 export const workflow = `${baseURL}#make-a-pull-request`;
-export const readmePackageJason = `${baseURL}#make-a-pull-request`;
+export const tslintJson = `${baseURL}#linter-tslintjson`;
+export const tsconfigJson = `${baseURL}#tsconfigjson`;
 export const packageJson = `${baseURL}#packagejson`;


### PR DESCRIPTION
Move the advice from [the PULL_REQUEST_TEMPLATE.md](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/.github/PULL_REQUEST_TEMPLATE.md#:~:text=shouldn't%20have%20any%20additional%20or%20disabling,need%20for%20disabling%20can%20be%20reviewed.) to the bot to explain the required form and what to do about it.