### PR TITLE
Don't query comments twice

### DIFF
--- a/src/_tests/fixtures/43136/_response.json
+++ b/src/_tests/fixtures/43136/_response.json
@@ -102,7 +102,10 @@
               "state": "APPROVED",
               "submittedAt": "2020-03-14T19:22:34Z",
               "url": "https://github.com/DefinitelyTyped/DefinitelyTyped/pull/43136#pullrequestreview-374748227",
-              "__typename": "PullRequestReview"
+              "__typename": "PullRequestReview",
+              "comments": {
+                "nodes": []
+              }
             },
             {
               "author": {
@@ -118,7 +121,10 @@
               "state": "COMMENTED",
               "submittedAt": "2020-03-14T19:23:36Z",
               "url": "https://github.com/DefinitelyTyped/DefinitelyTyped/pull/43136#pullrequestreview-374748276",
-              "__typename": "PullRequestReview"
+              "__typename": "PullRequestReview",
+              "comments": {
+                "nodes": []
+              }
             }
           ],
           "__typename": "PullRequestReviewConnection"

--- a/src/_tests/fixtures/43136/derived.json
+++ b/src/_tests/fixtures/43136/derived.json
@@ -6,7 +6,7 @@
   "headCommitAbbrOid": "e686353",
   "headCommitOid": "e6863537248bbfee8f0ef8c636bb00c25cf40b96",
   "lastPushDate": "2020-03-16T14:26:42.000Z",
-  "lastActivityDate": "2020-03-16T14:26:42.000Z",
+  "lastActivityDate": "2020-03-16T14:31:40.000Z",
   "maintainerBlessed": false,
   "hasMergeConflict": false,
   "isFirstContribution": true,

--- a/src/_tests/fixtures/43144/_response.json
+++ b/src/_tests/fixtures/43144/_response.json
@@ -88,7 +88,10 @@
               "state": "APPROVED",
               "submittedAt": "2020-03-15T01:29:09Z",
               "url": "https://github.com/DefinitelyTyped/DefinitelyTyped/pull/43144#pullrequestreview-374764862",
-              "__typename": "PullRequestReview"
+              "__typename": "PullRequestReview",
+              "comments": {
+                "nodes": []
+              }
             }
           ],
           "__typename": "PullRequestReviewConnection"

--- a/src/_tests/fixtures/43151/derived.json
+++ b/src/_tests/fixtures/43151/derived.json
@@ -6,7 +6,7 @@
   "headCommitAbbrOid": "bb6d315",
   "headCommitOid": "bb6d3150b485cd203d265e06ca910262256e523e",
   "lastPushDate": "2020-03-15T12:50:20.000Z",
-  "lastActivityDate": "2020-03-15T12:51:25.000Z",
+  "lastActivityDate": "2020-03-15T18:11:57.000Z",
   "maintainerBlessed": false,
   "hasMergeConflict": false,
   "isFirstContribution": false,

--- a/src/_tests/fixtures/43160/_response.json
+++ b/src/_tests/fixtures/43160/_response.json
@@ -78,7 +78,10 @@
               "state": "APPROVED",
               "submittedAt": "2020-03-17T14:33:47Z",
               "url": "https://github.com/DefinitelyTyped/DefinitelyTyped/pull/43160#pullrequestreview-376092132",
-              "__typename": "PullRequestReview"
+              "__typename": "PullRequestReview",
+              "comments": {
+                "nodes": []
+              }
             }
           ],
           "__typename": "PullRequestReviewConnection"

--- a/src/_tests/fixtures/43175/_response.json
+++ b/src/_tests/fixtures/43175/_response.json
@@ -82,7 +82,10 @@
               "state": "COMMENTED",
               "submittedAt": "2020-03-17T13:29:17Z",
               "url": "https://github.com/DefinitelyTyped/DefinitelyTyped/pull/43175#pullrequestreview-376024679",
