### PR TITLE
Make a way to mark comment tags that should be removed if not in actions

### DIFF
--- a/src/_tests/fixtures/38979/result.json
+++ b/src/_tests/fixtures/38979/result.json
@@ -29,6 +29,5 @@
   "shouldMerge": false,
   "shouldUpdateLabels": true,
   "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false,
-  "isReadyForAutoMerge": false
+  "shouldRemoveFromActiveColumns": false
 }

--- a/src/_tests/fixtures/43136/result.json
+++ b/src/_tests/fixtures/43136/result.json
@@ -22,6 +22,5 @@
   "shouldMerge": false,
   "shouldUpdateLabels": true,
   "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false,
-  "isReadyForAutoMerge": false
+  "shouldRemoveFromActiveColumns": false
 }

--- a/src/_tests/fixtures/43144/result.json
+++ b/src/_tests/fixtures/43144/result.json
@@ -19,6 +19,5 @@
   "shouldMerge": false,
   "shouldUpdateLabels": true,
   "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false,
-  "isReadyForAutoMerge": true
+  "shouldRemoveFromActiveColumns": false
 }

--- a/src/_tests/fixtures/43151/result.json
+++ b/src/_tests/fixtures/43151/result.json
@@ -18,6 +18,5 @@
   "shouldMerge": false,
   "shouldUpdateLabels": true,
   "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false,
-  "isReadyForAutoMerge": false
+  "shouldRemoveFromActiveColumns": false
 }

--- a/src/_tests/fixtures/43160/result.json
+++ b/src/_tests/fixtures/43160/result.json
@@ -20,6 +20,5 @@
   "shouldMerge": false,
   "shouldUpdateLabels": true,
   "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false,
-  "isReadyForAutoMerge": false
+  "shouldRemoveFromActiveColumns": false
 }

--- a/src/_tests/fixtures/43175/result.json
+++ b/src/_tests/fixtures/43175/result.json
@@ -23,6 +23,5 @@
   "shouldMerge": false,
   "shouldUpdateLabels": true,
   "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false,
-  "isReadyForAutoMerge": false
+  "shouldRemoveFromActiveColumns": false
 }

--- a/src/_tests/fixtures/43235/result.json
+++ b/src/_tests/fixtures/43235/result.json
@@ -16,6 +16,5 @@
   "shouldMerge": false,
   "shouldUpdateLabels": true,
   "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false,
-  "isReadyForAutoMerge": false
+  "shouldRemoveFromActiveColumns": false
 }

--- a/src/_tests/fixtures/43314/result.json
+++ b/src/_tests/fixtures/43314/result.json
@@ -18,6 +18,5 @@
   "shouldMerge": false,
   "shouldUpdateLabels": true,
   "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false,
-  "isReadyForAutoMerge": false
+  "shouldRemoveFromActiveColumns": false
 }

--- a/src/_tests/fixtures/43695-duplicate-comment/result.json
+++ b/src/_tests/fixtures/43695-duplicate-comment/result.json
@@ -27,6 +27,5 @@
   "shouldMerge": false,
   "shouldUpdateLabels": true,
   "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false,
-  "isReadyForAutoMerge": false
+  "shouldRemoveFromActiveColumns": false
 }

--- a/src/_tests/fixtures/43695-post-review/result.json
+++ b/src/_tests/fixtures/43695-post-review/result.json
@@ -19,6 +19,5 @@
   "shouldMerge": false,
   "shouldUpdateLabels": true,
   "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false,
-  "isReadyForAutoMerge": false
+  "shouldRemoveFromActiveColumns": false
 }

--- a/src/_tests/fixtures/43695/result.json
+++ b/src/_tests/fixtures/43695/result.json
@@ -19,6 +19,5 @@
   "shouldMerge": false,
   "shouldUpdateLabels": true,
   "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false,
-  "isReadyForAutoMerge": false
+  "shouldRemoveFromActiveColumns": false
 }

