### PR TITLE
Apply input type to JSON output to check safety

### DIFF
--- a/src/_tests/fixturedActions.test.ts
+++ b/src/_tests/fixturedActions.test.ts
@@ -2,7 +2,7 @@ import { readdirSync, readFileSync, lstatSync } from "fs";
 import { join } from "path";
 import { toMatchFile } from "jest-file-snapshot";
 import { process } from "../compute-pr-actions";
-import { deriveStateForPR } from "../pr-info";
+import { deriveStateForPR, BotResult } from "../pr-info";
 import { scrubDiagnosticDetails } from "../util/util";
 import * as cachedQueries from "./cachedQueries.json";
 jest.mock("../util/cachedQueries", () => ({
@@ -38,7 +38,7 @@ async function testFixture(dir: string) {
     response,
     (expr: string) => Promise.resolve(files[expr] as string),
     (name: string, _until?: Date) => name in downloads ? downloads[name] : 0,
-    readJSON(derivedPath).now
+    (readJSON(derivedPath) as BotResult).now
   );
 
   if (derived.type === "fail") throw new Error("Should never happen");

--- a/src/_tests/fixtures/43960-post-close/derived.json
+++ b/src/_tests/fixtures/43960-post-close/derived.json
@@ -1,5 +1,6 @@
 {
   "type": "remove",
+  "now": "2020-04-30T12:01:56-07:00",
   "pr_number": 43960,
   "message": "PR is not active",
   "isDraft": false

--- a/src/_tests/fixtures/44105/derived.json
+++ b/src/_tests/fixtures/44105/derived.json
@@ -1,5 +1,6 @@
 {
   "type": "remove",
+  "now": "2020-04-28T15:49:39-07:00",
   "pr_number": 44105,
   "message": "PR is not active",
   "isDraft": false

--- a/src/_tests/fixtures/44256/derived.json
+++ b/src/_tests/fixtures/44256/derived.json
@@ -1,5 +1,6 @@
 {
   "type": "remove",
+  "now": "2020-04-30T12:07:55-07:00",
   "pr_number": 44256,
   "message": "PR is not active",
   "isDraft": false

--- a/src/_tests/fixtures/44290/derived.json
+++ b/src/_tests/fixtures/44290/derived.json
@@ -1,5 +1,6 @@
 {
   "type": "remove",
+  "now": "2020-04-28T12:41:44-04:00",
   "pr_number": 44290,
   "message": "PR is a draft",
   "isDraft": true

--- a/src/commands/create-fixture.ts
+++ b/src/commands/create-fixture.ts
@@ -1,5 +1,5 @@
 import * as computeActions from "../compute-pr-actions";
-import { deriveStateForPR, queryPRInfo } from "../pr-info";
+import { deriveStateForPR, BotResult, queryPRInfo } from "../pr-info";
 import { writeFileSync, mkdirSync, existsSync, readFileSync } from "fs";
 import { join } from "path";
 import { fetchFile } from "../util/fetchFile";
@@ -79,7 +79,7 @@ export default async function main(directory: string, overwriteInfo: boolean) {
   }
 
   function getTimeFromFile() {
-    return JSON.parse(readFileSync(derivedFixturePath, "utf8")).now;
+    return (JSON.parse(readFileSync(derivedFixturePath, "utf8")) as BotResult).now;
   }
 }
 

--- a/src/compute-pr-actions.ts
+++ b/src/compute-pr-actions.ts
@@ -1,6 +1,6 @@
 import * as Comments from "./comments";
 import * as urls from "./urls";
-import { PrInfo, BotError, BotEnsureRemovedFromProject, FileInfo } from "./pr-info";
+import { PrInfo, BotNotFail, FileInfo } from "./pr-info";
 import { CIResult } from "./util/CIResult";
 import { ReviewInfo } from "./pr-info";
 import { noNullish, flatten, unique, sameUser, daysSince, sha256 } from "./util/util";
@@ -232,7 +232,7 @@ function extendPrInfo(info: PrInfo): ExtendedPrInfo {
 
 }
 
-export function process(prInfo: PrInfo | BotEnsureRemovedFromProject | BotError,
+export function process(prInfo: BotNotFail,
                         extendedCallback: (info: ExtendedPrInfo) => void = _i => {}): Actions {
     if (prInfo.type === "remove") {
         if (prInfo.isDraft) {


### PR DESCRIPTION
- Name `PrInfo | BotEnsureRemovedFromProject | BotNoPackages | BotError` to reduce repetition
- Fix `Property 'now' does not exist on type ...` now that it's not `any`