-              "__typename": "PullRequestReview"
+              "__typename": "PullRequestReview",
+              "comments": {
+                "nodes": []
+              }
             },
             {
               "author": {
@@ -98,7 +101,10 @@
               "state": "COMMENTED",
               "submittedAt": "2020-03-17T13:54:18Z",
               "url": "https://github.com/DefinitelyTyped/DefinitelyTyped/pull/43175#pullrequestreview-376054940",
-              "__typename": "PullRequestReview"
+              "__typename": "PullRequestReview",
+              "comments": {
+                "nodes": []
+              }
             }
           ],
           "__typename": "PullRequestReviewConnection"

--- a/src/_tests/fixtures/43695/_response.json
+++ b/src/_tests/fixtures/43695/_response.json
@@ -111,7 +111,10 @@
               "state": "CHANGES_REQUESTED",
               "submittedAt": "2020-04-08T16:23:52Z",
               "url": "https://github.com/DefinitelyTyped/DefinitelyTyped/pull/43695#pullrequestreview-390133785",
-              "__typename": "PullRequestReview"
+              "__typename": "PullRequestReview",
+              "comments": {
+                "nodes": []
+              }
             },
             {
               "author": {
@@ -127,7 +130,10 @@
               "state": "COMMENTED",
               "submittedAt": "2020-04-08T17:03:39Z",
               "url": "https://github.com/DefinitelyTyped/DefinitelyTyped/pull/43695#pullrequestreview-390164904",
-              "__typename": "PullRequestReview"
+              "__typename": "PullRequestReview",
+              "comments": {
+                "nodes": []
+              }
             }
           ],
           "__typename": "PullRequestReviewConnection"

--- a/src/_tests/fixtures/44282/derived.json
+++ b/src/_tests/fixtures/44282/derived.json
@@ -6,7 +6,7 @@
   "headCommitAbbrOid": "2579430",
   "headCommitOid": "25794304acf8c1fd70712bd068beb07b0e09755e",
   "lastPushDate": "2020-04-27T23:58:24.000Z",
-  "lastActivityDate": "2020-04-27T23:58:24.000Z",
+  "lastActivityDate": "2020-04-28T00:29:59.000Z",
   "maintainerBlessed": false,
   "hasMergeConflict": false,
   "isFirstContribution": true,

--- a/src/_tests/fixtures/44290/_response.json
+++ b/src/_tests/fixtures/44290/_response.json
@@ -99,7 +99,10 @@
               "state": "COMMENTED",
               "submittedAt": "2020-04-28T13:56:31Z",
               "url": "https://github.com/DefinitelyTyped/DefinitelyTyped/pull/44290#pullrequestreview-401861064",
-              "__typename": "PullRequestReview"
+              "__typename": "PullRequestReview",
+              "comments": {
+                "nodes": []
+              }
             }
           ],
           "__typename": "PullRequestReviewConnection"

--- a/src/pr-info.ts
+++ b/src/pr-info.ts
@@ -282,13 +282,12 @@ function getReopenedDate(timelineItems: PR_repository_pullRequest_timelineItems)
 }
 
 function getLastCommentishActivityDate(prInfo: PR_repository_pullRequest) {
-    const latestIssueCommentDate = max(noNullish(prInfo.comments.nodes)
-        .filter(authorNotBot)
-        .map(comment => new Date(comment.createdAt)));
-    const latestReviewCommentDate = max(noNullish(prInfo.reviews?.nodes)
-        .map(review => max(noNullish(review.comments.nodes)
-            .map(comment => new Date(comment.createdAt)))));
-    return max([latestIssueCommentDate, latestReviewCommentDate]);
+    const getCommentDate = (comment: { createdAt: string }) => new Date(comment.createdAt);
+    const latestIssueCommentDate = noNullish(prInfo.comments.nodes)
+        .filter(authorNotBot).map(getCommentDate);
+    const latestReviewCommentDate = noNullish(prInfo.reviews?.nodes)
+        .map(review => max(noNullish(review.comments.nodes).map(getCommentDate)));
+    return max([...latestIssueCommentDate, ...latestReviewCommentDate]);
 }
 
 type MovedColumnsInProjectEvent = PR_repository_pullRequest_timelineItems_nodes_MovedColumnsInProjectEvent;