--- a/src/_tests/fixtures/43960-post-close/result.json
+++ b/src/_tests/fixtures/43960-post-close/result.json
@@ -6,6 +6,5 @@
   "shouldMerge": false,
   "shouldUpdateLabels": false,
   "shouldUpdateProjectColumn": false,
-  "shouldRemoveFromActiveColumns": true,
-  "isReadyForAutoMerge": false
+  "shouldRemoveFromActiveColumns": true
 }

--- a/src/_tests/fixtures/43960/result.json
+++ b/src/_tests/fixtures/43960/result.json
@@ -19,6 +19,5 @@
   "shouldMerge": false,
   "shouldUpdateLabels": true,
   "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false,
-  "isReadyForAutoMerge": false
+  "shouldRemoveFromActiveColumns": false
 }

--- a/src/_tests/fixtures/44105/result.json
+++ b/src/_tests/fixtures/44105/result.json
@@ -6,6 +6,5 @@
   "shouldMerge": false,
   "shouldUpdateLabels": false,
   "shouldUpdateProjectColumn": false,
-  "shouldRemoveFromActiveColumns": true,
-  "isReadyForAutoMerge": false
+  "shouldRemoveFromActiveColumns": true
 }

--- a/src/_tests/fixtures/44256/result.json
+++ b/src/_tests/fixtures/44256/result.json
@@ -6,6 +6,5 @@
   "shouldMerge": false,
   "shouldUpdateLabels": false,
   "shouldUpdateProjectColumn": false,
-  "shouldRemoveFromActiveColumns": true,
-  "isReadyForAutoMerge": false
+  "shouldRemoveFromActiveColumns": true
 }

--- a/src/_tests/fixtures/44267/result.json
+++ b/src/_tests/fixtures/44267/result.json
@@ -15,6 +15,5 @@
   "shouldMerge": false,
   "shouldUpdateLabels": true,
   "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false,
-  "isReadyForAutoMerge": false
+  "shouldRemoveFromActiveColumns": false
 }

--- a/src/_tests/fixtures/44282/result.json
+++ b/src/_tests/fixtures/44282/result.json
@@ -19,6 +19,5 @@
   "shouldMerge": false,
   "shouldUpdateLabels": true,
   "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false,
-  "isReadyForAutoMerge": false
+  "shouldRemoveFromActiveColumns": false
 }

--- a/src/_tests/fixtures/44288/result.json
+++ b/src/_tests/fixtures/44288/result.json
@@ -16,6 +16,5 @@
   "shouldMerge": false,
   "shouldUpdateLabels": true,
   "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false,
-  "isReadyForAutoMerge": false
+  "shouldRemoveFromActiveColumns": false
 }

--- a/src/_tests/fixtures/44290/result.json
+++ b/src/_tests/fixtures/44290/result.json
@@ -7,6 +7,5 @@
   "shouldUpdateLabels": false,
   "shouldUpdateProjectColumn": true,
   "shouldRemoveFromActiveColumns": false,
-  "isReadyForAutoMerge": false,
   "targetColumn": "Needs Author Action"
 }

--- a/src/_tests/fixtures/44299-with-files/result.json
+++ b/src/_tests/fixtures/44299-with-files/result.json
@@ -18,6 +18,5 @@
   "shouldMerge": false,
   "shouldUpdateLabels": true,
   "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false,
-  "isReadyForAutoMerge": false
+  "shouldRemoveFromActiveColumns": false
 }

--- a/src/_tests/fixtures/44299/result.json
+++ b/src/_tests/fixtures/44299/result.json
@@ -18,6 +18,5 @@
   "shouldMerge": false,
   "shouldUpdateLabels": true,
   "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false,
-  "isReadyForAutoMerge": false
+  "shouldRemoveFromActiveColumns": false
 }

--- a/src/_tests/fixtures/44316/result.json
+++ b/src/_tests/fixtures/44316/result.json
@@ -20,6 +20,5 @@
   "shouldMerge": false,
   "shouldUpdateLabels": true,
   "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false,
