### PR TITLE
Add absolute date to timeline comments

### DIFF
--- a/src/_tests/fixtures/44989-14days/mutations.json
+++ b/src/_tests/fixtures/44989-14days/mutations.json
@@ -33,7 +33,7 @@
     "variables": {
       "input": {
         "subjectId": "MDExOlB1bGxSZXF1ZXN0NDIyMDc5Mjk3",
-        "body": "Re-ping @petr-motejlek / @TheHandsomeCoder, @donnut, @mdekrey, @sbking, @afharo, @teves-castro, @1M0reBug, @hojberg, @samsonkeung, @angeloocana, @raynerd, @moshensky, @ethanresnick, @deftomat, @blimusiek, @biern, @rayhaneh, @rgm, @drewwyatt, @jottenlips, @minitesh, @krantisinh, @pirix-gh, @brekk, @nemo108, @jituanlin, @Philippe-mills, @Saul-Mirone, @Nicholaiii:\n\nThis PR has been ready to merge for over a week, and I haven't seen any requests to merge it. I will close it in three weeks if this doesn't happen.\n\n(If there's no reason to avoid merging it, please do so.  Otherwise, if it shouldn't be merged or if it needs more time, please close it or turn it into a draft.)\n<!--typescript_bot_Unmerged:nearly:2020-05-23-->"
+        "body": "Re-ping @petr-motejlek / @TheHandsomeCoder, @donnut, @mdekrey, @sbking, @afharo, @teves-castro, @1M0reBug, @hojberg, @samsonkeung, @angeloocana, @raynerd, @moshensky, @ethanresnick, @deftomat, @blimusiek, @biern, @rayhaneh, @rgm, @drewwyatt, @jottenlips, @minitesh, @krantisinh, @pirix-gh, @brekk, @nemo108, @jituanlin, @Philippe-mills, @Saul-Mirone, @Nicholaiii:\n\nThis PR has been ready to merge for over a week, and I haven't seen any requests to merge it. I will close it on Jul 6 (in three weeks) if this doesn't happen.\n\n(If there's no reason to avoid merging it, please do so.  Otherwise, if it shouldn't be merged or if it needs more time, please close it or turn it into a draft.)\n<!--typescript_bot_Unmerged:nearly:2020-05-23-->"
       }
     }
   }

--- a/src/_tests/fixtures/44989-14days/result.json
+++ b/src/_tests/fixtures/44989-14days/result.json
@@ -18,7 +18,7 @@
     },
     {
       "tag": "Unmerged:nearly:2020-05-23",
-      "status": "Re-ping @petr-motejlek / @TheHandsomeCoder, @donnut, @mdekrey, @sbking, @afharo, @teves-castro, @1M0reBug, @hojberg, @samsonkeung, @angeloocana, @raynerd, @moshensky, @ethanresnick, @deftomat, @blimusiek, @biern, @rayhaneh, @rgm, @drewwyatt, @jottenlips, @minitesh, @krantisinh, @pirix-gh, @brekk, @nemo108, @jituanlin, @Philippe-mills, @Saul-Mirone, @Nicholaiii:\n\nThis PR has been ready to merge for over a week, and I haven't seen any requests to merge it. I will close it in three weeks if this doesn't happen.\n\n(If there's no reason to avoid merging it, please do so.  Otherwise, if it shouldn't be merged or if it needs more time, please close it or turn it into a draft.)"
+      "status": "Re-ping @petr-motejlek / @TheHandsomeCoder, @donnut, @mdekrey, @sbking, @afharo, @teves-castro, @1M0reBug, @hojberg, @samsonkeung, @angeloocana, @raynerd, @moshensky, @ethanresnick, @deftomat, @blimusiek, @biern, @rayhaneh, @rgm, @drewwyatt, @jottenlips, @minitesh, @krantisinh, @pirix-gh, @brekk, @nemo108, @jituanlin, @Philippe-mills, @Saul-Mirone, @Nicholaiii:\n\nThis PR has been ready to merge for over a week, and I haven't seen any requests to merge it. I will close it on Jul 6 (in three weeks) if this doesn't happen.\n\n(If there's no reason to avoid merging it, please do so.  Otherwise, if it shouldn't be merged or if it needs more time, please close it or turn it into a draft.)"
     }
   ],
   "shouldClose": false,

