### PR TITLE
Type check mutation inputs

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@azure/functions": "^1.2.2",
     "@graphql-codegen/fragment-matcher": "^1.15.4",
-    "@octokit/graphql-schema": "^6.70.1",
+    "@octokit/graphql-schema": "^10.11.0",
     "@octokit/webhooks": "^6.3.2",
     "@types/node": "latest",
     "@types/node-fetch": "^1.6.9",

--- a/src/execute-pr-actions.ts
+++ b/src/execute-pr-actions.ts
@@ -1,3 +1,4 @@
+import * as schema from "@octokit/graphql-schema/schema";
 import { PR as PRQueryResult, PR_repository_pullRequest } from "./queries/schema/PR";
 import { Actions, LabelNames, LabelName } from "./compute-pr-actions";
 import { createMutation, mutate } from "./graphql-client";
@@ -43,9 +44,9 @@ async function getMutationsForLabels(actions: Actions, pr: PR_repository_pullReq
     const makeMutations = async (pred: (l: LabelName) => boolean, query: string) => {
         const labels = LabelNames.filter(pred);
         return labels.length === 0 ? null
-            : createMutation(query, { input: {
+            : createMutation<schema.AddLabelsToLabelableInput & schema.RemoveLabelsFromLabelableInput>(query, {
                 labelIds: await Promise.all(labels.map(label => getLabelIdByName(label))),
-                labelableId: pr.id, } });
+                labelableId: pr.id, });
     };
     return Promise.all([
         makeMutations((label => !labels.includes(label) && actions.labels.includes(label)), addLabels),
@@ -57,17 +58,17 @@ async function getMutationsForProjectChanges(actions: Actions, pr: PR_repository
     if (actions.shouldRemoveFromActiveColumns) {
         const card = pr.projectCards.nodes?.find(card => card?.project.number === ProjectBoardNumber);
         if (card?.column?.name === "Recently Merged") return [];
-        return [createMutation(deleteProjectCard, { input: { cardId: card!.id } })];
+        return [createMutation<schema.DeleteProjectCardInput>(deleteProjectCard, { cardId: card!.id })];
     }
     if (!(actions.shouldUpdateProjectColumn && actions.targetColumn)) return [];
     const existingCard = pr.projectCards.nodes?.find(n => !!n?.column && n.project.number === ProjectBoardNumber);
     const targetColumnId = await getProjectBoardColumnIdByName(actions.targetColumn);
     // No existing card => create a new one
-    if (!existingCard) return [createMutation(addProjectCard, { input: { contentId: pr.id, projectColumnId: targetColumnId } })];
+    if (!existingCard) return [createMutation<schema.AddProjectCardInput>(addProjectCard, { contentId: pr.id, projectColumnId: targetColumnId })];
     // Existing card is ok => do nothing
     if (existingCard.column?.name === actions.targetColumn) return [];
     // Move existing card
-    return [createMutation(moveProjectCard, { input: { cardId: existingCard.id, columnId: targetColumnId } })];
+    return [createMutation<schema.MoveProjectCardInput>(moveProjectCard, { cardId: existingCard.id, columnId: targetColumnId })];
 }
 
 type ParsedComment = { id: string, body: string, tag: string, status: string };
@@ -85,13 +86,13 @@ function getMutationsForComments(actions: Actions, prId: string, botComments: Pa
     return flatten(actions.responseComments.map(wantedComment => {
         const sameTagComments = botComments.filter(comment => comment.tag === wantedComment.tag);
         return sameTagComments.length === 0
-            ? [createMutation(addComment, {
-                input: { subjectId: prId, body: comment.make(wantedComment) } })]
+            ? [createMutation<schema.AddCommentInput>(addComment, {
+                subjectId: prId, body: comment.make(wantedComment) })]
             : sameTagComments.map(actualComment =>
                 (actualComment.status === wantedComment.status) ? null // Comment is up-to-date; skip
-                : createMutation(editComment, { input: {
+                : createMutation<schema.UpdateIssueCommentInput>(editComment, {
                     id: actualComment.id,
-                    body: comment.make(wantedComment) } }));
+                    body: comment.make(wantedComment) }));
     }));
 }
 
@@ -100,7 +101,7 @@ function getMutationsForCommentRemovals(actions: Actions, botComments: ParsedCom
     const postedTags = actions.responseComments.map(c => c.tag);
     return botComments.map(comment => {
         const { tag, id } = comment;
-        const del = () => createMutation(deleteComment, { input: { id } });
+        const del = () => createMutation<schema.DeleteIssueCommentInput>(deleteComment, { id });
         // Remove stale CI 'your build is green' notifications
         if (tag.includes("ci-") && tag !== ciTagToKeep) return del();
         // tags for comments that should be removed when not included in the actions
@@ -112,17 +113,15 @@ function getMutationsForCommentRemovals(actions: Actions, botComments: ParsedCom
 function getMutationsForChangingPRState(actions: Actions, pr: PR_repository_pullRequest) {
     return [
         actions.shouldMerge
-            ? createMutation(mergePr, {
-                input: {
-                    commitHeadline: `🤖 Merge PR #${pr.number} ${pr.title} by @${pr.author?.login ?? "(ghost)"}`,
-                    expectedHeadOid: pr.headRefOid,
-                    mergeMethod: "SQUASH",
-                    pullRequestId: pr.id,
-                },
+            ? createMutation<schema.MergePullRequestInput>(mergePr, {
+                commitHeadline: `🤖 Merge PR #${pr.number} ${pr.title} by @${pr.author?.login ?? "(ghost)"}`,
+                expectedHeadOid: pr.headRefOid,
+                mergeMethod: "SQUASH",
+                pullRequestId: pr.id,
             })
             : null,
         actions.shouldClose
-            ? createMutation(closePr, { input: { pullRequestId: pr.id } })
+            ? createMutation<schema.ClosePullRequestInput>(closePr, { pullRequestId: pr.id })
             : null
     ];
 }

--- a/src/graphql-client.ts
+++ b/src/graphql-client.ts
@@ -46,7 +46,7 @@ export async function mutate(mutation: Mutation) {
     return await result.text();
 }
 
-export function createMutation(query: string, input: unknown): Mutation {
+export function createMutation<T>(query: string, input: T): Mutation {
     return {
         method: "POST",
         headers: {
@@ -55,7 +55,7 @@ export function createMutation(query: string, input: unknown): Mutation {
         },
         body: JSON.stringify({
             query,
-            variables: input
+            variables: { input }
         }, undefined, 2)
     };
 }

--- a/src/run.ts
+++ b/src/run.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import * as schema from "@octokit/graphql-schema/schema";
 import * as yargs from "yargs";
 import { process as computeActions } from "./compute-pr-actions";
 import { getAllOpenPRsAndCardIDs } from "./queries/all-open-prs-query";
@@ -98,7 +99,7 @@ const start = async function () {
             // during the scan would end up here.
             return console.log(`  Should delete "${id}" (${shoulda})`);
         }
-        const mutation = createMutation(deleteProjectCard, { input: { cardId: id }});
+        const mutation = createMutation<schema.DeleteProjectCardInput>(deleteProjectCard, { cardId: id });
         await mutate(mutation);
     }
     // Reduce "Recently Merged"

--- a/src/side-effects/merge-codeowner-prs.ts
+++ b/src/side-effects/merge-codeowner-prs.ts
@@ -1,3 +1,4 @@
+import * as schema from "@octokit/graphql-schema/schema";
 import { WebhookPayloadCheckSuite } from "@octokit/webhooks";
 import { createMutation, mutate } from "../graphql-client";
 import { mergePr } from "../execute-pr-actions";
@@ -15,11 +16,11 @@ export const mergeCodeOwnersOnGreen = async (payload: WebhookPayloadCheckSuite) 
   const isFromSameRepo = payload.check_suite.pull_requests[0].base.repo.id === payload.check_suite.pull_requests[0].head.repo.id;
 
   if (isGreen && isFromBot && hasRightCommitMsg && isFromSameRepo) {
-    const mergeMutation = createMutation(mergePr, {
+    const mergeMutation = createMutation<schema.MergePullRequestInput>(mergePr, {
       commitHeadline: `🤖 Auto Merge`,
       expectedHeadOid: payload.check_suite.head_commit.id,
       mergeMethod: "SQUASH",
-      pullRequestId: payload.check_suite.pull_requests[0].id,
+      pullRequestId: payload.check_suite.pull_requests[0].id.toFixed(),
     });
 
     await mutate(mergeMutation);


### PR DESCRIPTION
We already depend on `@octokit/graphql-schema` which ships types for these inputs. Use them to catch errors at build time.