-  "isReadyForAutoMerge": false
+  "shouldRemoveFromActiveColumns": false
 }

--- a/src/_tests/fixtures/44343-pending-travis/result.json
+++ b/src/_tests/fixtures/44343-pending-travis/result.json
@@ -16,6 +16,5 @@
   "shouldMerge": false,
   "shouldUpdateLabels": false,
   "shouldUpdateProjectColumn": false,
-  "shouldRemoveFromActiveColumns": false,
-  "isReadyForAutoMerge": false
+  "shouldRemoveFromActiveColumns": false
 }

--- a/src/_tests/fixtures/44343-pre-travis/result.json
+++ b/src/_tests/fixtures/44343-pre-travis/result.json
@@ -16,6 +16,5 @@
   "shouldMerge": false,
   "shouldUpdateLabels": false,
   "shouldUpdateProjectColumn": false,
-  "shouldRemoveFromActiveColumns": false,
-  "isReadyForAutoMerge": false
+  "shouldRemoveFromActiveColumns": false
 }

--- a/src/_tests/fixtures/44343/result.json
+++ b/src/_tests/fixtures/44343/result.json
@@ -16,6 +16,5 @@
   "shouldMerge": false,
   "shouldUpdateLabels": true,
   "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false,
-  "isReadyForAutoMerge": false
+  "shouldRemoveFromActiveColumns": false
 }

--- a/src/_tests/fixtures/44402/result.json
+++ b/src/_tests/fixtures/44402/result.json
@@ -9,6 +9,5 @@
   "shouldUpdateLabels": true,
   "shouldUpdateProjectColumn": true,
   "shouldRemoveFromActiveColumns": false,
-  "isReadyForAutoMerge": false,
   "targetColumn": "Needs Maintainer Action"
 }

--- a/src/_tests/fixtures/44411/result.json
+++ b/src/_tests/fixtures/44411/result.json
@@ -19,6 +19,5 @@
   "shouldMerge": false,
   "shouldUpdateLabels": true,
   "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false,
-  "isReadyForAutoMerge": false
+  "shouldRemoveFromActiveColumns": false
 }

--- a/src/_tests/fixtures/44424-1-travis-instantly-finished/result.json
+++ b/src/_tests/fixtures/44424-1-travis-instantly-finished/result.json
@@ -19,6 +19,5 @@
   "shouldMerge": false,
   "shouldUpdateLabels": true,
   "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false,
-  "isReadyForAutoMerge": false
+  "shouldRemoveFromActiveColumns": false
 }

--- a/src/_tests/fixtures/44424-2-after-travis-second/result.json
+++ b/src/_tests/fixtures/44424-2-after-travis-second/result.json
@@ -19,6 +19,5 @@
   "shouldMerge": false,
   "shouldUpdateLabels": true,
   "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false,
-  "isReadyForAutoMerge": false
+  "shouldRemoveFromActiveColumns": false
 }

--- a/src/_tests/fixtures/44437/result.json
+++ b/src/_tests/fixtures/44437/result.json
@@ -21,6 +21,5 @@
   "shouldMerge": false,
   "shouldUpdateLabels": true,
   "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false,
-  "isReadyForAutoMerge": true
+  "shouldRemoveFromActiveColumns": false
 }

--- a/src/_tests/fixtures/44439/result.json
+++ b/src/_tests/fixtures/44439/result.json
@@ -19,6 +19,5 @@
   "shouldMerge": false,
   "shouldUpdateLabels": true,
   "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false,
-  "isReadyForAutoMerge": false
+  "shouldRemoveFromActiveColumns": false
 }

--- a/src/_tests/fixtures/44631/result.json
+++ b/src/_tests/fixtures/44631/result.json
@@ -19,6 +19,5 @@
   "shouldMerge": false,
   "shouldUpdateLabels": true,
   "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false,
-  "isReadyForAutoMerge": false
+  "shouldRemoveFromActiveColumns": false
 }

