### PR TITLE
Fix insta-merges on approvals

### DIFF
--- a/src/_tests/fixtures/38979/derived.json
+++ b/src/_tests/fixtures/38979/derived.json
@@ -5,7 +5,6 @@
   "author": "ExE-Boss",
   "headCommitAbbrOid": "2223341",
   "headCommitOid": "222334139e52fc16369464cfb5dc95c82f71192f",
-  "mergeIsRequested": false,
   "stalenessInDays": 0,
   "lastPushDate": "2020-01-03T21:02:41.000Z",
   "reopenedDate": "2019-10-18T22:52:06.000Z",

--- a/src/_tests/fixtures/43136/derived.json
+++ b/src/_tests/fixtures/43136/derived.json
@@ -5,7 +5,6 @@
   "author": "larsrh",
   "headCommitAbbrOid": "e686353",
   "headCommitOid": "e6863537248bbfee8f0ef8c636bb00c25cf40b96",
-  "mergeIsRequested": false,
   "stalenessInDays": 3,
   "lastPushDate": "2020-03-16T14:26:42.000Z",
   "lastCommentDate": "2020-03-16T14:26:42.000Z",

--- a/src/_tests/fixtures/43144/derived.json
+++ b/src/_tests/fixtures/43144/derived.json
@@ -5,7 +5,6 @@
   "author": "jeffreymeng",
   "headCommitAbbrOid": "f1f5c4b",
   "headCommitOid": "f1f5c4bb0ae553f56766882f6458d2e22baa87c7",
-  "mergeIsRequested": false,
   "stalenessInDays": 4,
   "lastPushDate": "2020-03-15T00:11:48.000Z",
   "lastCommentDate": "2020-03-15T00:11:48.000Z",

--- a/src/_tests/fixtures/43151/derived.json
+++ b/src/_tests/fixtures/43151/derived.json
@@ -5,7 +5,6 @@
   "author": "adamzerella",
   "headCommitAbbrOid": "bb6d315",
   "headCommitOid": "bb6d3150b485cd203d265e06ca910262256e523e",
-  "mergeIsRequested": false,
   "stalenessInDays": 4,
   "lastPushDate": "2020-03-15T12:50:20.000Z",
   "lastCommentDate": "2020-03-15T12:50:20.000Z",

--- a/src/_tests/fixtures/43160/derived.json
+++ b/src/_tests/fixtures/43160/derived.json
@@ -5,7 +5,6 @@
   "author": "rikkertkoppes",
   "headCommitAbbrOid": "6d5d2a8",
   "headCommitOid": "6d5d2a85b41d287f97c9d331a9ff6a9824e2f1ff",
-  "mergeIsRequested": false,
   "stalenessInDays": 1,
   "lastPushDate": "2020-03-16T08:14:50.000Z",
   "lastCommentDate": "2020-03-16T08:14:50.000Z",

--- a/src/_tests/fixtures/43175/derived.json
+++ b/src/_tests/fixtures/43175/derived.json
@@ -5,7 +5,6 @@
   "author": "ankhler",
   "headCommitAbbrOid": "b4b3bc8",
   "headCommitOid": "b4b3bc8a617e2e0810d60e389415818d903e6362",
-  "mergeIsRequested": false,
   "stalenessInDays": 2,
   "lastPushDate": "2020-03-17T13:51:37.000Z",
   "lastCommentDate": "2020-03-17T13:51:37.000Z",

--- a/src/_tests/fixtures/43235/derived.json
+++ b/src/_tests/fixtures/43235/derived.json
@@ -5,7 +5,6 @@
   "author": "Favna",
   "headCommitAbbrOid": "933d8d8",
   "headCommitOid": "933d8d81859cea3cb2df640bd099ef80bee3d691",
-  "mergeIsRequested": false,
   "stalenessInDays": 0,
   "lastPushDate": "2020-03-19T14:37:52.000Z",
   "lastCommentDate": "2020-03-19T14:37:52.000Z",

--- a/src/_tests/fixtures/43314/derived.json
+++ b/src/_tests/fixtures/43314/derived.json
@@ -5,7 +5,6 @@
   "author": "metonym",
   "headCommitAbbrOid": "432f23f",
   "headCommitOid": "432f23fe1b87b12fe58bb1a8958f77ee3242741e",
