### PR TITLE
Count moved columns as fresh activity

### DIFF
--- a/src/_tests/fixtures/43314/derived.json
+++ b/src/_tests/fixtures/43314/derived.json
@@ -8,6 +8,7 @@
   "lastActivityDate": "2020-03-22T16:50:35.000Z",
   "maintainerBlessed": false,
   "hasMergeConflict": false,
+  "projectColumnName": "Waiting for Code Reviews",
   "isFirstContribution": false,
   "popularityLevel": "Well-liked by everyone",
   "pkgInfo": [

--- a/src/_tests/fixtures/43695-duplicate-comment/derived.json
+++ b/src/_tests/fixtures/43695-duplicate-comment/derived.json
@@ -8,6 +8,7 @@
   "lastActivityDate": "2020-05-01T00:19:19.000Z",
   "maintainerBlessed": false,
   "hasMergeConflict": false,
+  "projectColumnName": "Waiting for Code Reviews",
   "isFirstContribution": false,
   "popularityLevel": "Well-liked by everyone",
   "pkgInfo": [

--- a/src/_tests/fixtures/43695-post-review/derived.json
+++ b/src/_tests/fixtures/43695-post-review/derived.json
@@ -8,6 +8,7 @@
   "lastActivityDate": "2020-04-30T23:07:49.000Z",
   "maintainerBlessed": false,
   "hasMergeConflict": false,
+  "projectColumnName": "Waiting for Code Reviews",
   "isFirstContribution": false,
   "popularityLevel": "Well-liked by everyone",
   "pkgInfo": [

--- a/src/_tests/fixtures/43695-post-review/mutations.json
+++ b/src/_tests/fixtures/43695-post-review/mutations.json
@@ -1,5 +1,16 @@
 [
   {
+    "mutation": "mutation ($input: AddLabelsToLabelableInput!) {\n  addLabelsToLabelable(input: $input) {\n    __typename\n  }\n}\n",
+    "variables": {
+      "input": {
+        "labelIds": [
+          "MDU6TGFiZWwyNDYyODA0MzE1"
+        ],
+        "labelableId": "MDExOlB1bGxSZXF1ZXN0NDAwMTAwMTk2"
+      }
+    }
+  },
+  {
     "mutation": "mutation ($input: MoveProjectCardInput!) {\n  moveProjectCard(input: $input) {\n    __typename\n  }\n}\n",
     "variables": {
       "input": {
@@ -13,7 +24,7 @@
     "variables": {
       "input": {
         "id": "MDEyOklzc3VlQ29tbWVudDYxMDIzNDI3MA==",
-        "body": "@alexandercerutti Thank you for submitting this PR!\n\n***This is a live comment which I will keep updated.***\n\n## 1 package in this PR\n\n* `accedo__accedo-one` (*new!*) [on npm](https://www.npmjs.com/package/@accedo/accedo-one), [on unpkg](https://unpkg.com/browse/@accedo/accedo-one@latest/)\n  - 1 added owner: ✎@alexandercerutti\n\n## Code Reviews\n\nThis PR adds a new definition, so it needs to be reviewed by a DT maintainer before it can be merged.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ Only a DT maintainer can approve changes when there are new packages added\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n----------------------\n... diagnostics scrubbed ...\n<!--typescript_bot_welcome-->"
+        "body": "@alexandercerutti Thank you for submitting this PR!\n\n***This is a live comment which I will keep updated.***\n\n## 1 package in this PR\n\n* `accedo__accedo-one` (*new!*) [on npm](https://www.npmjs.com/package/@accedo/accedo-one), [on unpkg](https://unpkg.com/browse/@accedo/accedo-one@latest/)\n  - 1 added owner: ✎@alexandercerutti\n\n## Code Reviews\n\nThis PR adds a new definition, so it needs to be reviewed by a DT maintainer before it can be merged.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ Only a DT maintainer can approve changes when there are new packages added\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n## Inactive\n\nThis PR has been inactive for 15 days — please try to get reviewers!\n\n----------------------\n... diagnostics scrubbed ...\n<!--typescript_bot_welcome-->"
       }
     }
   },
@@ -23,6 +34,15 @@
       "input": {
         "subjectId": "MDExOlB1bGxSZXF1ZXN0NDAwMTAwMTk2",
         "body": "@alexandercerutti One or more reviewers has requested changes. Please address their comments. I'll be back once they sign off or you've pushed new commits. Thank you!\n<!--typescript_bot_reviewer-complaint-90c94f9-->"
+      }
+    }
+  },
+  {
+    "mutation": "mutation ($input: AddCommentInput!) {\n  addComment(input: $input) {\n    __typename\n  }\n}\n",
+    "variables": {
+      "input": {
+        "subjectId": "MDExOlB1bGxSZXF1ZXN0NDAwMTAwMTk2",
+        "body": "Re-ping «anyone?»:\n\nThis PR has been out for over a week, yet I haven't seen any reviews.\n\nCould someone please give it some attention? Thanks!\n<!--typescript_bot_Unreviewed:nearly:2020-04-15-->"
       }
     }
   }

--- a/src/_tests/fixtures/43695-post-review/result.json
+++ b/src/_tests/fixtures/43695-post-review/result.json
@@ -3,16 +3,21 @@
   "targetColumn": "Needs Author Action",
   "labels": [
     "Revision needed",
-    "New Definition"
+    "New Definition",
+    "Unreviewed"
   ],
   "responseComments": [
     {
       "tag": "welcome",
-      "status": "@alexandercerutti Thank you for submitting this PR!\n\n***This is a live comment which I will keep updated.***\n\n## 1 package in this PR\n\n* `accedo__accedo-one` (*new!*) [on npm](https://www.npmjs.com/package/@accedo/accedo-one), [on unpkg](https://unpkg.com/browse/@accedo/accedo-one@latest/)\n  - 1 added owner: ✎@alexandercerutti\n\n## Code Reviews\n\nThis PR adds a new definition, so it needs to be reviewed by a DT maintainer before it can be merged.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ Only a DT maintainer can approve changes when there are new packages added\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n----------------------\n... diagnostics scrubbed ..."
+      "status": "@alexandercerutti Thank you for submitting this PR!\n\n***This is a live comment which I will keep updated.***\n\n## 1 package in this PR\n\n* `accedo__accedo-one` (*new!*) [on npm](https://www.npmjs.com/package/@accedo/accedo-one), [on unpkg](https://unpkg.com/browse/@accedo/accedo-one@latest/)\n  - 1 added owner: ✎@alexandercerutti\n\n## Code Reviews\n\nThis PR adds a new definition, so it needs to be reviewed by a DT maintainer before it can be merged.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ Only a DT maintainer can approve changes when there are new packages added\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n## Inactive\n\nThis PR has been inactive for 15 days — please try to get reviewers!\n\n----------------------\n... diagnostics scrubbed ..."
     },
     {
       "tag": "reviewer-complaint-90c94f9",
       "status": "@alexandercerutti One or more reviewers has requested changes. Please address their comments. I'll be back once they sign off or you've pushed new commits. Thank you!"
+    },
+    {
+      "tag": "Unreviewed:nearly:2020-04-15",
+      "status": "Re-ping «anyone?»:\n\nThis PR has been out for over a week, yet I haven't seen any reviews.\n\nCould someone please give it some attention? Thanks!"
     }
   ],
   "shouldClose": false,

--- a/src/_tests/fixtures/43695/derived.json
+++ b/src/_tests/fixtures/43695/derived.json
@@ -8,6 +8,7 @@
   "lastActivityDate": "2020-04-08T16:23:52.000Z",
   "maintainerBlessed": false,
   "hasMergeConflict": false,
+  "projectColumnName": "Waiting for Code Reviews",
   "isFirstContribution": false,
   "popularityLevel": "Well-liked by everyone",
   "pkgInfo": [

--- a/src/_tests/fixtures/43960/derived.json
+++ b/src/_tests/fixtures/43960/derived.json
@@ -8,6 +8,7 @@
   "lastActivityDate": "2020-04-29T20:48:52.000Z",
   "maintainerBlessed": false,
   "hasMergeConflict": false,
+  "projectColumnName": "Needs Maintainer Review",
   "isFirstContribution": false,
   "popularityLevel": "Popular",
   "pkgInfo": [

--- a/src/_tests/fixtures/43960/mutations.json
+++ b/src/_tests/fixtures/43960/mutations.json
@@ -1,5 +1,16 @@
 [
   {
+    "mutation": "mutation ($input: AddLabelsToLabelableInput!) {\n  addLabelsToLabelable(input: $input) {\n    __typename\n  }\n}\n",
+    "variables": {
+      "input": {
+        "labelIds": [
+          "MDU6TGFiZWwyNDYyODA0MzE1"
+        ],
+        "labelableId": "MDExOlB1bGxSZXF1ZXN0NDA0NTUyMTQ2"
+      }
+    }
+  },
+  {
     "mutation": "mutation ($input: RemoveLabelsFromLabelableInput!) {\n  removeLabelsFromLabelable(input: $input) {\n    __typename\n  }\n}\n",
     "variables": {
       "input": {
@@ -24,7 +35,16 @@
     "variables": {
       "input": {
         "id": "MDEyOklzc3VlQ29tbWVudDYyMTQ1NDM1NA==",
-        "body": "@aaltepet Thank you for submitting this PR!\n\n***This is a live comment which I will keep updated.***\n\n## 1 package in this PR\n\n* `supertest` [on npm](https://www.npmjs.com/package/supertest), [on unpkg](https://unpkg.com/browse/supertest@latest/)\n\n## Code Reviews\n\nBecause you edited one package and updated the tests (👏), I can help you merge this PR once someone else signs off on it.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ Most recent commit is approved by type definition owners or DT maintainers\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n----------------------\n... diagnostics scrubbed ...\n<!--typescript_bot_welcome-->"
+        "body": "@aaltepet Thank you for submitting this PR!\n\n***This is a live comment which I will keep updated.***\n\n## 1 package in this PR\n\n* `supertest` [on npm](https://www.npmjs.com/package/supertest), [on unpkg](https://unpkg.com/browse/supertest@latest/)\n\n## Code Reviews\n\nBecause you edited one package and updated the tests (👏), I can help you merge this PR once someone else signs off on it.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ Most recent commit is approved by type definition owners or DT maintainers\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n## Inactive\n\nThis PR has been inactive for 13 days — please try to get reviewers!\n\n----------------------\n... diagnostics scrubbed ...\n<!--typescript_bot_welcome-->"
+      }
+    }
+  },
+  {
+    "mutation": "mutation ($input: AddCommentInput!) {\n  addComment(input: $input) {\n    __typename\n  }\n}\n",
+    "variables": {
+      "input": {
+        "subjectId": "MDExOlB1bGxSZXF1ZXN0NDA0NTUyMTQ2",
+        "body": "Re-ping @varju, @pietu:\n\nThis PR has been out for over a week, yet I haven't seen any reviews.\n\nCould someone please give it some attention? Thanks!\n<!--typescript_bot_Unreviewed:nearly:2020-04-16-->"
       }
     }
   }

--- a/src/_tests/fixtures/43960/result.json
+++ b/src/_tests/fixtures/43960/result.json
@@ -3,16 +3,21 @@
   "targetColumn": "Needs Author Action",
   "labels": [
     "Revision needed",
-    "Popular package"
+    "Popular package",
+    "Unreviewed"
   ],
   "responseComments": [
     {
       "tag": "welcome",
-      "status": "@aaltepet Thank you for submitting this PR!\n\n***This is a live comment which I will keep updated.***\n\n## 1 package in this PR\n\n* `supertest` [on npm](https://www.npmjs.com/package/supertest), [on unpkg](https://unpkg.com/browse/supertest@latest/)\n\n## Code Reviews\n\nBecause you edited one package and updated the tests (👏), I can help you merge this PR once someone else signs off on it.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ Most recent commit is approved by type definition owners or DT maintainers\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n----------------------\n... diagnostics scrubbed ..."
+      "status": "@aaltepet Thank you for submitting this PR!\n\n***This is a live comment which I will keep updated.***\n\n## 1 package in this PR\n\n* `supertest` [on npm](https://www.npmjs.com/package/supertest), [on unpkg](https://unpkg.com/browse/supertest@latest/)\n\n## Code Reviews\n\nBecause you edited one package and updated the tests (👏), I can help you merge this PR once someone else signs off on it.\n\n## Status\n\n * ✅ No merge conflicts\n * ✅ Continuous integration tests have passed\n * ❌ Most recent commit is approved by type definition owners or DT maintainers\n\nOnce every item on this list is checked, I'll ask you for permission to merge and publish the changes.\n\n## Inactive\n\nThis PR has been inactive for 13 days — please try to get reviewers!\n\n----------------------\n... diagnostics scrubbed ..."
     },
     {
       "tag": "reviewer-complaint-129f84e",
       "status": "@aaltepet One or more reviewers has requested changes. Please address their comments. I'll be back once they sign off or you've pushed new commits. Thank you!"
+    },
+    {
+      "tag": "Unreviewed:nearly:2020-04-16",
+      "status": "Re-ping @varju, @pietu:\n\nThis PR has been out for over a week, yet I haven't seen any reviews.\n\nCould someone please give it some attention? Thanks!"
     }
   ],
   "shouldClose": false,

--- a/src/_tests/fixtures/44267/derived.json
+++ b/src/_tests/fixtures/44267/derived.json
@@ -8,6 +8,7 @@
   "lastActivityDate": "2020-04-28T06:48:36.000Z",
   "maintainerBlessed": false,
   "hasMergeConflict": false,
+  "projectColumnName": "Waiting for Code Reviews",
   "isFirstContribution": true,
   "popularityLevel": "Well-liked by everyone",
   "pkgInfo": [

--- a/src/_tests/fixtures/44282/derived.json
+++ b/src/_tests/fixtures/44282/derived.json
@@ -8,6 +8,7 @@
   "lastActivityDate": "2020-04-28T00:29:59.000Z",
   "maintainerBlessed": false,
   "hasMergeConflict": false,
+  "projectColumnName": "Waiting for Code Reviews",
   "isFirstContribution": true,
   "popularityLevel": "Well-liked by everyone",
   "pkgInfo": [

--- a/src/_tests/fixtures/44288/derived.json
+++ b/src/_tests/fixtures/44288/derived.json
@@ -8,6 +8,7 @@
   "lastActivityDate": "2020-04-28T04:48:25.000Z",
   "maintainerBlessed": false,
   "hasMergeConflict": false,
+  "projectColumnName": "Waiting for Code Reviews",
   "isFirstContribution": true,
   "popularityLevel": "Well-liked by everyone",
   "pkgInfo": [

--- a/src/_tests/fixtures/44299-with-files/derived.json
+++ b/src/_tests/fixtures/44299-with-files/derived.json
@@ -8,6 +8,7 @@
   "lastActivityDate": "2020-04-29T10:57:59.000Z",
   "maintainerBlessed": false,
   "hasMergeConflict": false,
+  "projectColumnName": "Waiting for Code Reviews",
   "isFirstContribution": true,
   "popularityLevel": "Well-liked by everyone",
   "pkgInfo": [

--- a/src/_tests/fixtures/44299/derived.json
+++ b/src/_tests/fixtures/44299/derived.json
@@ -8,6 +8,7 @@
   "lastActivityDate": "2020-04-29T10:57:59.000Z",
   "maintainerBlessed": false,
   "hasMergeConflict": false,
+  "projectColumnName": "Waiting for Code Reviews",
   "isFirstContribution": true,
   "popularityLevel": "Well-liked by everyone",
   "pkgInfo": [

--- a/src/_tests/fixtures/44316/derived.json
+++ b/src/_tests/fixtures/44316/derived.json
@@ -8,6 +8,7 @@
   "lastActivityDate": "2020-04-29T15:19:08.000Z",
   "maintainerBlessed": false,
   "hasMergeConflict": false,
+  "projectColumnName": "Waiting for Code Reviews",
   "isFirstContribution": false,
   "popularityLevel": "Well-liked by everyone",
   "pkgInfo": [

--- a/src/_tests/fixtures/44343-pending-travis/derived.json
+++ b/src/_tests/fixtures/44343-pending-travis/derived.json
@@ -8,6 +8,7 @@
   "lastActivityDate": "2020-04-29T16:19:21.000Z",
   "maintainerBlessed": false,
   "hasMergeConflict": false,
+  "projectColumnName": "Waiting for Code Reviews",
   "isFirstContribution": false,
   "popularityLevel": "Well-liked by everyone",
   "pkgInfo": [

--- a/src/_tests/fixtures/44343-pre-travis/derived.json
+++ b/src/_tests/fixtures/44343-pre-travis/derived.json
@@ -8,6 +8,7 @@
   "lastActivityDate": "2020-04-29T16:19:21.000Z",
   "maintainerBlessed": false,
   "hasMergeConflict": false,
+  "projectColumnName": "Waiting for Code Reviews",
   "isFirstContribution": false,
   "popularityLevel": "Well-liked by everyone",
   "pkgInfo": [

--- a/src/_tests/fixtures/44343/derived.json
+++ b/src/_tests/fixtures/44343/derived.json
@@ -8,6 +8,7 @@
   "lastActivityDate": "2020-04-29T16:19:21.000Z",
   "maintainerBlessed": false,
   "hasMergeConflict": false,
+  "projectColumnName": "Waiting for Code Reviews",
   "isFirstContribution": false,
   "popularityLevel": "Well-liked by everyone",
   "pkgInfo": [

--- a/src/_tests/fixtures/44411/derived.json
+++ b/src/_tests/fixtures/44411/derived.json
@@ -8,6 +8,7 @@
   "lastActivityDate": "2020-05-01T10:24:45.000Z",
   "maintainerBlessed": false,
   "hasMergeConflict": false,
+  "projectColumnName": "Waiting for Code Reviews",
   "isFirstContribution": false,
   "popularityLevel": "Well-liked by everyone",
   "pkgInfo": [

--- a/src/_tests/fixtures/44424-1-travis-instantly-finished/derived.json
+++ b/src/_tests/fixtures/44424-1-travis-instantly-finished/derived.json
@@ -8,6 +8,7 @@
   "lastActivityDate": "2020-05-01T19:23:41.000Z",
   "maintainerBlessed": false,
   "hasMergeConflict": false,
+  "projectColumnName": "Waiting for Code Reviews",
   "isFirstContribution": false,
   "popularityLevel": "Well-liked by everyone",
   "pkgInfo": [

--- a/src/_tests/fixtures/44424-2-after-travis-second/derived.json
+++ b/src/_tests/fixtures/44424-2-after-travis-second/derived.json
@@ -8,6 +8,7 @@
   "lastActivityDate": "2020-05-01T19:23:41.000Z",
   "maintainerBlessed": false,
   "hasMergeConflict": false,
+  "projectColumnName": "Waiting for Code Reviews",
   "isFirstContribution": false,
   "popularityLevel": "Well-liked by everyone",
   "pkgInfo": [

--- a/src/_tests/fixtures/44437/derived.json
+++ b/src/_tests/fixtures/44437/derived.json
@@ -9,6 +9,7 @@
   "maintainerBlessed": false,
   "mergeOfferDate": "2020-05-02T12:19:18.000Z",
   "hasMergeConflict": false,
+  "projectColumnName": "Waiting for Author to Merge",
   "isFirstContribution": false,
   "popularityLevel": "Popular",
   "pkgInfo": [

--- a/src/_tests/fixtures/44439/derived.json
+++ b/src/_tests/fixtures/44439/derived.json
@@ -8,6 +8,7 @@
   "lastActivityDate": "2020-05-02T14:36:15.000Z",
   "maintainerBlessed": false,
   "hasMergeConflict": false,
+  "projectColumnName": "Waiting for Code Reviews",
   "isFirstContribution": true,
   "popularityLevel": "Well-liked by everyone",
   "pkgInfo": [

--- a/src/_tests/fixtures/44631/derived.json
+++ b/src/_tests/fixtures/44631/derived.json
@@ -9,6 +9,7 @@
   "maintainerBlessed": false,
   "mergeOfferDate": "2020-05-15T15:41:43.000Z",
   "hasMergeConflict": true,
+  "projectColumnName": "Waiting for Author to Merge",
   "isFirstContribution": false,
   "popularityLevel": "Well-liked by everyone",
   "pkgInfo": [

--- a/src/_tests/fixtures/44857/derived.json
+++ b/src/_tests/fixtures/44857/derived.json
@@ -8,6 +8,7 @@
   "lastActivityDate": "2020-08-30T10:22:56.000Z",
   "maintainerBlessed": false,
   "hasMergeConflict": false,
+  "projectColumnName": "Needs Maintainer Action",
   "isFirstContribution": false,
   "popularityLevel": "Critical",
   "pkgInfo": [

--- a/src/_tests/fixtures/44857/derived.json
+++ b/src/_tests/fixtures/44857/derived.json
@@ -5,7 +5,7 @@
   "author": "ExE-Boss",
   "headCommitOid": "4aff18f9b99fdfc26209485631ba429f5d3d29ba",
   "lastPushDate": "2020-07-28T16:54:29.000Z",
-  "lastActivityDate": "2020-07-29T16:31:48.000Z",
+  "lastActivityDate": "2020-08-30T10:22:56.000Z",
   "maintainerBlessed": false,
   "hasMergeConflict": false,
   "isFirstContribution": false,

--- a/src/_tests/fixtures/44989-14days/derived.json
+++ b/src/_tests/fixtures/44989-14days/derived.json
@@ -9,6 +9,7 @@
   "maintainerBlessed": false,
   "mergeOfferDate": "2020-05-23T10:05:30.000Z",
   "hasMergeConflict": false,
+  "projectColumnName": "Waiting for Author to Merge",
   "isFirstContribution": false,
   "popularityLevel": "Popular",
   "pkgInfo": [

--- a/src/_tests/fixtures/44989-32days/derived.json
+++ b/src/_tests/fixtures/44989-32days/derived.json
@@ -9,6 +9,7 @@
   "maintainerBlessed": false,
   "mergeOfferDate": "2020-05-23T10:05:30.000Z",
   "hasMergeConflict": false,
+  "projectColumnName": "Waiting for Author to Merge",
   "isFirstContribution": false,
   "popularityLevel": "Popular",
   "pkgInfo": [

--- a/src/_tests/fixtures/44989-3days/derived.json
+++ b/src/_tests/fixtures/44989-3days/derived.json
@@ -9,6 +9,7 @@
   "maintainerBlessed": false,
   "mergeOfferDate": "2020-05-23T10:05:30.000Z",
   "hasMergeConflict": false,
+  "projectColumnName": "Waiting for Author to Merge",
   "isFirstContribution": false,
   "popularityLevel": "Popular",
   "pkgInfo": [

--- a/src/_tests/fixtures/44989-7days/derived.json
+++ b/src/_tests/fixtures/44989-7days/derived.json
@@ -9,6 +9,7 @@
   "maintainerBlessed": false,
   "mergeOfferDate": "2020-05-23T10:05:30.000Z",
   "hasMergeConflict": false,
+  "projectColumnName": "Waiting for Author to Merge",
   "isFirstContribution": false,
   "popularityLevel": "Popular",
   "pkgInfo": [

--- a/src/_tests/fixtures/45137/derived.json
+++ b/src/_tests/fixtures/45137/derived.json
@@ -8,6 +8,7 @@
   "lastActivityDate": "2020-05-29T07:13:24.000Z",
   "maintainerBlessed": false,
   "hasMergeConflict": false,
+  "projectColumnName": "Needs Author Action",
   "isFirstContribution": false,
   "popularityLevel": "Popular",
   "pkgInfo": [

--- a/src/_tests/fixtures/45627/derived.json
+++ b/src/_tests/fixtures/45627/derived.json
@@ -11,6 +11,7 @@
   "mergeRequestDate": "2020-07-06T08:36:06.000Z",
   "mergeRequestUser": "spamshaker",
   "hasMergeConflict": false,
+  "projectColumnName": "Needs Maintainer Review",
   "isFirstContribution": false,
   "popularityLevel": "Critical",
   "pkgInfo": [

--- a/src/_tests/fixtures/45627/derived.json
+++ b/src/_tests/fixtures/45627/derived.json
@@ -5,7 +5,7 @@
   "author": "spamshaker",
   "headCommitOid": "15facc177c957646a1ace95abe5e71326007c721",
   "lastPushDate": "2020-06-21T09:33:06.000Z",
-  "lastActivityDate": "2020-07-06T08:36:06.000Z",
+  "lastActivityDate": "2020-07-06T08:36:10.000Z",
   "maintainerBlessed": true,
   "mergeOfferDate": "2020-04-30T01:31:41.000Z",
   "mergeRequestDate": "2020-07-06T08:36:06.000Z",

--- a/src/_tests/fixtures/45836/derived.json
+++ b/src/_tests/fixtures/45836/derived.json
@@ -11,6 +11,7 @@
   "mergeRequestDate": "2020-07-08T17:47:50.000Z",
   "mergeRequestUser": "mmorearty",
   "hasMergeConflict": false,
+  "projectColumnName": "Needs Author Action",
   "isFirstContribution": false,
   "popularityLevel": "Well-liked by everyone",
   "pkgInfo": [

--- a/src/_tests/fixtures/45884/derived.json
+++ b/src/_tests/fixtures/45884/derived.json
@@ -5,7 +5,7 @@
   "author": "sgratzl",
   "headCommitOid": "1dcf44a05908783324ca99231837267af495cdb7",
   "lastPushDate": "2020-07-04T08:33:11.000Z",
-  "lastActivityDate": "2020-07-06T06:50:47.000Z",
+  "lastActivityDate": "2020-07-06T06:51:09.000Z",
   "maintainerBlessed": true,
   "mergeOfferDate": "2020-07-06T06:51:10.000Z",
   "hasMergeConflict": false,

--- a/src/_tests/fixtures/45884/derived.json
+++ b/src/_tests/fixtures/45884/derived.json
@@ -9,6 +9,7 @@
   "maintainerBlessed": true,
   "mergeOfferDate": "2020-07-06T06:51:10.000Z",
   "hasMergeConflict": false,
+  "projectColumnName": "Waiting for Author to Merge",
   "isFirstContribution": true,
   "popularityLevel": "Well-liked by everyone",
   "pkgInfo": [

--- a/src/_tests/fixtures/45888/derived.json
+++ b/src/_tests/fixtures/45888/derived.json
@@ -8,6 +8,7 @@
   "lastActivityDate": "2020-07-06T07:40:21.000Z",
   "maintainerBlessed": true,
   "hasMergeConflict": false,
+  "projectColumnName": "Waiting for Code Reviews",
   "isFirstContribution": true,
   "popularityLevel": "Well-liked by everyone",
   "pkgInfo": [

--- a/src/_tests/fixtures/45890/derived.json
+++ b/src/_tests/fixtures/45890/derived.json
@@ -8,6 +8,7 @@
   "lastActivityDate": "2020-07-05T08:20:29.000Z",
   "maintainerBlessed": false,
   "hasMergeConflict": false,
+  "projectColumnName": "Needs Maintainer Review",
   "isFirstContribution": true,
   "popularityLevel": "Well-liked by everyone",
   "pkgInfo": [

--- a/src/_tests/fixtures/45946/derived.json
+++ b/src/_tests/fixtures/45946/derived.json
@@ -8,6 +8,7 @@
   "lastActivityDate": "2020-07-10T14:00:47.000Z",
   "maintainerBlessed": false,
   "hasMergeConflict": false,
+  "projectColumnName": "Needs Maintainer Review",
   "isFirstContribution": false,
   "popularityLevel": "Well-liked by everyone",
   "pkgInfo": [

--- a/src/_tests/fixtures/45999/derived.json
+++ b/src/_tests/fixtures/45999/derived.json
@@ -8,6 +8,7 @@
   "lastActivityDate": "2020-07-11T02:36:41.000Z",
   "maintainerBlessed": true,
   "hasMergeConflict": false,
+  "projectColumnName": "Waiting for Code Reviews",
   "isFirstContribution": false,
   "popularityLevel": "Critical",
   "pkgInfo": [

--- a/src/_tests/fixtures/46008/derived.json
+++ b/src/_tests/fixtures/46008/derived.json
@@ -8,6 +8,7 @@
   "lastActivityDate": "2020-07-11T02:09:10.000Z",
   "maintainerBlessed": true,
   "hasMergeConflict": false,
+  "projectColumnName": "Other",
   "isFirstContribution": true,
   "popularityLevel": "Well-liked by everyone",
   "pkgInfo": [

--- a/src/_tests/fixtures/46019/derived.json
+++ b/src/_tests/fixtures/46019/derived.json
@@ -9,6 +9,7 @@
   "maintainerBlessed": false,
   "mergeOfferDate": "2020-07-12T04:07:31.000Z",
   "hasMergeConflict": false,
+  "projectColumnName": "Waiting for Author to Merge",
   "isFirstContribution": false,
   "popularityLevel": "Well-liked by everyone",
   "pkgInfo": [

--- a/src/_tests/fixtures/46019/derived.json
+++ b/src/_tests/fixtures/46019/derived.json
@@ -5,7 +5,7 @@
   "author": "peterblazejewicz",
   "headCommitOid": "ceca9f768be945932c692d7dd48fa14b6ff38096",
   "lastPushDate": "2020-07-11T20:43:23.000Z",
-  "lastActivityDate": "2020-07-12T02:01:31.000Z",
+  "lastActivityDate": "2020-07-12T04:07:30.000Z",
   "maintainerBlessed": false,
   "mergeOfferDate": "2020-07-12T04:07:31.000Z",
   "hasMergeConflict": false,

--- a/src/_tests/fixtures/46120/derived.json
+++ b/src/_tests/fixtures/46120/derived.json
@@ -10,6 +10,7 @@
   "mergeRequestDate": "2020-07-19T16:36:44.000Z",
   "mergeRequestUser": "reubenrybnik",
   "hasMergeConflict": false,
+  "projectColumnName": "Needs Maintainer Action",
   "isFirstContribution": false,
   "popularityLevel": "Popular",
   "pkgInfo": [

--- a/src/_tests/fixtures/46191/derived.json
+++ b/src/_tests/fixtures/46191/derived.json
@@ -5,7 +5,7 @@
   "author": "jordanoverbye",
   "headCommitOid": "3cc81dbde57a1b0eda6f69f539fa49b8d420adff",
   "lastPushDate": "2020-07-20T06:54:57.000Z",
-  "lastActivityDate": "2020-07-20T07:08:31.000Z",
+  "lastActivityDate": "2020-07-20T07:10:31.000Z",
   "maintainerBlessed": false,
   "hasMergeConflict": false,
   "isFirstContribution": true,

--- a/src/_tests/fixtures/46191/derived.json
+++ b/src/_tests/fixtures/46191/derived.json
@@ -8,6 +8,7 @@
   "lastActivityDate": "2020-07-20T07:10:31.000Z",
   "maintainerBlessed": false,
   "hasMergeConflict": false,
+  "projectColumnName": "Needs Author Action",
   "isFirstContribution": true,
   "popularityLevel": "Well-liked by everyone",
   "pkgInfo": [

--- a/src/_tests/fixtures/46196/derived.json
+++ b/src/_tests/fixtures/46196/derived.json
@@ -8,6 +8,7 @@
   "lastActivityDate": "2020-07-20T12:12:39.000Z",
   "maintainerBlessed": false,
   "hasMergeConflict": false,
+  "projectColumnName": "Needs Maintainer Review",
   "isFirstContribution": true,
   "popularityLevel": "Well-liked by everyone",
   "pkgInfo": [

--- a/src/_tests/fixtures/46804/derived.json
+++ b/src/_tests/fixtures/46804/derived.json
@@ -8,6 +8,7 @@
   "lastActivityDate": "2020-08-25T19:30:37.000Z",
   "maintainerBlessed": true,
   "hasMergeConflict": false,
+  "projectColumnName": "Waiting for Code Reviews",
   "isFirstContribution": true,
   "popularityLevel": "Well-liked by everyone",
   "pkgInfo": [

--- a/src/_tests/fixtures/46879/derived.json
+++ b/src/_tests/fixtures/46879/derived.json
@@ -5,7 +5,7 @@
   "author": "Chaldron",
   "headCommitOid": "2586d74ca0dc553be5f3afc0135468b17b240d70",
   "lastPushDate": "2020-08-11T18:21:13.000Z",
-  "lastActivityDate": "2020-08-18T19:35:37.000Z",
+  "lastActivityDate": "2020-08-21T04:10:51.000Z",
   "maintainerBlessed": false,
   "hasMergeConflict": false,
   "isFirstContribution": false,

--- a/src/_tests/fixtures/47017-blessed-and-one-owner/derived.json
+++ b/src/_tests/fixtures/47017-blessed-and-one-owner/derived.json
@@ -8,6 +8,7 @@
   "lastActivityDate": "2020-08-26T20:01:58.000Z",
   "maintainerBlessed": true,
   "hasMergeConflict": false,
+  "projectColumnName": "Waiting for Code Reviews",
   "isFirstContribution": false,
   "popularityLevel": "Critical",
   "pkgInfo": [

--- a/src/_tests/fixtures/47017-blessed-and-two-owner/derived.json
+++ b/src/_tests/fixtures/47017-blessed-and-two-owner/derived.json
@@ -8,6 +8,7 @@
   "lastActivityDate": "2020-08-26T20:01:58.000Z",
   "maintainerBlessed": true,
   "hasMergeConflict": false,
+  "projectColumnName": "Waiting for Code Reviews",
   "isFirstContribution": false,
   "popularityLevel": "Critical",
   "pkgInfo": [

--- a/src/_tests/fixtures/47017-blessed/derived.json
+++ b/src/_tests/fixtures/47017-blessed/derived.json
@@ -8,6 +8,7 @@
   "lastActivityDate": "2020-08-26T20:01:58.000Z",
   "maintainerBlessed": true,
   "hasMergeConflict": false,
+  "projectColumnName": "Waiting for Code Reviews",
   "isFirstContribution": false,
   "popularityLevel": "Critical",
   "pkgInfo": [

--- a/src/_tests/fixtures/47017/derived.json
+++ b/src/_tests/fixtures/47017/derived.json
@@ -8,6 +8,7 @@
   "lastActivityDate": "2020-08-25T05:55:15.000Z",
   "maintainerBlessed": false,
   "hasMergeConflict": false,
+  "projectColumnName": "Waiting for Code Reviews",
   "isFirstContribution": false,
   "popularityLevel": "Critical",
   "pkgInfo": [

--- a/src/_tests/fixtures/47017/derived.json
+++ b/src/_tests/fixtures/47017/derived.json
@@ -5,7 +5,7 @@
   "author": "mastermatt",
   "headCommitOid": "dbe687d30362e4f887e88048a3646c13c0c4d907",
   "lastPushDate": "2020-08-25T05:47:26.000Z",
-  "lastActivityDate": "2020-08-25T05:54:37.000Z",
+  "lastActivityDate": "2020-08-25T05:55:15.000Z",
   "maintainerBlessed": false,
   "hasMergeConflict": false,
   "isFirstContribution": false,

--- a/src/_tests/fixtures/48216/derived.json
+++ b/src/_tests/fixtures/48216/derived.json
@@ -5,7 +5,7 @@
   "author": "jablko",
   "headCommitOid": "3f689bfb9d310612cdaf7c52c7ead41d1181b52f",
   "lastPushDate": "2020-09-27T17:23:58.000Z",
-  "lastActivityDate": "2020-09-27T19:01:23.000Z",
+  "lastActivityDate": "2020-09-27T19:01:58.000Z",
   "maintainerBlessed": false,
   "hasMergeConflict": false,
   "isFirstContribution": false,

--- a/src/_tests/fixtures/48216/derived.json
+++ b/src/_tests/fixtures/48216/derived.json
@@ -8,6 +8,7 @@
   "lastActivityDate": "2020-09-27T19:01:58.000Z",
   "maintainerBlessed": false,
   "hasMergeConflict": false,
+  "projectColumnName": "Needs Maintainer Review",
   "isFirstContribution": false,
   "popularityLevel": "Well-liked by everyone",
   "pkgInfo": [

--- a/src/_tests/fixtures/48236/derived.json
+++ b/src/_tests/fixtures/48236/derived.json
@@ -5,7 +5,7 @@
   "author": "jablko",
   "headCommitOid": "b4d71f672f0f204a514002348ebc2025d18866ca",
   "lastPushDate": "2020-09-27T17:25:18.000Z",
-  "lastActivityDate": "2020-10-02T19:13:08.000Z",
+  "lastActivityDate": "2020-10-02T19:13:40.000Z",
   "maintainerBlessed": false,
   "mergeOfferDate": "2020-09-30T00:08:26.000Z",
   "mergeRequestDate": "2020-10-02T18:45:57.000Z",

--- a/src/_tests/fixtures/48236/derived.json
+++ b/src/_tests/fixtures/48236/derived.json
@@ -11,6 +11,7 @@
   "mergeRequestDate": "2020-10-02T18:45:57.000Z",
   "mergeRequestUser": "jablko",
   "hasMergeConflict": false,
+  "projectColumnName": "Waiting for Author to Merge",
   "isFirstContribution": false,
   "popularityLevel": "Well-liked by everyone",
   "pkgInfo": [

--- a/src/_tests/fixtures/48652-merge-offer/derived.json
+++ b/src/_tests/fixtures/48652-merge-offer/derived.json
@@ -5,7 +5,7 @@
   "author": "mgol",
   "headCommitOid": "06d8d678f1fc73f43ee6e8efe11230c4db92cc83",
   "lastPushDate": "2020-11-02T15:56:23.000Z",
-  "lastActivityDate": "2020-11-04T00:31:53.000Z",
+  "lastActivityDate": "2020-11-04T00:32:28.000Z",
   "maintainerBlessed": false,
   "hasMergeConflict": false,
   "isFirstContribution": false,

--- a/src/_tests/fixtures/48652-prereq/derived.json
+++ b/src/_tests/fixtures/48652-prereq/derived.json
@@ -5,7 +5,7 @@
   "author": "mgol",
   "headCommitOid": "06d8d678f1fc73f43ee6e8efe11230c4db92cc83",
   "lastPushDate": "2020-11-02T15:56:23.000Z",
-  "lastActivityDate": "2020-11-04T00:31:53.000Z",
+  "lastActivityDate": "2020-11-04T00:32:28.000Z",
   "maintainerBlessed": false,
   "mergeRequestDate": "2020-11-02T20:15:49.000Z",
   "mergeRequestUser": "mgol",

--- a/src/_tests/fixtures/48652-retract-merge-offer-and-prerequest/derived.json
+++ b/src/_tests/fixtures/48652-retract-merge-offer-and-prerequest/derived.json
@@ -5,7 +5,7 @@
   "author": "mgol",
   "headCommitOid": "06d8d678f1fc73f43ee6e8efe11230c4db92cc83",
   "lastPushDate": "2020-11-02T15:56:23.000Z",
-  "lastActivityDate": "2020-11-04T00:31:53.000Z",
+  "lastActivityDate": "2020-11-04T00:32:28.000Z",
   "maintainerBlessed": false,
   "mergeOfferDate": "2020-11-04T00:23:45.000Z",
   "mergeRequestDate": "2020-11-02T20:15:49.000Z",

--- a/src/_tests/fixtures/48652-retract-merge-offer/derived.json
+++ b/src/_tests/fixtures/48652-retract-merge-offer/derived.json
@@ -5,7 +5,7 @@
   "author": "mgol",
   "headCommitOid": "06d8d678f1fc73f43ee6e8efe11230c4db92cc83",
   "lastPushDate": "2020-11-02T15:56:23.000Z",
-  "lastActivityDate": "2020-11-04T00:31:53.000Z",
+  "lastActivityDate": "2020-11-04T00:32:28.000Z",
   "maintainerBlessed": false,
   "mergeOfferDate": "2020-11-04T00:23:45.000Z",
   "hasMergeConflict": false,

--- a/src/_tests/fixtures/48708/derived.json
+++ b/src/_tests/fixtures/48708/derived.json
@@ -8,6 +8,7 @@
   "lastActivityDate": "2020-10-15T15:53:50.000Z",
   "maintainerBlessed": false,
   "hasMergeConflict": false,
+  "projectColumnName": "Needs Author Action",
   "isFirstContribution": false,
   "popularityLevel": "Critical",
   "pkgInfo": [

--- a/src/_tests/fixtures/48945/derived.json
+++ b/src/_tests/fixtures/48945/derived.json
@@ -9,6 +9,7 @@
   "maintainerBlessed": false,
   "mergeOfferDate": "2020-10-20T11:35:45.000Z",
   "hasMergeConflict": false,
+  "projectColumnName": "Needs Author Action",
   "isFirstContribution": false,
   "popularityLevel": "Well-liked by everyone",
   "pkgInfo": [

--- a/src/_tests/fixtures/49417/derived.json
+++ b/src/_tests/fixtures/49417/derived.json
@@ -5,7 +5,7 @@
   "author": "Methuselah96",
   "headCommitOid": "2b9d0980329843dc436a18460f85bb2e2d2f688c",
   "lastPushDate": "2020-11-08T07:52:53.000Z",
-  "lastActivityDate": "2020-11-16T07:38:51.000Z",
+  "lastActivityDate": "2020-11-16T16:47:52.000Z",
   "maintainerBlessed": false,
   "hasMergeConflict": false,
   "isFirstContribution": false,

--- a/src/_tests/fixtures/49417/derived.json
+++ b/src/_tests/fixtures/49417/derived.json
@@ -8,6 +8,7 @@
   "lastActivityDate": "2020-11-16T16:47:52.000Z",
   "maintainerBlessed": false,
   "hasMergeConflict": false,
+  "projectColumnName": "Waiting for Author to Merge",
   "isFirstContribution": false,
   "popularityLevel": "Well-liked by everyone",
   "pkgInfo": [

--- a/src/_tests/fixtures/49548/derived.json
+++ b/src/_tests/fixtures/49548/derived.json
@@ -8,6 +8,7 @@
   "lastActivityDate": "2020-11-16T20:15:33.000Z",
   "maintainerBlessed": false,
   "hasMergeConflict": false,
+  "projectColumnName": "Waiting for Code Reviews",
   "isFirstContribution": true,
   "popularityLevel": "Well-liked by everyone",
   "pkgInfo": [

--- a/src/_tests/fixtures/49841/derived.json
+++ b/src/_tests/fixtures/49841/derived.json
@@ -8,6 +8,7 @@
   "lastActivityDate": "2020-11-28T09:17:28.000Z",
   "maintainerBlessed": false,
   "hasMergeConflict": false,
+  "projectColumnName": "Other",
   "isFirstContribution": false,
   "popularityLevel": "Well-liked by everyone",
   "pkgInfo": [

--- a/src/compute-pr-actions.ts
+++ b/src/compute-pr-actions.ts
@@ -182,7 +182,7 @@ function extendPrInfo(info: PrInfo): ExtendedPrInfo {
         const mkStaleness = makeStaleness(info.now, info.author, otherOwners);
         if (canBeSelfMerged && info.mergeOfferDate) return mkStaleness(
             "Unmerged", info.mergeOfferDate, 4, 9, 30, "CLOSE");
-        if (needsAuthorAction) return mkStaleness(
+        if (info.projectColumnName === "Needs Author Action") return mkStaleness(
             "Abandoned", info.lastActivityDate, 6, 22, 30, "CLOSE");
         if (!approved) return mkStaleness(
             "Unreviewed", info.lastPushDate, 6, 10, 17, "Needs Maintainer Action");

--- a/src/pr-info.ts
+++ b/src/pr-info.ts
@@ -140,6 +140,8 @@ export interface PrInfo {
     readonly mergeRequestDate?: Date;
     readonly mergeRequestUser?: string;
 
+    readonly projectColumnName?: string;
+
     readonly isFirstContribution: boolean;
 
     readonly popularityLevel: PopularityLevel;
@@ -241,6 +243,7 @@ export async function deriveStateForPR(
         maintainerBlessed: lastBlessing ? lastBlessing > lastPushDate : false,
         mergeOfferDate, mergeRequestDate: mergeRequest?.date, mergeRequestUser: mergeRequest?.user,
         hasMergeConflict: prInfo.mergeable === "CONFLICTING",
+        projectColumnName: prInfo.projectCards.nodes?.find(card => card?.project.number === 5)?.column?.name,
         isFirstContribution,
         popularityLevel,
         pkgInfo,


### PR DESCRIPTION
Adds moved columns events to `lastActivityDate`.

Also don't close PRs before moving them to "Needs Author Action", which then generates fresh activity and triggers the usual timelines.

Fixes #306