--- a/src/_tests/fixtures/48708/mutations.json
+++ b/src/_tests/fixtures/48708/mutations.json
@@ -25,7 +25,7 @@
     "variables": {
       "input": {
         "id": "MDEyOklzc3VlQ29tbWVudDcyNjMyMDI0OQ==",
-        "body": "@martin-badin I haven't seen any activity on this PR in more than three weeks, and it still has problems that prevent it from being merged. The PR will be closed in a week if the issues aren't addressed.\n<!--typescript_bot_Abandoned:nearly:2020-10-15-->"
+        "body": "@martin-badin I haven't seen any activity on this PR in more than three weeks, and it still has problems that prevent it from being merged. The PR will be closed on Dec 12 (in a week) if the issues aren't addressed.\n<!--typescript_bot_Abandoned:nearly:2020-10-15-->"
       }
     }
   }

--- a/src/_tests/fixtures/48708/result.json
+++ b/src/_tests/fixtures/48708/result.json
@@ -18,7 +18,7 @@
     },
     {
       "tag": "Abandoned:nearly:2020-10-15",
-      "status": "@martin-badin I haven't seen any activity on this PR in more than three weeks, and it still has problems that prevent it from being merged. The PR will be closed in a week if the issues aren't addressed."
+      "status": "@martin-badin I haven't seen any activity on this PR in more than three weeks, and it still has problems that prevent it from being merged. The PR will be closed on Dec 12 (in a week) if the issues aren't addressed."
     }
   ],
   "shouldClose": false,

--- a/src/comments.ts
+++ b/src/comments.ts
@@ -97,18 +97,19 @@ export const StalenessExplanations: { [k: string]: string } = {
 };
 
 // Comments to post for the staleness timeline (the tag is computed in `makeStaleness`)
-export const StalenessComment = (author: string, otherOwners: string[]) => {
+export const StalenessComment = (author: string, otherOwners: string[], expires: Date) => {
     const owners = otherOwners.length === 0 ? "«anyone?»" : otherOwners.map(o => "@"+o).join(", ");
+    const { format } = new Intl.DateTimeFormat("en", { month: "short", day: "numeric", timeZone: "UTC" });
     return {
         // --Unmerged--
         "Unmerged:nearly": `Re-ping @${author} / ${owners}:
 
-This PR has been ready to merge for over a week, and I haven't seen any requests to merge it. I will close it in three weeks if this doesn't happen.
+This PR has been ready to merge for over a week, and I haven't seen any requests to merge it. I will close it on ${format(expires)} (in three weeks) if this doesn't happen.
 
 (If there's no reason to avoid merging it, please do so.  Otherwise, if it shouldn't be merged or if it needs more time, please close it or turn it into a draft.)`,
         "Unmerged:done": `After a month, no one has requested merging the PR 😞. I'm going to assume that the change is not wanted after all, and will therefore close it.`,
         // --Abandoned--
-        "Abandoned:nearly": `@${author} I haven't seen any activity on this PR in more than three weeks, and it still has problems that prevent it from being merged. The PR will be closed in a week if the issues aren't addressed.`,
+        "Abandoned:nearly": `@${author} I haven't seen any activity on this PR in more than three weeks, and it still has problems that prevent it from being merged. The PR will be closed on ${format(expires)} (in a week) if the issues aren't addressed.`,
         "Abandoned:done": `@${author} To keep things tidy, we have to close PRs that aren't mergeable and don't have activity in the last month. No worries, though — please open a new PR if you'd like to continue with this change. Thank you!`,
         // --Unreviewed--
         "Unreviewed:nearly": `Re-ping ${owners}:

--- a/src/compute-pr-actions.ts
+++ b/src/compute-pr-actions.ts
@@ -375,7 +375,9 @@ function makeStaleness(now: string, author: string, otherOwners: string[]) { // 
         const state = days <= freshDays ? "fresh" : days <= attnDays ? "attention" : days <= nearDays ? "nearly" : "done";
         const kindAndState = `${kind}:${state}`;
         const explanation = Comments.StalenessExplanations[kindAndState];
-        const comment = Comments.StalenessComment(author, otherOwners)[kindAndState];
+        const expires = new Date(now);
+        expires.setDate(expires.getDate() + nearDays);
+        const comment = Comments.StalenessComment(author, otherOwners, expires)[kindAndState];
         const doTimelineActions = (context: Actions) => {
             if (comment !== undefined) {
                 const tag = state === "done" ? kindAndState


### PR DESCRIPTION
What do you think about including an absolute date? Viewing a PR I found it was a little hard to tell how much time was remaining. This change removes any doubt whether "in three weeks" means from when the comment was posted, and I imagine there are rare cases where the timer has already started by then, e.g. when the bot/timelines are edited.