### PR TITLE
Add "now" to bot error fixtures

### DIFF
--- a/src/_tests/fixturedActions.test.ts
+++ b/src/_tests/fixturedActions.test.ts
@@ -38,7 +38,7 @@ async function testFixture(dir: string) {
     response,
     (expr: string) => Promise.resolve(files[expr] as string),
     (name: string, _until?: Date) => name in downloads ? downloads[name] : 0,
-    () => new Date(readJSON(derivedPath).now)
+    readJSON(derivedPath).now
   );
 
   if (derived.type === "fail") throw new Error("Should never happen");

--- a/src/_tests/fixtures/45982/derived.json
+++ b/src/_tests/fixtures/45982/derived.json
@@ -1,5 +1,6 @@
 {
   "type": "error",
+  "now": "2020-07-11T20:41:49.000Z",
   "message": "error parsing owners: At 1:1 : Expected /\\/\\/ Type definitions for (non-npm package )?/",
   "pr_number": 45982,
   "author": "dasa"

--- a/src/commands/create-fixture.ts
+++ b/src/commands/create-fixture.ts
@@ -35,7 +35,7 @@ export default async function main(directory: string, overwriteInfo: boolean) {
     response,
     shouldOverwrite(filesJSONPath) ? initFetchFilesAndWriteToFile() : getFilesFromFile,
     shouldOverwrite(downloadsJSONPath) ? initGetDownloadsAndWriteToFile() : getDownloadsFromFile,
-    shouldOverwrite(derivedFixturePath) ? undefined : getTimeFromFile,
+    shouldOverwrite(derivedFixturePath) ? undefined : getTimeFromFile(),
   );
 
   writeFileSync(derivedFixturePath, scrubDiagnosticDetails(JSON.stringify(derivedInfo, null, "  ")));
@@ -79,7 +79,7 @@ export default async function main(directory: string, overwriteInfo: boolean) {
   }
 
   function getTimeFromFile() {
-    return new Date(JSON.parse(readFileSync(derivedFixturePath, "utf8")).now);
+    return JSON.parse(readFileSync(derivedFixturePath, "utf8")).now;
   }
 }
 

--- a/src/pr-info.ts
+++ b/src/pr-info.ts
@@ -39,6 +39,7 @@ export interface BotFail {
 // Some error found, will be passed to `process` to report in a comment
 export interface BotError {
     readonly type: "error";
+    readonly now: string;
     readonly pr_number: number;
     readonly message: string;
     readonly author: string | undefined;
@@ -193,7 +194,7 @@ export async function deriveStateForPR(
     info: ApolloQueryResult<PRQueryResult>,
     fetchFile = defaultFetchFile,
     getDownloads = getMonthlyDownloadCount,
-    getNow = () => new Date(),
+    now = new Date().toISOString(),
 ): Promise<PrInfo | BotFail | BotError | BotEnsureRemovedFromProject | BotNoPackages>  {
     const prInfo = info.data.repository?.pullRequest;
 
@@ -224,7 +225,6 @@ export async function deriveStateForPR(
     const { pkgInfo, popularityLevel } = pkgInfoEtc;
     if (!pkgInfo.some(p => p.name)) return botNoPackages(prInfo.number);
 
-    const now = getNow().toISOString();
     const reviews = getReviews(prInfo);
     const latestReview = latestDate(...reviews.map(r => r.date));
     const comments = noNulls(prInfo.comments.nodes || []);
@@ -257,7 +257,7 @@ export async function deriveStateForPR(
     }
 
     function botError(pr_number: number, message: string): BotError {
-        return { type: "error", message, pr_number, author: prInfo?.author?.login };
+        return { type: "error", now, message, pr_number, author: prInfo?.author?.login };
     }
 
     function botEnsureRemovedFromProject(pr_number: number, message: string, isDraft: boolean): BotEnsureRemovedFromProject {


### PR DESCRIPTION
To avoid `RangeError: Invalid time value` when testing changes that make an existing fixture no longer error. RangeError is due to `getNow()` calling `new Date(readJSON(derivedPath).now)`, and `now` being `undefined` in `derived.json`.