### PR TITLE
Drop `No Other Owners` on infra PRs

### DIFF
--- a/src/_tests/fixtures/44402/mutations.json
+++ b/src/_tests/fixtures/44402/mutations.json
@@ -5,8 +5,7 @@
       "input": {
         "labelIds": [
           "MDU6TGFiZWw2OTcwMTg5NzI=",
-          "MDU6TGFiZWwxNjA4MjA4ODM1",
-          "MDU6TGFiZWwyMTU0ODU3ODAw"
+          "MDU6TGFiZWwxNjA4MjA4ODM1"
         ],
         "labelableId": "MDExOlB1bGxSZXF1ZXN0NDExODkwMDY5"
       }

--- a/src/_tests/fixtures/44402/result.json
+++ b/src/_tests/fixtures/44402/result.json
@@ -5,7 +5,6 @@
     "Other Approved",
     "Maintainer Approved",
     "Edits Infrastructure",
-    "No Other Owners",
     "Self Merge",
     "Edits Infrastructure"
   ],


### PR DESCRIPTION
* New `hasEditedPackages`: which is true when there *are* packages that
  are not new.  (I.e., not counting infra changes.)

* Use that as a condition for `No Other Owners`, so it doesn't turn on
  for infra PRs.

* Do the same for `Config Edit`, though there are no tests affected.

Supersedes #267.
