### PR TITLE
Rename noNulls() -> noNullish()

### DIFF
--- a/src/compute-pr-actions.ts
+++ b/src/compute-pr-actions.ts
@@ -2,7 +2,7 @@ import * as Comments from "./comments";
 import { PrInfo, BotError, BotEnsureRemovedFromProject, BotNoPackages, FileInfo } from "./pr-info";
 import { CIResult } from "./util/CIResult";
 import { ReviewInfo } from "./pr-info";
-import { noNulls, flatten, unique, sameUser, daysSince, sha256 } from "./util/util";
+import { noNullish, flatten, unique, sameUser, daysSince, sha256 } from "./util/util";
 
 type ColumnName =
     | "Needs Maintainer Action"
@@ -150,10 +150,10 @@ function extendPrInfo(info: PrInfo): ExtendedPrInfo {
     const noOtherOwners = allOwners.every(isAuthor);
     const tooManyOwners = allOwners.length > 50;
     const editsOwners = info.pkgInfo.some(p => p.kind === "edit" && p.addedOwners.length + p.deletedOwners.length > 0);
-    const packages = noNulls(info.pkgInfo.map(p => p.name));
+    const packages = noNullish(info.pkgInfo.map(p => p.name));
     const hasMultiplePackages = packages.length > 1;
     const hasTests = info.pkgInfo.some(p => p.files.some(f => f.kind === "test"));
-    const newPackages = noNulls(info.pkgInfo.map(p => p.kind === "add" ? p.name : null));
+    const newPackages = noNullish(info.pkgInfo.map(p => p.kind === "add" ? p.name : null));
     const hasNewPackages = newPackages.length > 0;
     const requireMaintainer = editsInfra || editsConfig || hasMultiplePackages || !hasTests || hasNewPackages || tooManyOwners;
     const blessable = !(hasNewPackages || editsInfra || noOtherOwners);
@@ -202,7 +202,7 @@ function extendPrInfo(info: PrInfo): ExtendedPrInfo {
     }
 
     function getPendingCriticalPackages() {
-        return noNulls(info.pkgInfo.map(p =>
+        return noNullish(info.pkgInfo.map(p =>
             p.popularityLevel === "Critical" && !p.owners.some(o => approvedReviews.some(r => sameUser(o, r.reviewer)))
             ? p.name : null));
     }

--- a/src/execute-pr-actions.ts
+++ b/src/execute-pr-actions.ts
@@ -38,7 +38,7 @@ export async function executePrActions(actions: Actions, info: PRQueryResult, dr
 
 async function getMutationsForLabels(actions: Actions, pr: PR_repository_pullRequest) {
     if (!actions.shouldUpdateLabels) return []
-    const labels = noNullish(pr.labels?.nodes!).map(l => l.name);
+    const labels = noNullish(pr.labels?.nodes).map(l => l.name);
     const makeMutations = async (pred: (l: LabelName) => boolean, query: string) => {
         const labels = LabelNames.filter(pred);
         return labels.length === 0 ? null

--- a/src/pr-info.ts
+++ b/src/pr-info.ts
@@ -16,7 +16,7 @@ import { getMonthlyDownloadCount } from "./util/npm";
 import { client } from "./graphql-client";
 import { ApolloQueryResult } from "apollo-boost";
 import { fetchFile as defaultFetchFile } from "./util/fetchFile";
-import { noNulls, notUndefined, findLast, forEachReverse, sameUser, authorNotBot, latestDate } from "./util/util";
+import { noNullish, notUndefined, findLast, forEachReverse, sameUser, authorNotBot, latestDate } from "./util/util";
 import * as comment from "./util/comment";
 import * as HeaderParser from "definitelytyped-header-parser";
 import * as jsonDiff from "fast-json-patch";
@@ -219,7 +219,7 @@ export async function deriveStateForPR(
     const reopenedDate = getReopenedDate(prInfo.timelineItems);
 
     const pkgInfoEtc = await getPackageInfosEtc(
-        noNulls(prInfo.files?.nodes).map(f => f.path).sort(),
+        noNullish(prInfo.files?.nodes).map(f => f.path).sort(),
         headCommit.oid, fetchFile, async name => await getDownloads(name, lastPushDate));
     if (pkgInfoEtc instanceof Error) return botError(prInfo.number, pkgInfoEtc.message);
     const { pkgInfo, popularityLevel } = pkgInfoEtc;
@@ -227,7 +227,7 @@ export async function deriveStateForPR(
 
     const reviews = getReviews(prInfo);
     const latestReview = latestDate(...reviews.map(r => r.date));
-    const comments = noNulls(prInfo.comments.nodes || []);
+    const comments = noNullish(prInfo.comments.nodes || []);
     const mergeOfferDate = getMergeOfferDate(comments, headCommit.abbreviatedOid);
     const mergeRequest = getMergeRequest(comments,
                                          pkgInfo.length === 1 ? [author, ...pkgInfo[0].owners] : [author],
@@ -465,7 +465,7 @@ function getReviews(prInfo: PR_repository_pullRequest) {
     const headCommitOid: string = prInfo.headRefOid;
     const reviews: ReviewInfo[] = [];
     // Do this in reverse order so we can detect up-to-date-reviews correctly
-    for (const r of noNulls(prInfo.reviews.nodes).reverse()) {
+    for (const r of noNullish(prInfo.reviews.nodes).reverse()) {
         const [reviewer, date] = [r?.author?.login, new Date(r.submittedAt)];
         // Skip nulls
         if (!(r?.commit && reviewer)) continue;

--- a/src/pr-info.ts
+++ b/src/pr-info.ts
@@ -227,7 +227,7 @@ export async function deriveStateForPR(
 
     const reviews = getReviews(prInfo);
     const latestReview = latestDate(...reviews.map(r => r.date));
-    const comments = noNullish(prInfo.comments.nodes || []);
+    const comments = noNullish(prInfo.comments.nodes);
     const mergeOfferDate = getMergeOfferDate(comments, headCommit.abbreviatedOid);
     const mergeRequest = getMergeRequest(comments,
                                          pkgInfo.length === 1 ? [author, ...pkgInfo[0].owners] : [author],

--- a/src/pr-info.ts
+++ b/src/pr-info.ts
@@ -16,7 +16,7 @@ import { getMonthlyDownloadCount } from "./util/npm";
 import { client } from "./graphql-client";
 import { ApolloQueryResult } from "apollo-boost";
 import { fetchFile as defaultFetchFile } from "./util/fetchFile";
-import { noNullish, notUndefined, findLast, forEachReverse, sameUser, authorNotBot, latestDate } from "./util/util";
+import { noNullish, findLast, forEachReverse, sameUser, authorNotBot, latestDate } from "./util/util";
 import * as comment from "./util/comment";
 import * as HeaderParser from "definitelytyped-header-parser";
 import * as jsonDiff from "fast-json-patch";
@@ -522,5 +522,5 @@ async function getOwnersOfPackage(packageName: string, version: string, fetchFil
     } catch (e) {
         if (e instanceof Error) return new Error(`error parsing owners: ${e.message}`);
     }
-    return parsed!.contributors.map(c => c.githubUsername).filter(notUndefined);
+    return noNullish(parsed!.contributors.map(c => c.githubUsername));
 }

--- a/src/util/cachedQueries.ts
+++ b/src/util/cachedQueries.ts
@@ -3,29 +3,24 @@ import { GetProjectColumns as GetProjectColumnsResult } from "../queries/schema/
 import { GetLabels as GetLabelsResult } from "../queries/schema/GetLabels";
 import { createCache } from "../ttl-cache";
 import { client } from "../graphql-client";
+import { noNullish } from "./util";
 
 const cache = createCache();
 
 export async function getProjectBoardColumns() {
   return cache.getAsync("project board colum names", Infinity, async () => {
-      const res = (await query<GetProjectColumnsResult>(GetProjectColumns))
-          .repository?.project?.columns.nodes?.filter(defined)
-          ?? [];
+      const res = noNullish((await query<GetProjectColumnsResult>(GetProjectColumns))
+          .repository?.project?.columns.nodes);
       return res.sort((a,b) => a.name.localeCompare(b.name));
   });
 }
 
 export async function getLabels() {
   return await cache.getAsync("label ids", Infinity, async () => {
-      const res = (await query<GetLabelsResult>(GetLabels))
-          .repository?.labels?.nodes?.filter(defined)
-          ?? [];
+      const res = noNullish((await query<GetLabelsResult>(GetLabels))
+          .repository?.labels?.nodes);
       return res.sort((a,b) => a.name.localeCompare(b.name));
   });
-}
-
-function defined<T>(arg: T | null | undefined): arg is T {
-  return arg != null;
 }
 
 async function query<T>(gql: any): Promise<T> {

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -6,8 +6,6 @@ export function noNullish<T>(arr: ReadonlyArray<T | null | undefined> | null | u
     return arr.filter(arr => arr != null) as T[];
 }
 
-export function notUndefined<T>(arg: T | undefined): arg is T { return arg !== undefined; }
-
 export function flatten<T>(xs: T[][]) {
     return ([] as T[]).concat(...xs);
 }

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -1,7 +1,7 @@
 import * as crypto from "crypto";
 import * as moment from "moment";
 
-export function noNulls<T>(arr: ReadonlyArray<T | null | undefined> | null | undefined): T[] {
+export function noNullish<T>(arr: ReadonlyArray<T | null | undefined> | null | undefined): T[] {
     if (arr == null) return [];
     return arr.filter(arr => arr != null) as T[];
 }


### PR DESCRIPTION
https://github.com/DefinitelyTyped/dt-mergebot/pull/235#discussion_r532957271

How about `noNullish()`? [`NonNullable<Type>`](https://www.typescriptlang.org/docs/handbook/utility-types.html#nonnullabletype) is somewhat analogous but "nullable" doesn't describe values. I went with "nullish" like ["nullish coalescing"](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#nullish-coalescing), "nullish checks", etc.