### PR TITLE
Rename `Config Edit` -> `Check Config` and show it for new packages

### DIFF
--- a/src/_tests/cachedQueries.json
+++ b/src/_tests/cachedQueries.json
@@ -55,7 +55,7 @@
     },
     {
       "id": "MDU6TGFiZWwyMTU0ODE2NTQ5",
-      "name": "Config Edit",
+      "name": "Check Config",
       "__typename": "Label"
     },
     {

--- a/src/_tests/fixtures/38979/_response.json
+++ b/src/_tests/fixtures/38979/_response.json
@@ -26,7 +26,7 @@
               "__typename": "Label"
             },
             {
-              "name": "Config Edit",
+              "name": "Check Config",
               "__typename": "Label"
             }
           ],

--- a/src/_tests/fixtures/38979/result.json
+++ b/src/_tests/fixtures/38979/result.json
@@ -4,7 +4,7 @@
   "labels": [
     "Critical package",
     "Other Approved",
-    "Config Edit",
+    "Check Config",
     "Unreviewed"
   ],
   "responseComments": [

--- a/src/_tests/fixtures/43151/mutations.json
+++ b/src/_tests/fixtures/43151/mutations.json
@@ -1,5 +1,16 @@
 [
   {
+    "query": "mutation($input: AddLabelsToLabelableInput!) { addLabelsToLabelable(input: $input) { clientMutationId } }",
+    "variables": {
+      "input": {
+        "labelIds": [
+          "MDU6TGFiZWwyMTU0ODE2NTQ5"
+        ],
+        "labelableId": "MDExOlB1bGxSZXF1ZXN0Mzg4Njk0NDU5"
+      }
+    }
+  },
+  {
     "query": "mutation($input: RemoveLabelsFromLabelableInput!) { removeLabelsFromLabelable(input: $input) { clientMutationId } }",
     "variables": {
       "input": {

--- a/src/_tests/fixtures/43151/result.json
+++ b/src/_tests/fixtures/43151/result.json
@@ -2,7 +2,8 @@
   "pr_number": 43151,
   "targetColumn": "Needs Maintainer Action",
   "labels": [
-    "New Definition"
+    "New Definition",
+    "Check Config"
   ],
   "responseComments": [
     {

--- a/src/_tests/fixtures/43314/mutations.json
+++ b/src/_tests/fixtures/43314/mutations.json
@@ -1,5 +1,16 @@
 [
   {
+    "query": "mutation($input: AddLabelsToLabelableInput!) { addLabelsToLabelable(input: $input) { clientMutationId } }",
+    "variables": {
+      "input": {
+        "labelIds": [
+          "MDU6TGFiZWwyMTU0ODE2NTQ5"
+        ],
+        "labelableId": "MDExOlB1bGxSZXF1ZXN0MzkyMDM2NjA4"
+      }
+    }
+  },
+  {
     "query": "mutation($input: MoveProjectCardInput!) { moveProjectCard(input: $input) { clientMutationId } }",
     "variables": {
       "input": {

--- a/src/_tests/fixtures/43314/result.json
+++ b/src/_tests/fixtures/43314/result.json
@@ -2,7 +2,8 @@
   "pr_number": 43314,
   "targetColumn": "Needs Maintainer Action",
   "labels": [
-    "New Definition"
+    "New Definition",
+    "Check Config"
   ],
   "responseComments": [
     {

--- a/src/_tests/fixtures/43695-duplicate-comment/_response.json
+++ b/src/_tests/fixtures/43695-duplicate-comment/_response.json
@@ -26,7 +26,7 @@
               "__typename": "Label"
             },
             {
-              "name": "Config Edit",
+              "name": "Check Config",
               "__typename": "Label"
             }
           ],

--- a/src/_tests/fixtures/43695-duplicate-comment/mutations.json
+++ b/src/_tests/fixtures/43695-duplicate-comment/mutations.json
@@ -15,8 +15,7 @@
     "variables": {
       "input": {
         "labelIds": [
-          "MDU6TGFiZWwyMTU0ODU3ODAw",
-          "MDU6TGFiZWwyMTU0ODE2NTQ5"
+          "MDU6TGFiZWwyMTU0ODU3ODAw"
         ],
         "labelableId": "MDExOlB1bGxSZXF1ZXN0NDAwMTAwMTk2"
       }

--- a/src/_tests/fixtures/43695-duplicate-comment/result.json
+++ b/src/_tests/fixtures/43695-duplicate-comment/result.json
@@ -3,6 +3,7 @@
   "targetColumn": "Needs Maintainer Action",
   "labels": [
     "New Definition",
+    "Check Config",
     "Unreviewed"
   ],
   "responseComments": [

--- a/src/_tests/fixtures/43695-post-review/mutations.json
+++ b/src/_tests/fixtures/43695-post-review/mutations.json
@@ -1,5 +1,16 @@
 [
   {
+    "query": "mutation($input: AddLabelsToLabelableInput!) { addLabelsToLabelable(input: $input) { clientMutationId } }",
+    "variables": {
+      "input": {
+        "labelIds": [
+          "MDU6TGFiZWwyMTU0ODE2NTQ5"
+        ],
+        "labelableId": "MDExOlB1bGxSZXF1ZXN0NDAwMTAwMTk2"
+      }
+    }
+  },
+  {
     "query": "mutation($input: MoveProjectCardInput!) { moveProjectCard(input: $input) { clientMutationId } }",
     "variables": {
       "input": {

--- a/src/_tests/fixtures/43695-post-review/result.json
+++ b/src/_tests/fixtures/43695-post-review/result.json
@@ -3,7 +3,8 @@
   "targetColumn": "Needs Author Action",
   "labels": [
     "Revision needed",
-    "New Definition"
+    "New Definition",
+    "Check Config"
   ],
   "responseComments": [
     {

--- a/src/_tests/fixtures/43695/mutations.json
+++ b/src/_tests/fixtures/43695/mutations.json
@@ -1,5 +1,16 @@
 [
   {
+    "query": "mutation($input: AddLabelsToLabelableInput!) { addLabelsToLabelable(input: $input) { clientMutationId } }",
+    "variables": {
+      "input": {
+        "labelIds": [
+          "MDU6TGFiZWwyMTU0ODE2NTQ5"
+        ],
+        "labelableId": "MDExOlB1bGxSZXF1ZXN0NDAwMTAwMTk2"
+      }
+    }
+  },
+  {
     "query": "mutation($input: MoveProjectCardInput!) { moveProjectCard(input: $input) { clientMutationId } }",
     "variables": {
       "input": {

--- a/src/_tests/fixtures/43695/result.json
+++ b/src/_tests/fixtures/43695/result.json
@@ -3,7 +3,8 @@
   "targetColumn": "Needs Author Action",
   "labels": [
     "Revision needed",
-    "New Definition"
+    "New Definition",
+    "Check Config"
   ],
   "responseComments": [
     {

--- a/src/_tests/fixtures/44299-with-files/mutations.json
+++ b/src/_tests/fixtures/44299-with-files/mutations.json
@@ -1,5 +1,16 @@
 [
   {
+    "query": "mutation($input: AddLabelsToLabelableInput!) { addLabelsToLabelable(input: $input) { clientMutationId } }",
+    "variables": {
+      "input": {
+        "labelIds": [
+          "MDU6TGFiZWwyMTU0ODE2NTQ5"
+        ],
+        "labelableId": "MDExOlB1bGxSZXF1ZXN0NDEwMjE2Nzgz"
+      }
+    }
+  },
+  {
     "query": "mutation($input: MoveProjectCardInput!) { moveProjectCard(input: $input) { clientMutationId } }",
     "variables": {
       "input": {

--- a/src/_tests/fixtures/44299-with-files/result.json
+++ b/src/_tests/fixtures/44299-with-files/result.json
@@ -2,7 +2,8 @@
   "pr_number": 44299,
   "targetColumn": "Needs Maintainer Action",
   "labels": [
-    "New Definition"
+    "New Definition",
+    "Check Config"
   ],
   "responseComments": [
     {

--- a/src/_tests/fixtures/44299/mutations.json
+++ b/src/_tests/fixtures/44299/mutations.json
@@ -1,5 +1,16 @@
 [
   {
+    "query": "mutation($input: AddLabelsToLabelableInput!) { addLabelsToLabelable(input: $input) { clientMutationId } }",
+    "variables": {
+      "input": {
+        "labelIds": [
+          "MDU6TGFiZWwyMTU0ODE2NTQ5"
+        ],
+        "labelableId": "MDExOlB1bGxSZXF1ZXN0NDEwMjE2Nzgz"
+      }
+    }
+  },
+  {
     "query": "mutation($input: MoveProjectCardInput!) { moveProjectCard(input: $input) { clientMutationId } }",
     "variables": {
       "input": {

--- a/src/_tests/fixtures/44299/result.json
+++ b/src/_tests/fixtures/44299/result.json
@@ -2,7 +2,8 @@
   "pr_number": 44299,
   "targetColumn": "Needs Maintainer Action",
   "labels": [
-    "New Definition"
+    "New Definition",
+    "Check Config"
   ],
   "responseComments": [
     {

--- a/src/_tests/fixtures/44316/_response.json
+++ b/src/_tests/fixtures/44316/_response.json
@@ -26,7 +26,7 @@
               "__typename": "Label"
             },
             {
-              "name": "Config Edit",
+              "name": "Check Config",
               "__typename": "Label"
             }
           ],

--- a/src/_tests/fixtures/44316/result.json
+++ b/src/_tests/fixtures/44316/result.json
@@ -4,7 +4,7 @@
   "labels": [
     "Author is Owner",
     "No Other Owners",
-    "Config Edit"
+    "Check Config"
   ],
   "responseComments": [
     {

--- a/src/_tests/fixtures/44411/_response.json
+++ b/src/_tests/fixtures/44411/_response.json
@@ -22,7 +22,7 @@
               "__typename": "Label"
             },
             {
-              "name": "Config Edit",
+              "name": "Check Config",
               "__typename": "Label"
             }
           ],

--- a/src/_tests/fixtures/44411/result.json
+++ b/src/_tests/fixtures/44411/result.json
@@ -3,7 +3,7 @@
   "targetColumn": "Needs Maintainer Review",
   "labels": [
     "Edits Owners",
-    "Config Edit"
+    "Check Config"
   ],
   "responseComments": [
     {

--- a/src/_tests/fixtures/44424-1-travis-instantly-finished/_response.json
+++ b/src/_tests/fixtures/44424-1-travis-instantly-finished/_response.json
@@ -22,7 +22,7 @@
               "__typename": "Label"
             },
             {
-              "name": "Config Edit",
+              "name": "Check Config",
               "__typename": "Label"
             }
           ],

--- a/src/_tests/fixtures/44424-1-travis-instantly-finished/result.json
+++ b/src/_tests/fixtures/44424-1-travis-instantly-finished/result.json
@@ -3,7 +3,7 @@
   "targetColumn": "Needs Maintainer Review",
   "labels": [
     "Author is Owner",
-    "Config Edit"
+    "Check Config"
   ],
   "responseComments": [
     {

--- a/src/_tests/fixtures/44424-2-after-travis-second/_response.json
+++ b/src/_tests/fixtures/44424-2-after-travis-second/_response.json
@@ -22,7 +22,7 @@
               "__typename": "Label"
             },
             {
-              "name": "Config Edit",
+              "name": "Check Config",
               "__typename": "Label"
             }
           ],

--- a/src/_tests/fixtures/44424-2-after-travis-second/result.json
+++ b/src/_tests/fixtures/44424-2-after-travis-second/result.json
@@ -3,7 +3,7 @@
   "targetColumn": "Waiting for Code Reviews",
   "labels": [
     "Author is Owner",
-    "Config Edit"
+    "Check Config"
   ],
   "responseComments": [
     {

--- a/src/_tests/fixtures/45890/mutations.json
+++ b/src/_tests/fixtures/45890/mutations.json
@@ -1,5 +1,16 @@
 [
   {
+    "query": "mutation($input: AddLabelsToLabelableInput!) { addLabelsToLabelable(input: $input) { clientMutationId } }",
+    "variables": {
+      "input": {
+        "labelIds": [
+          "MDU6TGFiZWwyMTU0ODE2NTQ5"
+        ],
+        "labelableId": "MDExOlB1bGxSZXF1ZXN0NDQ0MzI2NjIy"
+      }
+    }
+  },
+  {
     "query": "mutation($input: MoveProjectCardInput!) { moveProjectCard(input: $input) { clientMutationId } }",
     "variables": {
       "input": {

--- a/src/_tests/fixtures/45890/result.json
+++ b/src/_tests/fixtures/45890/result.json
@@ -3,7 +3,8 @@
   "targetColumn": "Needs Maintainer Action",
   "labels": [
     "Other Approved",
-    "New Definition"
+    "New Definition",
+    "Check Config"
   ],
   "responseComments": [
     {

--- a/src/_tests/fixtures/45946/result.json
+++ b/src/_tests/fixtures/45946/result.json
@@ -4,7 +4,7 @@
   "labels": [
     "Edits Infrastructure",
     "No Other Owners",
-    "Config Edit"
+    "Check Config"
   ],
   "responseComments": [
     {

--- a/src/_tests/fixtures/46019/mutations.json
+++ b/src/_tests/fixtures/46019/mutations.json
@@ -1,5 +1,16 @@
 [
   {
+    "query": "mutation($input: AddLabelsToLabelableInput!) { addLabelsToLabelable(input: $input) { clientMutationId } }",
+    "variables": {
+      "input": {
+        "labelIds": [
+          "MDU6TGFiZWwyMTU0ODE2NTQ5"
+        ],
+        "labelableId": "MDExOlB1bGxSZXF1ZXN0NDQ3ODE1MDgx"
+      }
+    }
+  },
+  {
     "query": "mutation($input: UpdateIssueCommentInput!) { updateIssueComment(input: $input) { clientMutationId } }",
     "variables": {
       "input": {

--- a/src/_tests/fixtures/46019/result.json
+++ b/src/_tests/fixtures/46019/result.json
@@ -4,6 +4,7 @@
   "labels": [
     "Maintainer Approved",
     "New Definition",
+    "Check Config",
     "Self Merge"
   ],
   "responseComments": [

--- a/src/_tests/fixtures/46191/_response.json
+++ b/src/_tests/fixtures/46191/_response.json
@@ -18,7 +18,7 @@
         "labels": {
           "nodes": [
             {
-              "name": "Config Edit",
+              "name": "Check Config",
               "__typename": "Label"
             },
             {

--- a/src/_tests/fixtures/46196/_response.json
+++ b/src/_tests/fixtures/46196/_response.json
@@ -18,7 +18,7 @@
         "labels": {
           "nodes": [
             {
-              "name": "Config Edit",
+              "name": "Check Config",
               "__typename": "Label"
             },
             {

--- a/src/_tests/fixtures/48216/_response.json
+++ b/src/_tests/fixtures/48216/_response.json
@@ -17,7 +17,7 @@
         "labels": {
           "nodes": [
             {
-              "name": "Config Edit",
+              "name": "Check Config",
               "__typename": "Label"
             },
             {

--- a/src/_tests/fixtures/48236/_response.json
+++ b/src/_tests/fixtures/48236/_response.json
@@ -17,7 +17,7 @@
         "labels": {
           "nodes": [
             {
-              "name": "Config Edit",
+              "name": "Check Config",
               "__typename": "Label"
             },
             {

--- a/src/_tests/fixtures/49841/mutations.json
+++ b/src/_tests/fixtures/49841/mutations.json
@@ -5,7 +5,8 @@
       "input": {
         "labelIds": [
           "MDU6TGFiZWwyMDk2NzQzNjAw",
-          "MDU6TGFiZWw2NDY3ODg4ODg="
+          "MDU6TGFiZWw2NDY3ODg4ODg=",
+          "MDU6TGFiZWwyMTU0ODE2NTQ5"
         ],
         "labelableId": "MDExOlB1bGxSZXF1ZXN0NTI4OTE2Mjg5"
       }

--- a/src/_tests/fixtures/49841/result.json
+++ b/src/_tests/fixtures/49841/result.json
@@ -3,7 +3,8 @@
   "targetColumn": "Needs Author Action",
   "labels": [
     "The CI failed",
-    "New Definition"
+    "New Definition",
+    "Check Config"
   ],
   "responseComments": [
     {


### PR DESCRIPTION
The information of having this label is useful for new packages too,
since it's added when the new config files don't get auto-blessed by the
file checkers.

OTOH, `Config Edit` is a bad name, since it's only used for the configs
that are not found to be OK.  So something like `Suspicious Config`
would be better --- but it sounds like a potentially malicious content,
so settle for `Check Config`.

Supersedes: #273.

Co-authored-by: Jack Bates <jack@nottheoilrig.com>