--- a/src/_tests/fixtures/44857/result.json
+++ b/src/_tests/fixtures/44857/result.json
@@ -28,6 +28,5 @@
   "shouldMerge": false,
   "shouldUpdateLabels": true,
   "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false,
-  "isReadyForAutoMerge": false
+  "shouldRemoveFromActiveColumns": false
 }

--- a/src/_tests/fixtures/44989-14days/result.json
+++ b/src/_tests/fixtures/44989-14days/result.json
@@ -25,6 +25,5 @@
   "shouldMerge": false,
   "shouldUpdateLabels": true,
   "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false,
-  "isReadyForAutoMerge": true
+  "shouldRemoveFromActiveColumns": false
 }

--- a/src/_tests/fixtures/44989-32days/result.json
+++ b/src/_tests/fixtures/44989-32days/result.json
@@ -25,6 +25,5 @@
   "shouldMerge": false,
   "shouldUpdateLabels": true,
   "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": true,
-  "isReadyForAutoMerge": true
+  "shouldRemoveFromActiveColumns": true
 }

--- a/src/_tests/fixtures/44989-3days/result.json
+++ b/src/_tests/fixtures/44989-3days/result.json
@@ -20,6 +20,5 @@
   "shouldMerge": false,
   "shouldUpdateLabels": true,
   "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false,
-  "isReadyForAutoMerge": true
+  "shouldRemoveFromActiveColumns": false
 }

--- a/src/_tests/fixtures/44989-7days/result.json
+++ b/src/_tests/fixtures/44989-7days/result.json
@@ -20,6 +20,5 @@
   "shouldMerge": false,
   "shouldUpdateLabels": true,
   "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false,
-  "isReadyForAutoMerge": true
+  "shouldRemoveFromActiveColumns": false
 }

--- a/src/_tests/fixtures/45137/result.json
+++ b/src/_tests/fixtures/45137/result.json
@@ -18,6 +18,5 @@
   "shouldMerge": false,
   "shouldUpdateLabels": true,
   "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false,
-  "isReadyForAutoMerge": false
+  "shouldRemoveFromActiveColumns": false
 }

