### PR TITLE
Fix unreviewed staleness timeline

### DIFF
--- a/src/_tests/fixtures/43695-duplicate-comment/mutations.json
+++ b/src/_tests/fixtures/43695-duplicate-comment/mutations.json
@@ -1,16 +1,5 @@
 [
   {
-    "query": "mutation($input: AddLabelsToLabelableInput!) { addLabelsToLabelable(input: $input) { clientMutationId } }",
-    "variables": {
-      "input": {
-        "labelIds": [
-          "MDU6TGFiZWwyNDYyODA0MzE1"
-        ],
-        "labelableId": "MDExOlB1bGxSZXF1ZXN0NDAwMTAwMTk2"
-      }
-    }
-  },
-  {
     "query": "mutation($input: RemoveLabelsFromLabelableInput!) { removeLabelsFromLabelable(input: $input) { clientMutationId } }",
     "variables": {
       "input": {
@@ -36,7 +25,7 @@
     "variables": {
       "input": {
         "id": "MDEyOklzc3VlQ29tbWVudDYxMDIzNDI3MA==",
-        "body": "@alexandercerutti Thank you for submitting this PR!\n\n***This is a live comment which I will keep updated.***\n\n## 1 package in this PR\n\n* `accedo__accedo-one` (*new!*) [on npm](https://www.npmjs.com/package/@accedo/accedo-one), [on unpkg](https://unpkg.com/browse/@accedo/accedo-one@latest/)\n  - 1 added owner: ✎@alexandercerutti\n\n## Code Reviews\n\nThis PR adds a new definition, so it needs to be reviewed by a DT maintainer before it can be merged.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ Only a DT maintainer can approve changes when there are new packages added\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n## Inactive\n\nThis PR has been inactive for 24 days — it is *still* unreviewed!\n\n----------------------\n... diagnostics scrubbed ...\n<!--typescript_bot_welcome-->"
+        "body": "@alexandercerutti Thank you for submitting this PR!\n\n***This is a live comment which I will keep updated.***\n\n## 1 package in this PR\n\n* `accedo__accedo-one` (*new!*) [on npm](https://www.npmjs.com/package/@accedo/accedo-one), [on unpkg](https://unpkg.com/browse/@accedo/accedo-one@latest/)\n  - 1 added owner: ✎@alexandercerutti\n\n## Code Reviews\n\nThis PR adds a new definition, so it needs to be reviewed by a DT maintainer before it can be merged.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ Only a DT maintainer can approve changes when there are new packages added\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n----------------------\n... diagnostics scrubbed ...\n<!--typescript_bot_welcome-->"
       }
     }
   },
@@ -55,15 +44,6 @@
       "input": {
         "subjectId": "MDExOlB1bGxSZXF1ZXN0NDAwMTAwMTk2",
         "body": "@andrewbranch, @RyanCavanaugh Thank you for reviewing this PR! The author has pushed new commits since your last review. Could you take another look and submit a fresh review?\n<!--typescript_bot_stale-ping-61f252-a5285cd-->"
-      }
-    }
-  },
-  {
-    "query": "mutation($input: AddCommentInput!) { addComment(input: $input) { clientMutationId } }",
-    "variables": {
-      "input": {
-        "subjectId": "MDExOlB1bGxSZXF1ZXN0NDAwMTAwMTk2",
-        "body": "It has been more than two weeks and this PR still has no reviews.\n\nI'll bump it to the DT maintainer queue. Thank you for your patience, @alexandercerutti.\n\n(Ping «anyone?».)\n<!--typescript_bot_Unreviewed:done-->"
       }
     }
   }

--- a/src/_tests/fixtures/43695-duplicate-comment/result.json
+++ b/src/_tests/fixtures/43695-duplicate-comment/result.json
@@ -2,13 +2,12 @@
   "pr_number": 43695,
   "targetColumn": "Needs Maintainer Action",
   "labels": [
-    "New Definition",
-    "Unreviewed"
+    "New Definition"
   ],
   "responseComments": [
     {
       "tag": "welcome",
-      "status": "@alexandercerutti Thank you for submitting this PR!\n\n***This is a live comment which I will keep updated.***\n\n## 1 package in this PR\n\n* `accedo__accedo-one` (*new!*) [on npm](https://www.npmjs.com/package/@accedo/accedo-one), [on unpkg](https://unpkg.com/browse/@accedo/accedo-one@latest/)\n  - 1 added owner: ✎@alexandercerutti\n\n## Code Reviews\n\nThis PR adds a new definition, so it needs to be reviewed by a DT maintainer before it can be merged.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ Only a DT maintainer can approve changes when there are new packages added\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n## Inactive\n\nThis PR has been inactive for 24 days — it is *still* unreviewed!\n\n----------------------\n... diagnostics scrubbed ..."
+      "status": "@alexandercerutti Thank you for submitting this PR!\n\n***This is a live comment which I will keep updated.***\n\n## 1 package in this PR\n\n* `accedo__accedo-one` (*new!*) [on npm](https://www.npmjs.com/package/@accedo/accedo-one), [on unpkg](https://unpkg.com/browse/@accedo/accedo-one@latest/)\n  - 1 added owner: ✎@alexandercerutti\n\n## Code Reviews\n\nThis PR adds a new definition, so it needs to be reviewed by a DT maintainer before it can be merged.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ Only a DT maintainer can approve changes when there are new packages added\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n----------------------\n... diagnostics scrubbed ..."
     },
     {
       "tag": "pinging-reviewers-others",
@@ -17,10 +16,6 @@
     {
       "tag": "stale-ping-61f252-a5285cd",
       "status": "@andrewbranch, @RyanCavanaugh Thank you for reviewing this PR! The author has pushed new commits since your last review. Could you take another look and submit a fresh review?"
-    },
-    {
-      "tag": "Unreviewed:done",
-      "status": "It has been more than two weeks and this PR still has no reviews.\n\nI'll bump it to the DT maintainer queue. Thank you for your patience, @alexandercerutti.\n\n(Ping «anyone?».)"
     }
   ],
   "shouldClose": false,

--- a/src/_tests/fixtures/44282/mutations.json
+++ b/src/_tests/fixtures/44282/mutations.json
@@ -11,11 +11,20 @@
     }
   },
   {
+    "query": "mutation($input: MoveProjectCardInput!) { moveProjectCard(input: $input) { clientMutationId } }",
+    "variables": {
+      "input": {
+        "cardId": "MDExOlByb2plY3RDYXJkMzcxMzAyNTE=",
+        "columnId": "MDEzOlByb2plY3RDb2x1bW45ODY3MDA2"
+      }
+    }
+  },
+  {
     "query": "mutation($input: UpdateIssueCommentInput!) { updateIssueComment(input: $input) { clientMutationId } }",
     "variables": {
       "input": {
         "id": "MDEyOklzc3VlQ29tbWVudDYyMDI4OTg3OA==",
-        "body": "@fishcharlie Thank you for submitting this PR! I see this is your first time submitting to DefinitelyTyped 👋 — I'm the local bot who will help you through the process of getting things through.\n\n***This is a live comment which I will keep updated.***\n\n## 1 package in this PR\n\n* `benchmark` [on npm](https://www.npmjs.com/package/benchmark), [on unpkg](https://unpkg.com/browse/benchmark@latest/)\n  - 1 added owner: ✎@fishcharlie\n\n## Code Reviews\n\nBecause you edited one package and updated the tests (👏), I can help you merge this PR once someone else signs off on it.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ Most recent commit is approved by type definition owners, DT maintainers or others\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n----------------------\n... diagnostics scrubbed ...\n<!--typescript_bot_welcome-->"
+        "body": "@fishcharlie Thank you for submitting this PR! I see this is your first time submitting to DefinitelyTyped 👋 — I'm the local bot who will help you through the process of getting things through.\n\n***This is a live comment which I will keep updated.***\n\n## 1 package in this PR\n\n* `benchmark` [on npm](https://www.npmjs.com/package/benchmark), [on unpkg](https://unpkg.com/browse/benchmark@latest/)\n  - 1 added owner: ✎@fishcharlie\n\n## Code Reviews\n\nThere aren't any other owners of this package, so a DT maintainer will review it.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ A DT maintainer can merge changes when there are no other reviewers\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n----------------------\n... diagnostics scrubbed ...\n<!--typescript_bot_welcome-->"
       }
     }
   },