-  "mergeIsRequested": false,
   "stalenessInDays": 0,
   "lastPushDate": "2020-03-22T16:48:44.000Z",
   "lastCommentDate": "2020-03-22T16:48:44.000Z",

--- a/src/_tests/fixtures/43695-duplicate-comment/derived.json
+++ b/src/_tests/fixtures/43695-duplicate-comment/derived.json
@@ -5,7 +5,6 @@
   "author": "alexandercerutti",
   "headCommitAbbrOid": "3e83617",
   "headCommitOid": "3e836178b736e5512361ffda46e84a5c668d7a90",
-  "mergeIsRequested": false,
   "stalenessInDays": 0,
   "lastPushDate": "2020-04-07T07:51:12.000Z",
   "reopenedDate": "2020-04-30T23:08:16.000Z",

--- a/src/_tests/fixtures/43695-post-review/derived.json
+++ b/src/_tests/fixtures/43695-post-review/derived.json
@@ -5,7 +5,6 @@
   "author": "alexandercerutti",
   "headCommitAbbrOid": "90c94f9",
   "headCommitOid": "90c94f91120c026f5f8bcc586426e8590b7b4048",
-  "mergeIsRequested": false,
   "stalenessInDays": 0,
   "lastPushDate": "2020-04-15T15:53:29.000Z",
   "lastCommentDate": "2020-04-30T23:07:44.000Z",

--- a/src/_tests/fixtures/43695/derived.json
+++ b/src/_tests/fixtures/43695/derived.json
@@ -5,7 +5,6 @@
   "author": "alexandercerutti",
   "headCommitAbbrOid": "a5285cd",
   "headCommitOid": "a5285cda2722912a390770722a334e6d6e43d1ab",
-  "mergeIsRequested": false,
   "stalenessInDays": 0,
   "lastPushDate": "2020-04-07T07:41:37.000Z",
   "lastCommentDate": "2020-04-07T07:41:37.000Z",

--- a/src/_tests/fixtures/43960/derived.json
+++ b/src/_tests/fixtures/43960/derived.json
@@ -5,7 +5,6 @@
   "author": "aaltepet",
   "headCommitAbbrOid": "129f84e",
   "headCommitOid": "129f84e4492a76e7cd5af9d946c4583a60e6eb88",
-  "mergeIsRequested": false,
   "stalenessInDays": 0,
   "lastPushDate": "2020-04-16T17:21:54.000Z",
   "reopenedDate": "2020-04-29T20:48:52.000Z",

--- a/src/_tests/fixtures/44267/derived.json
+++ b/src/_tests/fixtures/44267/derived.json
@@ -5,7 +5,6 @@
   "author": "ErikMartensson",
   "headCommitAbbrOid": "ceb74b3",
   "headCommitOid": "ceb74b3471454b2f57cbe671e130028c680ffb88",
-  "mergeIsRequested": false,
   "stalenessInDays": 2,
   "lastPushDate": "2020-04-27T14:15:25.000Z",
   "lastCommentDate": "2020-04-27T14:15:25.000Z",

--- a/src/_tests/fixtures/44282/derived.json
+++ b/src/_tests/fixtures/44282/derived.json
@@ -5,7 +5,6 @@
   "author": "fishcharlie",
   "headCommitAbbrOid": "2579430",
   "headCommitOid": "25794304acf8c1fd70712bd068beb07b0e09755e",
-  "mergeIsRequested": false,
   "stalenessInDays": 0,
   "lastPushDate": "2020-04-27T23:58:24.000Z",
   "lastCommentDate": "2020-04-27T23:58:24.000Z",

--- a/src/_tests/fixtures/44288/derived.json
+++ b/src/_tests/fixtures/44288/derived.json
@@ -5,7 +5,6 @@
   "author": "nomatteus",
   "headCommitAbbrOid": "05ee6f2",
   "headCommitOid": "05ee6f2784d694258f61e7a93a95e758ea29ad9d",
-  "mergeIsRequested": false,
   "stalenessInDays": 0,
   "lastPushDate": "2020-04-28T04:46:31.000Z",
   "lastCommentDate": "2020-04-28T04:46:31.000Z",