--- a/src/_tests/fixtures/45627/mutations.json
+++ b/src/_tests/fixtures/45627/mutations.json
@@ -30,6 +30,15 @@
     }
   },
   {
+    "query": "mutation($input: UpdateIssueCommentInput!) { updateIssueComment(input: $input) { clientMutationId } }",
+    "variables": {
+      "input": {
+        "id": "MDEyOklzc3VlQ29tbWVudDYyMTU1OTExNA==",
+        "body": "@spamshaker Everything looks good here. Great job! I am ready to merge this PR (at 15facc1) on your behalf.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n\n(@tkqubo, @bumbleblym, @bcherny, @tommytroylin, @mohsen1, @jcreamer898, @alan-agius4, @dennispg, @christophehurpeau, @ZSkycat, @johnnyreilly, @rwaskiewicz, @kuehlein, @grgur, @rubenspgcavalcante, @andersk, @ofhouse, @danielthank, @sasurau4, @dionshihk, @peterblazejewicz: you can do this too.)\n<!--typescript_bot_merge-offer-->"
+      }
+    }
+  },
+  {
     "query": "mutation($input: AddCommentInput!) { addComment(input: $input) { clientMutationId } }",
     "variables": {
       "input": {

--- a/src/_tests/fixtures/45627/result.json
+++ b/src/_tests/fixtures/45627/result.json
@@ -15,6 +15,10 @@
       "status": "@spamshaker Thank you for submitting this PR!\n\n***This is a live comment which I will keep updated.***\n\nThis PR doesn't modify any tests, so it's hard to know what's being fixed, and your changes might regress in the future. Have you considered [adding tests](https://github.com/DefinitelyTyped/DefinitelyTyped#testing) to cover the change you're making? Including tests allows this PR to be merged by yourself and the owners of this module. This can potentially save days of time for you.\n\n## 1 package in this PR\n\n* `webpack` [on npm](https://www.npmjs.com/package/webpack), [on unpkg](https://unpkg.com/browse/webpack@latest/)\n  - owner-approval: @ofhouse\n  - 1 added owner: ✎@spamshaker\n\n@spamshaker: I see that you have added yourself as an owner, are you sure you want to [become an owner](https://github.com/DefinitelyTyped/DefinitelyTyped#definition-owners)?\n\n## Code Reviews\n\nThis PR can be merged once it's reviewed.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ✅ Most recent commit is approved by type definition owners or DT maintainers\n\nAll of the items on the list are green. **To merge, you need to post a comment including the string \"Ready to merge\"** to bring in your changes.\n\n## Inactive\n\nThis PR has been inactive for 67 days — waiting for a DT maintainer!\n\n----------------------\n... diagnostics scrubbed ..."
     },
     {
+      "tag": "merge-offer",
+      "status": "@spamshaker Everything looks good here. Great job! I am ready to merge this PR (at 15facc1) on your behalf.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n\n(@tkqubo, @bumbleblym, @bcherny, @tommytroylin, @mohsen1, @jcreamer898, @alan-agius4, @dennispg, @christophehurpeau, @ZSkycat, @johnnyreilly, @rwaskiewicz, @kuehlein, @grgur, @rubenspgcavalcante, @andersk, @ofhouse, @danielthank, @sasurau4, @dionshihk, @peterblazejewicz: you can do this too.)"
+    },
+    {
       "tag": "Unmerged:done",
       "status": "After a month, no one has requested merging the PR 😞. I'm going to assume that the change is not wanted after all, and will therefore close it."
     }
@@ -23,6 +27,5 @@
   "shouldMerge": true,
   "shouldUpdateLabels": true,
   "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": true,
-  "isReadyForAutoMerge": true
+  "shouldRemoveFromActiveColumns": true
 }

--- a/src/_tests/fixtures/45836/result.json
+++ b/src/_tests/fixtures/45836/result.json
@@ -20,6 +20,5 @@
   "shouldMerge": false,
   "shouldUpdateLabels": true,
   "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false,
-  "isReadyForAutoMerge": false
+  "shouldRemoveFromActiveColumns": false
 }

--- a/src/_tests/fixtures/45884/result.json
+++ b/src/_tests/fixtures/45884/result.json
@@ -20,6 +20,5 @@
   "shouldMerge": false,
   "shouldUpdateLabels": true,
   "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false,
-  "isReadyForAutoMerge": true
+  "shouldRemoveFromActiveColumns": false
 }

--- a/src/_tests/fixtures/45888/result.json
+++ b/src/_tests/fixtures/45888/result.json
@@ -19,6 +19,5 @@
   "shouldMerge": false,
   "shouldUpdateLabels": true,
   "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false,
-  "isReadyForAutoMerge": false
+  "shouldRemoveFromActiveColumns": false
 }

--- a/src/_tests/fixtures/45890/result.json
+++ b/src/_tests/fixtures/45890/result.json
@@ -19,6 +19,5 @@
   "shouldMerge": false,
   "shouldUpdateLabels": true,
   "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false,
-  "isReadyForAutoMerge": false
+  "shouldRemoveFromActiveColumns": false
 }

--- a/src/_tests/fixtures/45946/result.json
+++ b/src/_tests/fixtures/45946/result.json
@@ -20,6 +20,5 @@
   "shouldMerge": false,
   "shouldUpdateLabels": true,
   "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false,
-  "isReadyForAutoMerge": false
+  "shouldRemoveFromActiveColumns": false
 }

--- a/src/_tests/fixtures/45982/result.json
+++ b/src/_tests/fixtures/45982/result.json
@@ -14,6 +14,5 @@
   "shouldMerge": false,
   "shouldUpdateLabels": true,
   "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false,
-  "isReadyForAutoMerge": false
+  "shouldRemoveFromActiveColumns": false
 }