--- a/src/queries/pr-query.ts
+++ b/src/queries/pr-query.ts
@@ -34,14 +34,9 @@ query PR($pr_number: Int!) {
         state
         headRefOid
 
-        timelineItems(last: 200, itemTypes: [ISSUE_COMMENT, REOPENED_EVENT, READY_FOR_REVIEW_EVENT,
+        timelineItems(last: 200, itemTypes: [REOPENED_EVENT, READY_FOR_REVIEW_EVENT,
                                              MOVED_COLUMNS_IN_PROJECT_EVENT]) {
           nodes {
-            __typename
-            ... on IssueComment {
-              author { login }
-              createdAt
-            }
             ... on ReopenedEvent {
               createdAt
             }
@@ -112,7 +107,7 @@ query PR($pr_number: Int!) {
           }
         }
 
-        comments(first: 100) {
+        comments(last: 100) {
           totalCount
           nodes {
             id

--- a/src/queries/schema/PR.ts
+++ b/src/queries/schema/PR.ts
@@ -42,27 +42,7 @@ export interface PR_repository_pullRequest_labels {
 }
 
 export interface PR_repository_pullRequest_timelineItems_nodes_AddedToProjectEvent {
-  __typename: "AddedToProjectEvent" | "AssignedEvent" | "AutomaticBaseChangeFailedEvent" | "AutomaticBaseChangeSucceededEvent" | "BaseRefChangedEvent" | "BaseRefDeletedEvent" | "BaseRefForcePushedEvent" | "ClosedEvent" | "CommentDeletedEvent" | "ConnectedEvent" | "ConvertToDraftEvent" | "ConvertedNoteToIssueEvent" | "CrossReferencedEvent" | "DemilestonedEvent" | "DeployedEvent" | "DeploymentEnvironmentChangedEvent" | "DisconnectedEvent" | "HeadRefDeletedEvent" | "HeadRefForcePushedEvent" | "HeadRefRestoredEvent" | "LabeledEvent" | "LockedEvent" | "MarkedAsDuplicateEvent" | "MentionedEvent" | "MergedEvent" | "MilestonedEvent" | "PinnedEvent" | "PullRequestCommit" | "PullRequestCommitCommentThread" | "PullRequestReview" | "PullRequestReviewThread" | "PullRequestRevisionMarker" | "ReferencedEvent" | "RemovedFromProjectEvent" | "RenamedTitleEvent" | "ReviewDismissedEvent" | "ReviewRequestRemovedEvent" | "ReviewRequestedEvent" | "SubscribedEvent" | "TransferredEvent" | "UnassignedEvent" | "UnlabeledEvent" | "UnlockedEvent" | "UnmarkedAsDuplicateEvent" | "UnpinnedEvent" | "UnsubscribedEvent" | "UserBlockedEvent";
-}
-
-export interface PR_repository_pullRequest_timelineItems_nodes_IssueComment_author {
-  __typename: "EnterpriseUserAccount" | "Organization" | "User" | "Mannequin" | "Bot";
-  /**
-   * The username of the actor.
-   */
-  login: string;
-}
-
-export interface PR_repository_pullRequest_timelineItems_nodes_IssueComment {
-  __typename: "IssueComment";
-  /**
-   * The actor who authored the comment.
-   */
-  author: PR_repository_pullRequest_timelineItems_nodes_IssueComment_author | null;
-  /**
-   * Identifies the date and time when the object was created.
-   */
-  createdAt: any;
+  __typename: "AddedToProjectEvent" | "AssignedEvent" | "AutomaticBaseChangeFailedEvent" | "AutomaticBaseChangeSucceededEvent" | "BaseRefChangedEvent" | "BaseRefDeletedEvent" | "BaseRefForcePushedEvent" | "ClosedEvent" | "CommentDeletedEvent" | "ConnectedEvent" | "ConvertToDraftEvent" | "ConvertedNoteToIssueEvent" | "CrossReferencedEvent" | "DemilestonedEvent" | "DeployedEvent" | "DeploymentEnvironmentChangedEvent" | "DisconnectedEvent" | "HeadRefDeletedEvent" | "HeadRefForcePushedEvent" | "HeadRefRestoredEvent" | "IssueComment" | "LabeledEvent" | "LockedEvent" | "MarkedAsDuplicateEvent" | "MentionedEvent" | "MergedEvent" | "MilestonedEvent" | "PinnedEvent" | "PullRequestCommit" | "PullRequestCommitCommentThread" | "PullRequestReview" | "PullRequestReviewThread" | "PullRequestRevisionMarker" | "ReferencedEvent" | "RemovedFromProjectEvent" | "RenamedTitleEvent" | "ReviewDismissedEvent" | "ReviewRequestRemovedEvent" | "ReviewRequestedEvent" | "SubscribedEvent" | "TransferredEvent" | "UnassignedEvent" | "UnlabeledEvent" | "UnlockedEvent" | "UnmarkedAsDuplicateEvent" | "UnpinnedEvent" | "UnsubscribedEvent" | "UserBlockedEvent";
 }
 
 export interface PR_repository_pullRequest_timelineItems_nodes_ReopenedEvent {
@@ -101,7 +81,7 @@ export interface PR_repository_pullRequest_timelineItems_nodes_MovedColumnsInPro
   createdAt: any;
 }
 
-export type PR_repository_pullRequest_timelineItems_nodes = PR_repository_pullRequest_timelineItems_nodes_AddedToProjectEvent | PR_repository_pullRequest_timelineItems_nodes_IssueComment | PR_repository_pullRequest_timelineItems_nodes_ReopenedEvent | PR_repository_pullRequest_timelineItems_nodes_ReadyForReviewEvent | PR_repository_pullRequest_timelineItems_nodes_MovedColumnsInProjectEvent;
+export type PR_repository_pullRequest_timelineItems_nodes = PR_repository_pullRequest_timelineItems_nodes_AddedToProjectEvent | PR_repository_pullRequest_timelineItems_nodes_ReopenedEvent | PR_repository_pullRequest_timelineItems_nodes_ReadyForReviewEvent | PR_repository_pullRequest_timelineItems_nodes_MovedColumnsInProjectEvent;
 
 export interface PR_repository_pullRequest_timelineItems {
   __typename: "PullRequestTimelineItemsConnection";

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -37,19 +37,6 @@ export function findLast<T>(arr: readonly T[] | null | undefined, predicate: (it
     return undefined;
 }
 
-export function forEachReverse<T, U>(arr: readonly T[] | null | undefined, action: (item: T) => U | undefined): U | undefined {
-    if (!arr) {
-        return undefined;
-    }
-    for (let i = arr.length - 1; i >= 0; i--) {
-        const result = action(arr[i]);
-        if (result !== undefined) {
-            return result;
-        }
-    }
-    return undefined;
-}
-
 export function min<T>(arr: readonly [T, ...(T | undefined)[]]): T;
 export function min<T>(arr: readonly T[], compare?: (a: T, b: T) => number): T | undefined;
 export function min<T>(arr: readonly T[], compare?: (a: T, b: T) => number) {


### PR DESCRIPTION
`pullRequest.comments` and `pullRequest.timelineItems(itemTypes: ISSUE_COMMENT)` are the same thing, so use one or the other. Trims the query without changing the behavior.