--- a/src/_tests/fixtures/44299-with-files/derived.json
+++ b/src/_tests/fixtures/44299-with-files/derived.json
@@ -5,7 +5,6 @@
   "author": "geopic",
   "headCommitAbbrOid": "683fb3b",
   "headCommitOid": "683fb3b1298223256be3a49823686f35bd94a730",
-  "mergeIsRequested": false,
   "stalenessInDays": 0,
   "lastPushDate": "2020-04-29T10:57:59.000Z",
   "lastCommentDate": "2020-04-29T10:57:59.000Z",

--- a/src/_tests/fixtures/44299/derived.json
+++ b/src/_tests/fixtures/44299/derived.json
@@ -5,7 +5,6 @@
   "author": "geopic",
   "headCommitAbbrOid": "683fb3b",
   "headCommitOid": "683fb3b1298223256be3a49823686f35bd94a730",
-  "mergeIsRequested": false,
   "stalenessInDays": 0,
   "lastPushDate": "2020-04-29T10:57:59.000Z",
   "lastCommentDate": "2020-04-29T10:57:59.000Z",

--- a/src/_tests/fixtures/44316/derived.json
+++ b/src/_tests/fixtures/44316/derived.json
@@ -5,7 +5,6 @@
   "author": "mattleff",
   "headCommitAbbrOid": "55357f7",
   "headCommitOid": "55357f7d60d059b5c84a23bd92854276a8f9a419",
-  "mergeIsRequested": false,
   "stalenessInDays": 2,
   "lastPushDate": "2020-04-29T15:19:08.000Z",
   "lastCommentDate": "2020-04-29T00:16:19.000Z",

--- a/src/_tests/fixtures/44343-pending-travis/derived.json
+++ b/src/_tests/fixtures/44343-pending-travis/derived.json
@@ -5,7 +5,6 @@
   "author": "sandersn",
   "headCommitAbbrOid": "abd65c3",
   "headCommitOid": "abd65c3bbbf3463b41127be203c37fe64f717a7e",
-  "mergeIsRequested": false,
   "stalenessInDays": 0,
   "lastPushDate": "2020-04-29T16:19:21.000Z",
   "lastCommentDate": "2020-04-29T16:19:21.000Z",

--- a/src/_tests/fixtures/44343-pre-travis/derived.json
+++ b/src/_tests/fixtures/44343-pre-travis/derived.json
@@ -5,7 +5,6 @@
   "author": "sandersn",
   "headCommitAbbrOid": "abd65c3",
   "headCommitOid": "abd65c3bbbf3463b41127be203c37fe64f717a7e",
-  "mergeIsRequested": false,
   "stalenessInDays": 0,
   "lastPushDate": "2020-04-29T16:19:21.000Z",
   "lastCommentDate": "2020-04-29T16:19:21.000Z",

--- a/src/_tests/fixtures/44343/derived.json
+++ b/src/_tests/fixtures/44343/derived.json
@@ -5,7 +5,6 @@
   "author": "sandersn",
   "headCommitAbbrOid": "abd65c3",
   "headCommitOid": "abd65c3bbbf3463b41127be203c37fe64f717a7e",
-  "mergeIsRequested": false,
   "stalenessInDays": 0,
   "lastPushDate": "2020-04-29T16:19:21.000Z",
   "lastCommentDate": "2020-04-29T16:19:21.000Z",

--- a/src/_tests/fixtures/44411/derived.json
+++ b/src/_tests/fixtures/44411/derived.json
@@ -5,7 +5,6 @@
   "author": "peterblazejewicz",
   "headCommitAbbrOid": "d0d51a0",
   "headCommitOid": "d0d51a062525a6a4b83b297cd0e75adb4d5628f6",
-  "mergeIsRequested": false,
   "stalenessInDays": 0,
   "lastPushDate": "2020-05-01T10:24:23.000Z",
   "lastCommentDate": "2020-05-01T10:24:23.000Z",