--- a/src/_tests/fixtures/45999/result.json
+++ b/src/_tests/fixtures/45999/result.json
@@ -20,6 +20,5 @@
   "shouldMerge": false,
   "shouldUpdateLabels": true,
   "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false,
-  "isReadyForAutoMerge": true
+  "shouldRemoveFromActiveColumns": false
 }

--- a/src/_tests/fixtures/46008/result.json
+++ b/src/_tests/fixtures/46008/result.json
@@ -20,6 +20,5 @@
   "shouldMerge": false,
   "shouldUpdateLabels": true,
   "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false,
-  "isReadyForAutoMerge": true
+  "shouldRemoveFromActiveColumns": false
 }

--- a/src/_tests/fixtures/46019/result.json
+++ b/src/_tests/fixtures/46019/result.json
@@ -20,6 +20,5 @@
   "shouldMerge": false,
   "shouldUpdateLabels": true,
   "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false,
-  "isReadyForAutoMerge": true
+  "shouldRemoveFromActiveColumns": false
 }

--- a/src/_tests/fixtures/46120/result.json
+++ b/src/_tests/fixtures/46120/result.json
@@ -25,6 +25,5 @@
   "shouldMerge": false,
   "shouldUpdateLabels": true,
   "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false,
-  "isReadyForAutoMerge": true
+  "shouldRemoveFromActiveColumns": false
 }

--- a/src/_tests/fixtures/46191/result.json
+++ b/src/_tests/fixtures/46191/result.json
@@ -24,6 +24,5 @@
   "shouldMerge": false,
   "shouldUpdateLabels": true,
   "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false,
-  "isReadyForAutoMerge": false
+  "shouldRemoveFromActiveColumns": false
 }

--- a/src/_tests/fixtures/46196/result.json
+++ b/src/_tests/fixtures/46196/result.json
@@ -16,6 +16,5 @@
   "shouldMerge": false,
   "shouldUpdateLabels": true,
   "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false,
-  "isReadyForAutoMerge": false
+  "shouldRemoveFromActiveColumns": false
 }

--- a/src/_tests/fixtures/46279/result.json
+++ b/src/_tests/fixtures/46279/result.json
@@ -20,6 +20,5 @@
   "shouldMerge": false,
   "shouldUpdateLabels": true,
   "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false,
-  "isReadyForAutoMerge": false
+  "shouldRemoveFromActiveColumns": false
 }

--- a/src/_tests/fixtures/46804/result.json
+++ b/src/_tests/fixtures/46804/result.json
@@ -18,6 +18,5 @@
   "shouldMerge": false,
   "shouldUpdateLabels": true,
   "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false,
-  "isReadyForAutoMerge": false
+  "shouldRemoveFromActiveColumns": false
 }

--- a/src/_tests/fixtures/46879/result.json
+++ b/src/_tests/fixtures/46879/result.json
@@ -18,6 +18,5 @@
   "shouldMerge": false,
   "shouldUpdateLabels": true,
   "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false,
-  "isReadyForAutoMerge": false
+  "shouldRemoveFromActiveColumns": false
 }

--- a/src/_tests/fixtures/47017-blessed-and-one-owner/result.json
+++ b/src/_tests/fixtures/47017-blessed-and-one-owner/result.json
@@ -15,6 +15,5 @@
   "shouldMerge": false,
   "shouldUpdateLabels": true,
   "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false,
-  "isReadyForAutoMerge": false
+  "shouldRemoveFromActiveColumns": false
 }

--- a/src/_tests/fixtures/47017-blessed-and-two-owner/result.json
+++ b/src/_tests/fixtures/47017-blessed-and-two-owner/result.json
@@ -21,6 +21,5 @@
   "shouldMerge": false,
   "shouldUpdateLabels": true,
   "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false,
-  "isReadyForAutoMerge": true
+  "shouldRemoveFromActiveColumns": false
 }

