### PR TITLE
Process scrubbed response so created fixtures pass

### DIFF
--- a/src/commands/create-fixture.ts
+++ b/src/commands/create-fixture.ts
@@ -18,13 +18,10 @@ export default async function main(directory: string, overwriteInfo: boolean) {
   if (!existsSync(fixturePath)) mkdirSync(fixturePath);
 
   const jsonFixturePath = join(fixturePath, "_response.json");
-  let response;
   if (overwriteInfo || !existsSync(jsonFixturePath)) {
-    response = await queryPRInfo(prNumber);
-    writeJsonSync(jsonFixturePath, response);
-  } else {
-    response = JSON.parse(readFileSync(jsonFixturePath, "utf8"));
+    writeJsonSync(jsonFixturePath, await queryPRInfo(prNumber));
   }
+  const response = JSON.parse(readFileSync(jsonFixturePath, "utf8"));
 
   const filesJSONPath = join(fixturePath, "_files.json");
   const filesFetched: {[expr: string]: string | undefined} = {};


### PR DESCRIPTION
Because `create-fixture.ts` and [`fixturedActions.test.ts`](https://github.com/DefinitelyTyped/dt-mergebot/blob/756610c890cbb5b381fa2a1ad501ba418da48f07/src/_tests/fixturedActions.test.ts#L33) process different responses (unscrubbed and scrubbed) they can have different outputs, e.g. different mutations. The differences cause freshly created fixtures to fail, requiring a subsequent `--updateSnapshot`.

This change makes `create-fixture.ts` process the same (scrubbed) response as `fixturedActions.test.ts`, resulting in the same outputs and the fixture passing.