--- a/src/_tests/fixtures/44424-1-travis-instantly-finished/derived.json
+++ b/src/_tests/fixtures/44424-1-travis-instantly-finished/derived.json
@@ -5,7 +5,6 @@
   "author": "tomer-openfin",
   "headCommitAbbrOid": "af63694",
   "headCommitOid": "af636941dac21c0752befa1617297dfdac3e0a52",
-  "mergeIsRequested": false,
   "stalenessInDays": 0,
   "lastPushDate": "2020-05-01T19:20:22.000Z",
   "lastCommentDate": "2020-05-01T19:20:22.000Z",

--- a/src/_tests/fixtures/44424-2-after-travis-second/derived.json
+++ b/src/_tests/fixtures/44424-2-after-travis-second/derived.json
@@ -5,7 +5,6 @@
   "author": "tomer-openfin",
   "headCommitAbbrOid": "af63694",
   "headCommitOid": "af636941dac21c0752befa1617297dfdac3e0a52",
-  "mergeIsRequested": false,
   "stalenessInDays": 0,
   "lastPushDate": "2020-05-01T19:20:22.000Z",
   "lastCommentDate": "2020-05-01T19:20:22.000Z",

--- a/src/_tests/fixtures/44437/derived.json
+++ b/src/_tests/fixtures/44437/derived.json
@@ -5,7 +5,6 @@
   "author": "johnnyreilly",
   "headCommitAbbrOid": "eb92456",
   "headCommitOid": "eb92456861d4537c6e96dd7865e715aa4812aae0",
-  "mergeIsRequested": false,
   "stalenessInDays": 0,
   "lastPushDate": "2020-05-02T12:17:06.000Z",
   "lastCommentDate": "2020-05-02T12:17:06.000Z",

--- a/src/_tests/fixtures/44439/derived.json
+++ b/src/_tests/fixtures/44439/derived.json
@@ -5,7 +5,6 @@
   "author": "ivandevp",
   "headCommitAbbrOid": "f8b1612",
   "headCommitOid": "f8b161266a38186c3d7ab715ea63f68d5ef542ed",
-  "mergeIsRequested": false,
   "stalenessInDays": 0,
   "lastPushDate": "2020-05-02T13:54:02.000Z",
   "lastCommentDate": "2020-05-02T14:36:15.000Z",

--- a/src/_tests/fixtures/44631/derived.json
+++ b/src/_tests/fixtures/44631/derived.json
@@ -5,7 +5,6 @@
   "author": "mAAdhaTTah",
   "headCommitAbbrOid": "96d6582",
   "headCommitOid": "96d6582f60431d273c179dcf6816426b4f1e37ac",
-  "mergeIsRequested": false,
   "stalenessInDays": 0,
   "lastPushDate": "2020-05-10T21:26:25.000Z",
   "lastCommentDate": "2020-05-10T21:26:25.000Z",

--- a/src/_tests/fixtures/44857/derived.json
+++ b/src/_tests/fixtures/44857/derived.json
@@ -5,7 +5,6 @@
   "author": "ExE-Boss",
   "headCommitAbbrOid": "4aff18f",
   "headCommitOid": "4aff18f9b99fdfc26209485631ba429f5d3d29ba",
-  "mergeIsRequested": false,
   "stalenessInDays": 31,
   "lastPushDate": "2020-07-28T16:54:29.000Z",
   "lastCommentDate": "2020-07-29T16:31:48.000Z",

--- a/src/_tests/fixtures/44989-3days/derived.json
+++ b/src/_tests/fixtures/44989-3days/derived.json
@@ -5,7 +5,6 @@
   "author": "petr-motejlek",
   "headCommitAbbrOid": "9ca6086",
   "headCommitOid": "9ca60862ea56c9ff8d6b0f26c28b7e0bdaef4b34",
-  "mergeIsRequested": false,
   "stalenessInDays": 3,
   "lastPushDate": "2020-05-23T08:41:39.000Z",
   "lastCommentDate": "2020-05-23T08:45:20.000Z",

--- a/src/_tests/fixtures/44989-5days/derived.json
+++ b/src/_tests/fixtures/44989-5days/derived.json
@@ -5,7 +5,6 @@
   "author": "petr-motejlek",
   "headCommitAbbrOid": "9ca6086",
   "headCommitOid": "9ca60862ea56c9ff8d6b0f26c28b7e0bdaef4b34",