--- a/src/_tests/fixtures/47017-blessed/result.json
+++ b/src/_tests/fixtures/47017-blessed/result.json
@@ -19,6 +19,5 @@
   "shouldMerge": false,
   "shouldUpdateLabels": true,
   "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false,
-  "isReadyForAutoMerge": false
+  "shouldRemoveFromActiveColumns": false
 }

--- a/src/_tests/fixtures/47017/result.json
+++ b/src/_tests/fixtures/47017/result.json
@@ -19,6 +19,5 @@
   "shouldMerge": false,
   "shouldUpdateLabels": true,
   "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false,
-  "isReadyForAutoMerge": false
+  "shouldRemoveFromActiveColumns": false
 }

--- a/src/_tests/fixtures/48216/result.json
+++ b/src/_tests/fixtures/48216/result.json
@@ -16,6 +16,5 @@
   "shouldMerge": false,
   "shouldUpdateLabels": true,
   "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false,
-  "isReadyForAutoMerge": false
+  "shouldRemoveFromActiveColumns": false
 }

--- a/src/_tests/fixtures/48236/result.json
+++ b/src/_tests/fixtures/48236/result.json
@@ -13,12 +13,15 @@
     {
       "tag": "pinging-reviewers",
       "status": "🔔 @climba03003 — please [review this PR](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/48236/files) in the next few days. Be sure to explicitly select **`Approve`** or **`Request Changes`** in the GitHub UI so I know what's going on."
+    },
+    {
+      "tag": "merge-offer",
+      "status": "@jablko Everything looks good here. Great job! I am ready to merge this PR (at b4d71f6) on your behalf.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n\n(@climba03003: you can do this too.)"
     }
   ],
   "shouldClose": false,
   "shouldMerge": true,
   "shouldUpdateLabels": true,
   "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false,
-  "isReadyForAutoMerge": true
+  "shouldRemoveFromActiveColumns": false
 }

--- a/src/_tests/fixtures/48652-merge-offer/result.json
+++ b/src/_tests/fixtures/48652-merge-offer/result.json
@@ -25,6 +25,5 @@
   "shouldMerge": false,
   "shouldUpdateLabels": true,
   "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false,
-  "isReadyForAutoMerge": true
+  "shouldRemoveFromActiveColumns": false
 }

--- a/src/_tests/fixtures/48652-prereq/result.json
+++ b/src/_tests/fixtures/48652-prereq/result.json
@@ -29,6 +29,5 @@
   "shouldMerge": false,
   "shouldUpdateLabels": true,
   "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false,
-  "isReadyForAutoMerge": true
+  "shouldRemoveFromActiveColumns": false
 }

--- a/src/_tests/fixtures/48652-retract-merge-offer-and-prerequest/result.json
+++ b/src/_tests/fixtures/48652-retract-merge-offer-and-prerequest/result.json
@@ -23,6 +23,5 @@
   "shouldMerge": false,
   "shouldUpdateLabels": true,
   "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false,
-  "isReadyForAutoMerge": false
+  "shouldRemoveFromActiveColumns": false
 }

--- a/src/_tests/fixtures/48652-retract-merge-offer/result.json
+++ b/src/_tests/fixtures/48652-retract-merge-offer/result.json
@@ -19,6 +19,5 @@
   "shouldMerge": false,
   "shouldUpdateLabels": true,
   "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false,
-  "isReadyForAutoMerge": false
+  "shouldRemoveFromActiveColumns": false
 }

--- a/src/_tests/fixtures/48708/result.json
+++ b/src/_tests/fixtures/48708/result.json
@@ -25,6 +25,5 @@
   "shouldMerge": false,
   "shouldUpdateLabels": true,
   "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false,
-  "isReadyForAutoMerge": false
+  "shouldRemoveFromActiveColumns": false
 }

--- a/src/_tests/fixtures/48945/result.json
+++ b/src/_tests/fixtures/48945/result.json
@@ -19,6 +19,5 @@
   "shouldMerge": false,
   "shouldUpdateLabels": true,
   "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false,
