### PR TITLE
Fix re-running of queries in pr-info

### DIFF
--- a/src/pr-info.ts
+++ b/src/pr-info.ts
@@ -183,7 +183,7 @@ export async function queryPRInfo(prNumber: number) {
         });
         const prInfo = info.data.repository?.pullRequest;
         if (!prInfo) return info; // let `deriveStateForPR` handle the missing result
-        if (prInfo.mergeable !== "UNKNOWN") return info;
+        if (!(prInfo.state === "OPEN" && prInfo.mergeable === "UNKNOWN")) return info;
         const { nodes, totalCount } = prInfo.files!;
         if (nodes!.length < totalCount) console.warn(`  *** Note: ${totalCount - nodes!.length} files were not seen by this query!`);
         if (++retries > 5) { // we already did 5 tries, so give up and...


### PR DESCRIPTION
Previously, I changed it to re-run the query if `mergeable` is `UNKNOWN`
because it sometimes takes a few seconds for the GH api to update this
information.  Turns out that this should be done *only* for PRs that are
`OPEN`, in other states (`CLOSED` & `MERGED`) it's *expected* to be
`UNKNOWN`.  This broke the removal of project cards for closed/merged
PRs, since it would just spin the 5 retries while getting `UNKNOWN`
every time, eventually treating it as bogus (and also timing out the
gateway).

Should fix #278.