-  "mergeIsRequested": false,
   "stalenessInDays": 5,
   "lastPushDate": "2020-05-23T08:41:39.000Z",
   "lastCommentDate": "2020-05-23T08:45:20.000Z",

--- a/src/_tests/fixtures/44989-6days/derived.json
+++ b/src/_tests/fixtures/44989-6days/derived.json
@@ -5,7 +5,6 @@
   "author": "petr-motejlek",
   "headCommitAbbrOid": "9ca6086",
   "headCommitOid": "9ca60862ea56c9ff8d6b0f26c28b7e0bdaef4b34",
-  "mergeIsRequested": false,
   "stalenessInDays": 6,
   "lastPushDate": "2020-05-23T08:41:39.000Z",
   "lastCommentDate": "2020-05-23T08:45:20.000Z",

--- a/src/_tests/fixtures/44989-9days/derived.json
+++ b/src/_tests/fixtures/44989-9days/derived.json
@@ -5,7 +5,6 @@
   "author": "petr-motejlek",
   "headCommitAbbrOid": "9ca6086",
   "headCommitOid": "9ca60862ea56c9ff8d6b0f26c28b7e0bdaef4b34",
-  "mergeIsRequested": false,
   "stalenessInDays": 9,
   "lastPushDate": "2020-05-23T08:41:39.000Z",
   "lastCommentDate": "2020-05-23T08:45:20.000Z",

--- a/src/_tests/fixtures/45137/derived.json
+++ b/src/_tests/fixtures/45137/derived.json
@@ -5,7 +5,6 @@
   "author": "lirbank",
   "headCommitAbbrOid": "22c73c8",
   "headCommitOid": "22c73c88cc9c09efd4c2998ec360607dd4c36c2e",
-  "mergeIsRequested": false,
   "stalenessInDays": 0,
   "lastPushDate": "2020-05-29T04:38:59.000Z",
   "lastCommentDate": "2020-05-29T04:43:45.000Z",

--- a/src/_tests/fixtures/45627/derived.json
+++ b/src/_tests/fixtures/45627/derived.json
@@ -5,7 +5,7 @@
   "author": "spamshaker",
   "headCommitAbbrOid": "15facc1",
   "headCommitOid": "15facc177c957646a1ace95abe5e71326007c721",
-  "mergeIsRequested": true,
+  "lastMergeRequestDate": "2020-07-06T08:36:06.000Z",
   "stalenessInDays": 0,
   "lastPushDate": "2020-06-21T09:33:06.000Z",
   "lastCommentDate": "2020-07-06T08:36:06.000Z",

--- a/src/_tests/fixtures/45836/derived.json
+++ b/src/_tests/fixtures/45836/derived.json
@@ -5,7 +5,7 @@
   "author": "mmorearty",
   "headCommitAbbrOid": "6c7735e",
   "headCommitOid": "6c7735e2b8f39640cb73e40ae04cb6642a8ab2cd",
-  "mergeIsRequested": true,
+  "lastMergeRequestDate": "2020-07-08T17:47:50.000Z",
   "stalenessInDays": 0,
   "lastPushDate": "2020-07-01T23:06:38.000Z",
   "lastCommentDate": "2020-07-08T18:13:23.000Z",

--- a/src/_tests/fixtures/45884/derived.json
+++ b/src/_tests/fixtures/45884/derived.json
@@ -5,7 +5,6 @@
   "author": "sgratzl",
   "headCommitAbbrOid": "1dcf44a",
   "headCommitOid": "1dcf44a05908783324ca99231837267af495cdb7",
-  "mergeIsRequested": false,
   "stalenessInDays": 0,
   "lastPushDate": "2020-07-04T08:33:11.000Z",
   "lastCommentDate": "2020-07-04T08:40:23.000Z",

--- a/src/_tests/fixtures/45888/derived.json
+++ b/src/_tests/fixtures/45888/derived.json
@@ -5,7 +5,6 @@
   "author": "gstvds",
   "headCommitAbbrOid": "8a7a2fc",
   "headCommitOid": "8a7a2fc1cdbfe1d3a7af7d1f7a346977fdf47b0d",
