### PR TITLE
Bind data and variable types to queries

### DIFF
--- a/src/pr-info.ts
+++ b/src/pr-info.ts
@@ -163,7 +163,7 @@ export async function queryPRInfo(prNumber: number) {
     // get a proper value, or return a useless one if giving up.
     let retries = 0;
     while (true) {
-        const info = await client.query<PRQueryResult>({
+        const info = await client.query({
             query: GetPRInfo,
             variables: { pr_number: prNumber },
             fetchPolicy: "network-only",

--- a/src/queries/SHA1-to-PR-query.ts
+++ b/src/queries/SHA1-to-PR-query.ts
@@ -1,9 +1,9 @@
-import { gql } from "@apollo/client/core";
+import { gql, TypedDocumentNode } from "@apollo/client/core";
 import { client } from "../graphql-client";
-import { GetPRForSHA1 } from "./schema/GetPRForSHA1";
+import { GetPRForSHA1, GetPRForSHA1Variables } from "./schema/GetPRForSHA1";
 
 export const runQueryToGetPRMetadataForSHA1 = async (owner: string, repo: string, sha1: string) => {
-  const info = await client.query<GetPRForSHA1>({
+  const info = await client.query({
       query: GetPRForSHA1Query,
       variables: { query: `${sha1} type:pr repo:${owner}/${repo}` },
       fetchPolicy: "network-only",
@@ -12,7 +12,7 @@ export const runQueryToGetPRMetadataForSHA1 = async (owner: string, repo: string
   return pr?.__typename === "PullRequest" ? pr : undefined;
 };
 
-export const GetPRForSHA1Query = gql`
+export const GetPRForSHA1Query: TypedDocumentNode<GetPRForSHA1, GetPRForSHA1Variables> = gql`
 query GetPRForSHA1($query: String!) {
   search(query: $query, first: 1, type: ISSUE) {
     nodes {

--- a/src/queries/all-open-prs-query.ts
+++ b/src/queries/all-open-prs-query.ts
@@ -1,8 +1,8 @@
-import { gql } from "@apollo/client/core";
+import { gql, TypedDocumentNode } from "@apollo/client/core";
 import { client } from "../graphql-client";
 import { GetAllOpenPRsAndCardIDs, GetAllOpenPRsAndCardIDsVariables } from "./schema/GetAllOpenPRsAndCardIDs";
 
-export const getAllOpenPRsAndCardIDsQuery = gql`
+export const getAllOpenPRsAndCardIDsQuery: TypedDocumentNode<GetAllOpenPRsAndCardIDs, GetAllOpenPRsAndCardIDsVariables> = gql`
 query GetAllOpenPRsAndCardIDs($after: String) {
   repository(owner: "DefinitelyTyped", name: "DefinitelyTyped") {
     id
@@ -24,7 +24,7 @@ export async function getAllOpenPRsAndCardIDs() {
   const cardIDs: string[] = [];
   let after: string | undefined;
   while (true) {
-    const results = await client.query<GetAllOpenPRsAndCardIDs, GetAllOpenPRsAndCardIDsVariables>({
+    const results = await client.query({
       query: getAllOpenPRsAndCardIDsQuery,
       fetchPolicy: "network-only",
       variables: { after }

--- a/src/queries/card-id-to-pr-query.ts
+++ b/src/queries/card-id-to-pr-query.ts
@@ -1,7 +1,7 @@
-import { gql } from "@apollo/client/core";
+import { gql, TypedDocumentNode } from "@apollo/client/core";
 import { client } from "../graphql-client";
 import { PullRequestState } from "./schema/graphql-global-types";
-import { CardIdToPr } from "./schema/CardIdToPr";
+import { CardIdToPr, CardIdToPrVariables } from "./schema/CardIdToPr";
 
 interface CardPRInfo {
     number: number;
@@ -9,13 +9,13 @@ interface CardPRInfo {
 }
 
 export const runQueryToGetPRForCardId = async (id: string): Promise<CardPRInfo | undefined> => {
-    const info = await client.query<CardIdToPr>({
+    const info = await client.query({
         query: gql`
             query CardIdToPr($id: ID!) {
                 node(id: $id) {
                     ... on ProjectCard { content { ... on PullRequest { state number } } }
                 }
-            }`,
+            }` as TypedDocumentNode<CardIdToPr, CardIdToPrVariables>,
         variables: { id },
         fetchPolicy: "network-only",
     });

--- a/src/queries/file-query.ts
+++ b/src/queries/file-query.ts
@@ -1,6 +1,9 @@
-import { gql } from "@apollo/client/core";
+import { gql, TypedDocumentNode } from "@apollo/client/core";
+import { GetFileContent, GetFileContentVariables } from "./schema/GetFileContent";
 
-export const GetFileContent = gql`
+export { GetFileContent };
+
+const GetFileContent: TypedDocumentNode<GetFileContent, GetFileContentVariables> = gql`
   query GetFileContent($owner: String!, $name: String!, $expr: String!) {
     repository(owner: $owner, name: $name) {
       id

--- a/src/queries/label-columns-queries.ts
+++ b/src/queries/label-columns-queries.ts
@@ -1,6 +1,10 @@
-import { gql } from "@apollo/client/core";
+import { gql, TypedDocumentNode } from "@apollo/client/core";
+import { GetLabels } from "./schema/GetLabels";
+import { GetProjectColumns } from "./schema/GetProjectColumns";
 
-export const GetLabels = gql`
+export { GetLabels, GetProjectColumns };
+
+const GetLabels: TypedDocumentNode<GetLabels, never> = gql`
 query GetLabels {
   repository(name:"DefinitelyTyped", owner:"DefinitelyTyped") {
     id
@@ -13,7 +17,7 @@ query GetLabels {
   }
 }`;
 
-export const GetProjectColumns = gql`
+const GetProjectColumns: TypedDocumentNode<GetProjectColumns, never> = gql`
 query GetProjectColumns {
   repository(name:"DefinitelyTyped", owner:"DefinitelyTyped") {
     id

--- a/src/queries/pr-query.ts
+++ b/src/queries/pr-query.ts
@@ -1,4 +1,5 @@
-import { gql } from "@apollo/client/core";
+import { gql, TypedDocumentNode } from "@apollo/client/core";
+import { PR, PRVariables } from "./schema/PR";
 
 // Note: If you want to work on this in a copy of GraphiQL (the IDE-like for GraphQL)
 // - You will need to download the electron app: https://github.com/skevy/graphiql-app
@@ -9,7 +10,7 @@ import { gql } from "@apollo/client/core";
 // - Now you're good to C&P the query below
 
 /** This is a GraphQL AST tree */
-export const GetPRInfo = gql`
+export const GetPRInfo: TypedDocumentNode<PR, PRVariables> = gql`
 query PR($pr_number: Int!) {
     repository(owner: "DefinitelyTyped", name: "DefinitelyTyped") {
       id

--- a/src/queries/projectboard-cards.ts
+++ b/src/queries/projectboard-cards.ts
@@ -1,8 +1,8 @@
-import { gql } from "@apollo/client/core";
+import { gql, TypedDocumentNode } from "@apollo/client/core";
 import { client } from "../graphql-client";
 import { GetProjectBoardCards } from "./schema/GetProjectBoardCards";
 
-const GetProjectBoardCardsQuery = gql`
+const GetProjectBoardCardsQuery: TypedDocumentNode<GetProjectBoardCards, never> = gql`
   query GetProjectBoardCards {
     repository(owner: "DefinitelyTyped", name: "DefinitelyTyped") {
       id
@@ -36,7 +36,7 @@ interface ColumnInfo {
 }
 
 export async function getProjectBoardCards() {
-    const results = await client.query<GetProjectBoardCards>({
+    const results = await client.query({
         query: GetProjectBoardCardsQuery,
         fetchPolicy: "network-only",
     });

--- a/src/util/cachedQueries.ts
+++ b/src/util/cachedQueries.ts
@@ -1,6 +1,5 @@
+import { TypedDocumentNode } from "@apollo/client/core";
 import { GetLabels, GetProjectColumns } from "../queries/label-columns-queries";
-import { GetProjectColumns as GetProjectColumnsResult } from "../queries/schema/GetProjectColumns";
-import { GetLabels as GetLabelsResult } from "../queries/schema/GetLabels";
 import { createCache } from "../ttl-cache";
 import { client } from "../graphql-client";
 import { noNullish } from "./util";
@@ -9,7 +8,7 @@ const cache = createCache();
 
 export async function getProjectBoardColumns() {
   return cache.getAsync("project board colum names", Infinity, async () => {
-      const res = noNullish((await query<GetProjectColumnsResult>(GetProjectColumns))
+      const res = noNullish((await query(GetProjectColumns))
           .repository?.project?.columns.nodes);
       return res.sort((a,b) => a.name.localeCompare(b.name));
   });
@@ -17,14 +16,14 @@ export async function getProjectBoardColumns() {
 
 export async function getLabels() {
   return await cache.getAsync("label ids", Infinity, async () => {
-      const res = noNullish((await query<GetLabelsResult>(GetLabels))
+      const res = noNullish((await query(GetLabels))
           .repository?.labels?.nodes);
       return res.sort((a,b) => a.name.localeCompare(b.name));
   });
 }
 
-async function query<T>(gql: any): Promise<T> {
-  const res = await client.query<T>({
+async function query<T>(gql: TypedDocumentNode<T>): Promise<T> {
+  const res = await client.query({
       query: gql,
       fetchPolicy: "network-only",
   });

--- a/src/util/fetchFile.ts
+++ b/src/util/fetchFile.ts
@@ -1,9 +1,8 @@
 import { client } from "../graphql-client";
 import { GetFileContent } from "../queries/file-query";
-import { GetFileContent as GetFileContentResult } from "../queries/schema/GetFileContent";
 
 export async function fetchFile(expr: string, limit?: number): Promise<string | undefined> {
-  const info = await client.query<GetFileContentResult>({
+  const info = await client.query({
       query: GetFileContent,
       variables: {
           name: "DefinitelyTyped",


### PR DESCRIPTION
Instead of passing them independently at the call site (`query<T, TVariables>()`) https://github.com/apollographql/apollo-client/blob/main/CHANGELOG.md#user-content-improvements-9:~:text=allows%20the%20APIs%20to%20infer%20the,types%20explicitly%20at%20the%20call%20site

As a result of binding types to queries, this PR type checks variables in a couple places that were missed before. ~This PR is a draft because it depends on #301.~ Ready now :+1: