### PR TITLE
asJson() -> toJSON()

### DIFF
--- a/src/_tests/fixturedActions.test.ts
+++ b/src/_tests/fixturedActions.test.ts
@@ -49,7 +49,7 @@ async function testFixture(dir: string) {
   expect(JSONString(derived)).toMatchFile(derivedPath);
 
   const mutations = await executePrActions(action, response.data, /*dry*/ true);
-  expect(JSONString(mutations.map(m => m.asJson()))).toMatchFile(mutationsPath);
+  expect(JSONString(mutations)).toMatchFile(mutationsPath);
 }
 
 describe("Test fixtures", () => {

--- a/src/commands/create-fixture.ts
+++ b/src/commands/create-fixture.ts
@@ -51,7 +51,7 @@ export default async function main(directory: string, overwriteInfo: boolean) {
 
   const mutationsFixturePath = join(fixturePath, "mutations.json");
   const mutations = await executePrActions(actions, response.data, /*dry*/ true);
-  writeJsonSync(mutationsFixturePath, mutations.map(m => m.asJson()));
+  writeJsonSync(mutationsFixturePath, mutations);
 
   console.log(`Recorded`);
 

--- a/src/execute-pr-actions.ts
+++ b/src/execute-pr-actions.ts
@@ -1,3 +1,4 @@
+import { MutationOptions } from "@apollo/client/core";
 import * as schema from "@octokit/graphql-schema/schema";
 import { PR as PRQueryResult, PR_repository_pullRequest } from "./queries/schema/PR";
 import { Actions, LabelNames, LabelName } from "./compute-pr-actions";
@@ -22,7 +23,8 @@ export async function executePrActions(actions: Actions, info: PRQueryResult, dr
     ]);
     if (!dry) {
         // Perform mutations one at a time
-        for (const mutation of mutations) await client.mutate<void, typeof mutations[number]["variables"]>(mutation);
+        for (const mutation of mutations)
+            await client.mutate(mutation as MutationOptions<void, typeof mutations[number]["variables"]>);
     }
     return mutations;
 }

--- a/src/run.ts
+++ b/src/run.ts
@@ -87,7 +87,7 @@ const start = async function () {
         if (args["show-actions"]) show("Actions", actions);
         // Act on the actions
         const mutations = await executePrActions(actions, info.data, args.dry);
-        if (args["show-mutations"] ?? args.dry) show("Mutations", mutations.map(m => m.asJson()));
+        if (args["show-mutations"] ?? args.dry) show("Mutations", mutations);
     }
     if (args.dry || !args.cleanup) return;
     //


### PR DESCRIPTION
Cosmetic suggestion, please dismiss if it's not an improvement.

Replace `asJson()` with `toJSON()`, which `JSON.stringify()` calls automatically.