-  "mergeIsRequested": false,
   "stalenessInDays": 0,
   "lastPushDate": "2020-07-04T18:01:47.000Z",
   "lastCommentDate": "2020-07-04T18:01:47.000Z",

--- a/src/_tests/fixtures/45890/derived.json
+++ b/src/_tests/fixtures/45890/derived.json
@@ -5,7 +5,6 @@
   "author": "dimkirt",
   "headCommitAbbrOid": "146c312",
   "headCommitOid": "146c312eac4c4ac8931b4ec6b2762457f8f4b6e6",
-  "mergeIsRequested": false,
   "stalenessInDays": 1,
   "lastPushDate": "2020-07-04T22:02:07.000Z",
   "lastCommentDate": "2020-07-04T22:04:02.000Z",

--- a/src/_tests/fixtures/45946/derived.json
+++ b/src/_tests/fixtures/45946/derived.json
@@ -5,7 +5,6 @@
   "author": "rubensworks",
   "headCommitAbbrOid": "a5eb1f1",
   "headCommitOid": "a5eb1f19e7a31387e7d7c79b3acc483b0e60b32e",
-  "mergeIsRequested": false,
   "stalenessInDays": 0,
   "lastPushDate": "2020-07-08T06:31:29.000Z",
   "lastCommentDate": "2020-07-10T14:00:47.000Z",

--- a/src/_tests/fixtures/45999/derived.json
+++ b/src/_tests/fixtures/45999/derived.json
@@ -5,7 +5,6 @@
   "author": "alexpyzhianov",
   "headCommitAbbrOid": "381a2a9",
   "headCommitOid": "381a2a9d17d14e111f7d002c866debfcac6724e8",
-  "mergeIsRequested": false,
   "stalenessInDays": 0,
   "lastPushDate": "2020-07-10T13:10:49.000Z",
   "lastCommentDate": "2020-07-10T14:38:56.000Z",

--- a/src/_tests/fixtures/46008/derived.json
+++ b/src/_tests/fixtures/46008/derived.json
@@ -5,7 +5,6 @@
   "author": "risingBirdSong",
   "headCommitAbbrOid": "3e19cb9",
   "headCommitOid": "3e19cb9cae4689fb736fd6682f7f76d8efafcaa2",
-  "mergeIsRequested": false,
   "stalenessInDays": 0,
   "lastPushDate": "2020-07-10T00:44:49.000Z",
   "lastCommentDate": "2020-07-10T18:58:06.000Z",

--- a/src/_tests/fixtures/46019/derived.json
+++ b/src/_tests/fixtures/46019/derived.json
@@ -5,7 +5,6 @@
   "author": "peterblazejewicz",
   "headCommitAbbrOid": "ceca9f7",
   "headCommitOid": "ceca9f768be945932c692d7dd48fa14b6ff38096",
-  "mergeIsRequested": false,
   "stalenessInDays": 0,
   "lastPushDate": "2020-07-11T20:43:23.000Z",
   "lastCommentDate": "2020-07-11T20:43:23.000Z",

--- a/src/_tests/fixtures/46120/derived.json
+++ b/src/_tests/fixtures/46120/derived.json
@@ -5,7 +5,7 @@
   "author": "reubenrybnik",
   "headCommitAbbrOid": "5ef8fe2",
   "headCommitOid": "5ef8fe2907257beac41e27c3dc2399a087eddb67",
-  "mergeIsRequested": false,
+  "lastMergeRequestDate": "2020-07-19T16:36:44.000Z",
   "stalenessInDays": 0,
   "lastPushDate": "2020-07-17T14:12:06.000Z",
   "lastCommentDate": "2020-07-19T22:33:41.000Z",

--- a/src/_tests/fixtures/46191/derived.json
+++ b/src/_tests/fixtures/46191/derived.json
@@ -5,7 +5,6 @@
   "author": "jordanoverbye",
   "headCommitAbbrOid": "3cc81db",
   "headCommitOid": "3cc81dbde57a1b0eda6f69f539fa49b8d420adff",
-  "mergeIsRequested": false,
   "stalenessInDays": 0,
   "lastPushDate": "2020-07-20T06:54:57.000Z",
   "lastCommentDate": "2020-07-20T06:54:57.000Z",