--- a/src/_tests/fixtures/44282/result.json
+++ b/src/_tests/fixtures/44282/result.json
@@ -1,6 +1,6 @@
 {
   "pr_number": 44282,
-  "targetColumn": "Waiting for Code Reviews",
+  "targetColumn": "Needs Maintainer Action",
   "labels": [
     "Edits Owners",
     "No Other Owners"
@@ -8,7 +8,7 @@
   "responseComments": [
     {
       "tag": "welcome",
-      "status": "@fishcharlie Thank you for submitting this PR! I see this is your first time submitting to DefinitelyTyped 👋 — I'm the local bot who will help you through the process of getting things through.\n\n***This is a live comment which I will keep updated.***\n\n## 1 package in this PR\n\n* `benchmark` [on npm](https://www.npmjs.com/package/benchmark), [on unpkg](https://unpkg.com/browse/benchmark@latest/)\n  - 1 added owner: ✎@fishcharlie\n\n## Code Reviews\n\nBecause you edited one package and updated the tests (👏), I can help you merge this PR once someone else signs off on it.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ Most recent commit is approved by type definition owners, DT maintainers or others\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n----------------------\n... diagnostics scrubbed ..."
+      "status": "@fishcharlie Thank you for submitting this PR! I see this is your first time submitting to DefinitelyTyped 👋 — I'm the local bot who will help you through the process of getting things through.\n\n***This is a live comment which I will keep updated.***\n\n## 1 package in this PR\n\n* `benchmark` [on npm](https://www.npmjs.com/package/benchmark), [on unpkg](https://unpkg.com/browse/benchmark@latest/)\n  - 1 added owner: ✎@fishcharlie\n\n## Code Reviews\n\nThere aren't any other owners of this package, so a DT maintainer will review it.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ A DT maintainer can merge changes when there are no other reviewers\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n----------------------\n... diagnostics scrubbed ..."
     },
     {
       "tag": "pinging-reviewers-others",

--- a/src/_tests/fixtures/49548/mutations.json
+++ b/src/_tests/fixtures/49548/mutations.json
@@ -1,12 +1,10 @@
 [
   {
-    "query": "mutation($input: AddLabelsToLabelableInput!) { addLabelsToLabelable(input: $input) { clientMutationId } }",
+    "query": "mutation($input: MoveProjectCardInput!) { moveProjectCard(input: $input) { clientMutationId } }",
     "variables": {
       "input": {
-        "labelIds": [
-          "MDU6TGFiZWwyNDYyODA0MzE1"
-        ],
-        "labelableId": "MDExOlB1bGxSZXF1ZXN0NTIwODA1MjIx"
+        "cardId": "MDExOlByb2plY3RDYXJkNDkzMjE3NzM=",
+        "columnId": "MDEzOlByb2plY3RDb2x1bW45ODY3MDA2"
       }
     }
   },
@@ -15,16 +13,7 @@
     "variables": {
       "input": {
         "id": "MDEyOklzc3VlQ29tbWVudDcyNjk4OTM0NQ==",
-        "body": "@concision Thank you for submitting this PR! I see this is your first time submitting to DefinitelyTyped 👋 — I'm the local bot who will help you through the process of getting things through.\n\n***This is a live comment which I will keep updated.***\n\n## 1 package in this PR\n\n* `gulp-sourcemaps` [on npm](https://www.npmjs.com/package/gulp-sourcemaps), [on unpkg](https://unpkg.com/browse/gulp-sourcemaps@latest/)\n  - 2 added owners: @pspeter3, ✎@concision\n\n## Code Reviews\n\nBecause you edited one package and updated the tests (👏), I can help you merge this PR once someone else signs off on it.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ Most recent commit is approved by type definition owners, DT maintainers or others\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n## Inactive\n\nThis PR has been inactive for 14 days — please try to get reviewers!\n\n----------------------\n... diagnostics scrubbed ...\n<!--typescript_bot_welcome-->"
-      }
-    }
-  },
-  {
-    "query": "mutation($input: AddCommentInput!) { addComment(input: $input) { clientMutationId } }",
-    "variables": {
-      "input": {
-        "subjectId": "MDExOlB1bGxSZXF1ZXN0NTIwODA1MjIx",
-        "body": "Re-ping «anyone?»:\n\nThis PR has been out for over a week, yet I haven't seen any reviews.\n\nCould someone please give it some attention? Thanks!\n<!--typescript_bot_Unreviewed:nearly:2020-11-16-->"
+        "body": "@concision Thank you for submitting this PR! I see this is your first time submitting to DefinitelyTyped 👋 — I'm the local bot who will help you through the process of getting things through.\n\n***This is a live comment which I will keep updated.***\n\n## 1 package in this PR\n\n* `gulp-sourcemaps` [on npm](https://www.npmjs.com/package/gulp-sourcemaps), [on unpkg](https://unpkg.com/browse/gulp-sourcemaps@latest/)\n  - 2 added owners: @pspeter3, ✎@concision\n\n## Code Reviews\n\nThere aren't any other owners of this package, so a DT maintainer will review it.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ A DT maintainer can merge changes when there are no other reviewers\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n----------------------\n... diagnostics scrubbed ...\n<!--typescript_bot_welcome-->"
       }
     }
   }

--- a/src/_tests/fixtures/49548/result.json
+++ b/src/_tests/fixtures/49548/result.json
@@ -1,23 +1,18 @@
 {
   "pr_number": 49548,
-  "targetColumn": "Waiting for Code Reviews",
+  "targetColumn": "Needs Maintainer Action",
   "labels": [
     "Edits Owners",
-    "No Other Owners",
-    "Unreviewed"
+    "No Other Owners"
   ],
   "responseComments": [
     {
       "tag": "welcome",
-      "status": "@concision Thank you for submitting this PR! I see this is your first time submitting to DefinitelyTyped 👋 — I'm the local bot who will help you through the process of getting things through.\n\n***This is a live comment which I will keep updated.***\n\n## 1 package in this PR\n\n* `gulp-sourcemaps` [on npm](https://www.npmjs.com/package/gulp-sourcemaps), [on unpkg](https://unpkg.com/browse/gulp-sourcemaps@latest/)\n  - 2 added owners: @pspeter3, ✎@concision\n\n## Code Reviews\n\nBecause you edited one package and updated the tests (👏), I can help you merge this PR once someone else signs off on it.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ Most recent commit is approved by type definition owners, DT maintainers or others\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n## Inactive\n\nThis PR has been inactive for 14 days — please try to get reviewers!\n\n----------------------\n... diagnostics scrubbed ..."
+      "status": "@concision Thank you for submitting this PR! I see this is your first time submitting to DefinitelyTyped 👋 — I'm the local bot who will help you through the process of getting things through.\n\n***This is a live comment which I will keep updated.***\n\n## 1 package in this PR\n\n* `gulp-sourcemaps` [on npm](https://www.npmjs.com/package/gulp-sourcemaps), [on unpkg](https://unpkg.com/browse/gulp-sourcemaps@latest/)\n  - 2 added owners: @pspeter3, ✎@concision\n\n## Code Reviews\n\nThere aren't any other owners of this package, so a DT maintainer will review it.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ A DT maintainer can merge changes when there are no other reviewers\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n----------------------\n... diagnostics scrubbed ..."
     },
     {
       "tag": "pinging-reviewers-others",
       "status": "🔔 @concision — you're the only owner, but it would still be good if you find someone to [review this PR](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/49548/files) in the next few days, otherwise a maintainer will look at it. (And if you do find someone, maybe even recruit them to be a second owner to make future changes easier...)"
-    },
-    {
-      "tag": "Unreviewed:nearly:2020-11-16",
-      "status": "Re-ping «anyone?»:\n\nThis PR has been out for over a week, yet I haven't seen any reviews.\n\nCould someone please give it some attention? Thanks!"
     }
   ],
   "shouldClose": false,

--- a/src/comments.ts
+++ b/src/comments.ts
@@ -83,28 +83,38 @@ export const StalenessExplanations: { [k: string]: string } = {
 };
 
 // Comments to post for the staleness timeline (the tag is computed in `makeStaleness`)
-export const StalenessComment = (author: string, otherOwners: string[]) => {
-    const owners = otherOwners.length === 0 ? "«anyone?»" : otherOwners.map(o => "@"+o).join(", ");
-    return {
-        // --Unmerged--
-        "Unmerged:nearly": `Re-ping @${author} / ${owners}:
+const allOwners = (otherOwners: string[]) => {
+    if (otherOwners.length > 0) return otherOwners.map(o => "@"+o).join(", ");
+    // report an error, but don't fail (which would make it worse)
+    console.error("  *** Possible internal error: no `otherOwners` to ping!");
+    return "«anyone?»";
+};
+export const StalenessComment: { [k: string]: ((author: string, otherOwners: string[]) => string) | undefined } = {
+    // --Unmerged--
+    "Unmerged:nearly": (author: string, otherOwners: string[]) =>
+        `Re-ping @${author} / ${allOwners(otherOwners)}:
 
 This PR has been ready to merge for over a week, and I haven't seen any requests to merge it. I will close it in three weeks if this doesn't happen.
 
 (Note that posting a comment will restart the month-timer again, so avoid doing that if you don't want me to nag you again... or you can just close it or turn it into a draft now.)`,
-        "Unmerged:done": `After a month, no one has requested merging the PR 😞. I'm going to assume that the change is not wanted after all, and will therefore close it.`,
-        // --Abandoned--
-        "Abandoned:nearly": `@${author} I haven't seen any activity on this PR in more than three weeks, and it still has problems that prevent it from being merged. The PR will be closed in a week if the issues aren't addressed.`,
-        "Abandoned:done": `@${author} To keep things tidy, we have to close PRs that aren't mergeable and don't have activity in the last month. No worries, though — please open a new PR if you'd like to continue with this change. Thank you!`,
-        // --Unreviewed--
-        "Unreviewed:nearly": `Re-ping ${owners}:
+    "Unmerged:done": (_author: string, _otherOwners: string[]) =>
+        `After a month, no one has requested merging the PR 😞. I'm going to assume that the change is not wanted after all, and will therefore close it.`,
+    // --Abandoned--
+    "Abandoned:nearly": (author: string, _otherOwners: string[]) =>
+        `@${author} I haven't seen any activity on this PR in more than three weeks, and it still has problems that prevent it from being merged. The PR will be closed in a week if the issues aren't addressed.`,
+    "Abandoned:done": (author: string, _otherOwners: string[]) =>
+        `@${author} To keep things tidy, we have to close PRs that aren't mergeable and don't have activity in the last month. No worries, though — please open a new PR if you'd like to continue with this change. Thank you!`,
+    // --Unreviewed--
+    "Unreviewed:nearly": (_author: string, otherOwners: string[]) =>
+        `Re-ping ${allOwners(otherOwners)}:
 
 This PR has been out for over a week, yet I haven't seen any reviews.
 
 Could someone please give it some attention? Thanks!`,
-        "Unreviewed:done": `It has been more than two weeks and this PR still has no reviews.
+    "Unreviewed:done": (author: string, otherOwners: string[]) =>
+        `It has been more than two weeks and this PR still has no reviews.
 
 I'll bump it to the DT maintainer queue. Thank you for your patience, @${author}.
 
-(Ping ${owners}.)`} as { [k: string]: string };
+(Ping ${allOwners(otherOwners)}.)`
 };

--- a/src/compute-pr-actions.ts
+++ b/src/compute-pr-actions.ts
@@ -149,8 +149,8 @@ function extendPrInfo(info: PrInfo): ExtendedPrInfo {
     const hasTests = info.pkgInfo.some(p => p.files.some(f => f.kind === "test"));
     const newPackages = noNullish(info.pkgInfo.map(p => p.kind === "add" ? p.name : null));
     const hasNewPackages = newPackages.length > 0;
-    const requireMaintainer = editsInfra || editsConfig || hasMultiplePackages || !hasTests || hasNewPackages || tooManyOwners;
-    const blessable = !(hasNewPackages || editsInfra || noOtherOwners);
+    const requireMaintainer = editsInfra || hasNewPackages || noOtherOwners || editsConfig || hasMultiplePackages || !hasTests || tooManyOwners;
+    const blessable = !(editsInfra || hasNewPackages || noOtherOwners);
     const approvedReviews = info.reviews.filter(r => r.type === "approved") as ExtendedPrInfo["approvedReviews"];
     const changereqReviews = info.reviews.filter(r => r.type === "changereq") as ExtendedPrInfo["changereqReviews"];
     const staleReviews = info.reviews.filter(r => r.type === "stale") as ExtendedPrInfo["staleReviews"];
@@ -183,7 +183,7 @@ function extendPrInfo(info: PrInfo): ExtendedPrInfo {
             "Unmerged", info.mergeOfferDate, 4, 9, 30, "CLOSE");
         if (needsAuthorAction) return mkStaleness(
             "Abandoned", info.lastActivityDate, 6, 22, 30, "CLOSE");
-        if (!approved) return mkStaleness(
+        if (!approved && !(requireMaintainer && !blessable)) return mkStaleness(
             "Unreviewed", info.lastPushDate, 6, 10, 17, "Needs Maintainer Action");
         return undefined;
     }
@@ -210,9 +210,7 @@ function extendPrInfo(info: PrInfo): ExtendedPrInfo {
             : info.popularityLevel === "Critical" ? "maintainer"
             : undefined;
         if (!who) throw new Error("Unknown popularity level " + info.popularityLevel);
-        return who === "maintainer" && blessed && !noOtherOwners ? "owner"
-            : who === "owner" && noOtherOwners ? "maintainer"
-            : who;
+        return who === "maintainer" && blessed ? "owner" : who;
     }
 
     function getApproved() {
@@ -384,12 +382,12 @@ function makeStaleness(now: string, author: string, otherOwners: string[]) { // 
         const state = days <= freshDays ? "fresh" : days <= attnDays ? "attention" : days <= nearDays ? "nearly" : "done";
         const kindAndState = `${kind}:${state}`;
         const explanation = Comments.StalenessExplanations[kindAndState];
-        const comment = Comments.StalenessComment(author, otherOwners)[kindAndState];
+        const commentGen = Comments.StalenessComment[kindAndState];
         const doTimelineActions = (context: Actions) => {
-            if (comment !== undefined) {
+            if (commentGen !== undefined) {
                 const tag = state === "done" ? kindAndState
                     : `${kindAndState}:${since.toISOString().replace(/T.*$/, "")}`;
-                context.responseComments.push({ tag, status: comment });
+                context.responseComments.push({ tag, status: commentGen(author, otherOwners) });
             }
             if (state === "done") {
                 if (doneColumn === "CLOSE") {


### PR DESCRIPTION
Two changes:

* The `Unreviewed` timeline needs `!(requireMaintainer && !blessable)`
  to start.

* `noOtherOwners` => `requireMaintainer`.

Also:

* Reorganize the subterms in `blessable` to match `requireMaintainer` so
  the relationship between the two is clearer.

* Change `Comments.StalenessComment` so the index returns a
  function (instead of the other way around), which makes it possible to
  spit out an error line if it uses `otherOwners` and it is empty.

* Add this error to `comments.ts`.  Note that it doesn't throw an
  exception, just prints the error.  This is because if it happens, it's
  not a big problem to mention `«anyone?»`, but it is useful to debug
  such cases (which shouldn't happen, and with this fix they don't).

Fixes the new problem that was raised in #105.