-  "isReadyForAutoMerge": false
+  "shouldRemoveFromActiveColumns": false
 }

--- a/src/_tests/fixtures/49417/result.json
+++ b/src/_tests/fixtures/49417/result.json
@@ -24,6 +24,5 @@
   "shouldMerge": false,
   "shouldUpdateLabels": true,
   "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false,
-  "isReadyForAutoMerge": true
+  "shouldRemoveFromActiveColumns": false
 }

--- a/src/_tests/fixtures/49548/result.json
+++ b/src/_tests/fixtures/49548/result.json
@@ -24,6 +24,5 @@
   "shouldMerge": false,
   "shouldUpdateLabels": true,
   "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false,
-  "isReadyForAutoMerge": false
+  "shouldRemoveFromActiveColumns": false
 }

--- a/src/_tests/fixtures/49841/result.json
+++ b/src/_tests/fixtures/49841/result.json
@@ -23,6 +23,5 @@
   "shouldMerge": false,
   "shouldUpdateLabels": true,
   "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false,
-  "isReadyForAutoMerge": false
+  "shouldRemoveFromActiveColumns": false
 }

--- a/src/comments.ts
+++ b/src/comments.ts
@@ -1,5 +1,12 @@
 import { sha256 } from "./util/util";
 
+// use `deletedWhenNotPresent` for comments that should be removed if not in the actions
+export const tagsToDeleteIfNotPosted: string[] = [];
+const deletedWhenNotPresent = <T>(tag: string, f: (tag: string) => T) => {
+    tagsToDeleteIfNotPosted.push(tag);
+    return f(tag);
+};
+
 export type Comment = { tag: string, status: string };
 
 export const HadError = (user: string | undefined, error: string) => ({
@@ -49,10 +56,11 @@ export const PingStaleReviewer = (reviewedAbbrOid: string, reviewers: string[]) 
     status: `@${reviewers.join(", @")} Thank you for reviewing this PR! The author has pushed new commits since your last review. Could you take another look and submit a fresh review?`
 });
 
-export const OfferSelfMerge = (user: string, otherOwners: string[], abbrOid: string) => ({
-    tag: `merge-offer`,
-    // Note: pr-info.ts searches for the `(at ${abbrOid})`
-    status: `@${user} Everything looks good here. Great job! I am ready to merge this PR (at ${abbrOid}) on your behalf.
+export const OfferSelfMerge = deletedWhenNotPresent("merge-offer", tag =>
+    (user: string, otherOwners: string[], abbrOid: string) => ({
+        tag,
+        // Note: pr-info.ts searches for the `(at ${abbrOid})`
+        status: `@${user} Everything looks good here. Great job! I am ready to merge this PR (at ${abbrOid}) on your behalf.
 
 If you'd like that to happen, please post a comment saying:
 
@@ -60,7 +68,7 @@ If you'd like that to happen, please post a comment saying:
 
 and I'll merge this PR almost instantly. Thanks for helping out! :heart:
 ${otherOwners.length === 0 ? "" : `
-(${otherOwners.map(o => "@" + o).join(", ")}: you can do this too.)`}`});
+(${otherOwners.map(o => "@" + o).join(", ")}: you can do this too.)`}`}));
 
 export const WaitUntilMergeIsOK = (user: string, abbrOid: string, uri: string) => ({
     // at most one reminder per update

--- a/src/util/fetchFile.ts
+++ b/src/util/fetchFile.ts
@@ -11,7 +11,7 @@ export async function fetchFile(expr: string, limit?: number): Promise<string | 
           expr: `${expr}`
       }
   });
-  const obj = info.data.repository?.object;
+  const obj = info.data?.repository?.object;
   if (!obj || obj.__typename !== "Blob") return undefined;
   if (!obj) return undefined;
   if (obj.text && limit && obj.text.length > limit) {


### PR DESCRIPTION
Use it instead of `actions.isReadyForAutoMerge`.

Also, a random fix in `fetchFile`: `GetFileContentResult` can be null.