--- a/src/_tests/fixtures/46196/derived.json
+++ b/src/_tests/fixtures/46196/derived.json
@@ -5,7 +5,6 @@
   "author": "bytetyde",
   "headCommitAbbrOid": "2f300d2",
   "headCommitOid": "2f300d234e09e9e34c88e884f6466f2d6d0db399",
-  "mergeIsRequested": false,
   "stalenessInDays": 0,
   "lastPushDate": "2020-07-20T12:12:39.000Z",
   "lastCommentDate": "2020-07-20T12:12:39.000Z",

--- a/src/_tests/fixtures/46279/derived.json
+++ b/src/_tests/fixtures/46279/derived.json
@@ -5,7 +5,6 @@
   "author": "pzingg",
   "headCommitAbbrOid": "8032238",
   "headCommitOid": "80322389c71c13e0fca466b744b35b742a3ee161",
-  "mergeIsRequested": false,
   "stalenessInDays": 0,
   "lastPushDate": "2020-07-23T01:03:50.000Z",
   "lastCommentDate": "2020-07-23T01:03:50.000Z",

--- a/src/_tests/fixtures/46804/derived.json
+++ b/src/_tests/fixtures/46804/derived.json
@@ -5,7 +5,6 @@
   "author": "ETHANTALJAFFE",
   "headCommitAbbrOid": "3e3524f",
   "headCommitOid": "3e3524f41de19cd97d5c32a531eab3f0e9206f75",
-  "mergeIsRequested": false,
   "stalenessInDays": 0,
   "lastPushDate": "2020-08-15T20:29:40.000Z",
   "lastCommentDate": "2020-08-15T20:29:40.000Z",

--- a/src/_tests/fixtures/46879/derived.json
+++ b/src/_tests/fixtures/46879/derived.json
@@ -5,7 +5,6 @@
   "author": "Chaldron",
   "headCommitAbbrOid": "2586d74",
   "headCommitOid": "2586d74ca0dc553be5f3afc0135468b17b240d70",
-  "mergeIsRequested": false,
   "stalenessInDays": 0,
   "lastPushDate": "2020-08-11T18:21:13.000Z",
   "lastCommentDate": "2020-08-11T18:21:13.000Z",

--- a/src/_tests/fixtures/47017/derived.json
+++ b/src/_tests/fixtures/47017/derived.json
@@ -5,7 +5,6 @@
   "author": "mastermatt",
   "headCommitAbbrOid": "dbe687d",
   "headCommitOid": "dbe687d30362e4f887e88048a3646c13c0c4d907",
-  "mergeIsRequested": false,
   "stalenessInDays": 1,
   "lastPushDate": "2020-08-25T05:47:26.000Z",
   "lastCommentDate": "2020-08-25T05:54:37.000Z",

--- a/src/_tests/fixtures/48216/derived.json
+++ b/src/_tests/fixtures/48216/derived.json
@@ -5,7 +5,6 @@
   "author": "jablko",
   "headCommitAbbrOid": "3f689bf",
   "headCommitOid": "3f689bfb9d310612cdaf7c52c7ead41d1181b52f",
-  "mergeIsRequested": false,
   "stalenessInDays": 0,
   "lastPushDate": "2020-09-27T17:23:58.000Z",
   "reopenedDate": "2020-09-27T19:01:23.000Z",

--- a/src/_tests/fixtures/48236/derived.json
+++ b/src/_tests/fixtures/48236/derived.json
@@ -5,7 +5,7 @@
   "author": "jablko",
   "headCommitAbbrOid": "b4d71f6",
   "headCommitOid": "b4d71f672f0f204a514002348ebc2025d18866ca",
-  "mergeIsRequested": true,
+  "lastMergeRequestDate": "2020-10-02T18:45:57.000Z",
   "stalenessInDays": 2,
   "lastPushDate": "2020-09-27T17:25:18.000Z",
   "reopenedDate": "2020-09-27T19:03:37.000Z",

--- a/src/_tests/fixtures/48708/derived.json
+++ b/src/_tests/fixtures/48708/derived.json
@@ -5,7 +5,6 @@
   "author": "martin-badin",
   "headCommitAbbrOid": "eb13547",
   "headCommitOid": "eb13547e342b1316aeea85df84983a534cfb092f",
-  "mergeIsRequested": false,
   "stalenessInDays": 28,
   "lastPushDate": "2020-10-12T12:27:56.000Z",
   "lastCommentDate": "2020-10-15T15:53:50.000Z",

--- a/src/_tests/fixtures/48945/derived.json
+++ b/src/_tests/fixtures/48945/derived.json
@@ -5,7 +5,7 @@
   "author": "google-api-typings-generator",
   "headCommitAbbrOid": "759b4cb",
   "headCommitOid": "759b4cb2339ff12a22c8101f143a7a68ed535c70",
-  "mergeIsRequested": false,
+  "lastMergeRequestDate": "2020-10-20T11:30:38.000Z",
   "stalenessInDays": 9,
   "lastPushDate": "2020-10-20T11:30:40.000Z",
   "lastCommentDate": "2020-11-03T02:30:59.000Z",

--- a/src/pr-info.ts
+++ b/src/pr-info.ts
@@ -225,7 +225,7 @@ export async function deriveStateForPR(
         author,
         headCommitAbbrOid: headCommit.abbreviatedOid,
         headCommitOid: headCommit.oid,
-        lastMergeRequestDate: usersSayReadyToMerge(noNulls(prInfo.comments.nodes),
+        lastMergeRequestDate: getLastMergeRequestDate(noNulls(prInfo.comments.nodes),
                                     pkgInfo.length === 1 ? [author, ...pkgInfo[0].owners] : [author]),
         stalenessInDays,
         lastPushDate, reopenedDate, lastCommentDate,
@@ -427,7 +427,7 @@ function makeJsonCheckerFromCore(requiredForm: any, ignoredKeys: string[]) {
     };
 }
 
-function usersSayReadyToMerge(comments: PR_repository_pullRequest_comments_nodes[], users: string[]) {
+function getLastMergeRequestDate(comments: PR_repository_pullRequest_comments_nodes[], users: string[]) {
     return latestDate(...comments.map(comment =>
         users.includes(comment.author?.login || " ")
         && comment.body.trim().toLowerCase().startsWith("ready to merge")


### PR DESCRIPTION
"Ready to merge" must come after sufficient approval. Iterates on #197 and #190 to address #216.

I realize the dust hasn't settled yet, just putting this out there for consideration.

#190 addressed the issue of insta-merges (the bot auto-merging instantly on approval due to a previous "ready to merge" request) by ignoring requests before the last approval (any approval). That opened the issue of additional approvals trampling valid merge requests, so #197 did the next simplest thing and instead ignored requests before the *first* approval. It's smart enough to be the first *valid* approval (concerning the current revision) but not smart about a *sufficient* approval (sufficient to auto-merge). That reopens the issue of insta-merges, as in #216 (1: insufficient approval, 2: request to merge, 3: sufficient approval, 4: :collision: insta-merge).

I think what we want is auto-merge to require 1) sufficient approval, 2) a request to merge, 3) in that order (request after invitation). That precludes insta-merges.

So instead of mapping approvals to approval flags, then consulting the flags for overall approval, this PR checks whether each approval is sufficient, gets the date of the first one and uses that to predicate the request to merge (and overall approval).

Simple! Except that the sufficiency check depends on the approver kind, the request to merge depends on the comments, and currently the approver kind is in [`compute-pr-actions.ts`](https://github.com/DefinitelyTyped/dt-mergebot/blob/97d0bb24966763de0d3333b0ebf977c84253dd1d/src/compute-pr-actions.ts#L183) and the comments are in [`pr-info.ts`](https://github.com/DefinitelyTyped/dt-mergebot/blob/97d0bb24966763de0d3333b0ebf977c84253dd1d/src/pr-info.ts#L229).

Assuming adding the comments to `PrInfo` isn't wanted, this PR copy-pastes the approver kind and all of its transitive dependencies from `compute-pr-actions.ts` to `pr-info.ts`. That aside, the functional change (making `firstApprovalDate` the first *sufficient* approval) is small.

Fixes #216