### PR TITLE
Switch to project references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /bin/
 /node_modules/
 /coverage/
+tsconfig.tsbuildinfo

--- a/PR-Trigger/index.js
+++ b/PR-Trigger/index.js
@@ -1,5 +1,3 @@
-// @ts-check
-
 const { queryPRInfo, deriveStateForPR } = require("../bin/pr-info");
 const compute = require("../bin/compute-pr-actions");
 const { executePrActions } = require("../bin/execute-pr-actions");
@@ -26,7 +24,7 @@ const httpTrigger = async function (context, _req) {
     const isDev = process.env.AZURE_FUNCTIONS_ENVIRONMENT === "Development";
     const secret = process.env.GITHUB_WEBHOOK_SECRET;
     const webhooks = new Webhooks({ secret });
-    
+
     // For process.env.GITHUB_WEBHOOK_SECRET see
     // https://ms.portal.azure.com/#blade/WebsitesExtension/FunctionsIFrameBlade/id/%2Fsubscriptions%2F57bfeeed-c34a-4ffd-a06b-ccff27ac91b8%2FresourceGroups%2Fdtmergebot%2Fproviders%2FMicrosoft.Web%2Fsites%2FDTMergeBot
     if (!isDev && !webhooks.verify(req.body, webhooks.sign(req.body))) {

--- a/PR-Trigger/tsconfig.json
+++ b/PR-Trigger/tsconfig.json
@@ -1,0 +1,10 @@
+{
+    "extends": "../tsconfig.json",
+    "compilerOptions": {
+        "outDir": "../bin/PR-Trigger",
+        "allowJs": true
+    },
+    "files": [
+        "index.js"
+    ]
+}

--- a/package.json
+++ b/package.json
@@ -53,8 +53,8 @@
   },
   "scripts": {
     "prepublishOnly": "npm run build",
-    "build": "tsc",
-    "watch": "tsc --watch",
+    "build": "tsc -b",
+    "watch": "tsc -b --watch",
     "graphql-schema": "npx apollo client:codegen schema --target typescript --globalTypesFile=src/queries/schema/graphql-global-types.ts",
     "create-fixture": "npm run build && node bin/commands/create-fixture.js",
     "update-test-data": "npm run build && node bin/commands/update-test-data.js",

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -1,0 +1,10 @@
+{
+    "extends": "../tsconfig.json",
+    "compilerOptions": {
+        "outDir": "../bin"
+    },
+    "include": [
+        "./**/*.ts",
+        "./_tests/cachedQueries.json"
+    ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,10 @@
 {
-    "include": ["src"],
-    "exclude": ["src/use-pr-info.ts"],
+    "references": [
+        { "path": "src" },
+        { "path": "PR-Trigger" }
+    ],
     "compilerOptions": {
-        "outDir": "bin",
-        "rootDir": "src",
+        "composite": true,
         "strict": true,
         "module": "commonjs",
         "target": "es6",


### PR DESCRIPTION
Related to #294, but also as a step towards switching
`PR-Trigger/index.js` to TS so we can avoid more silly problems as after
the recent library updates.

Note that `PR-Trigger/tsconfig.json` is a bit bogus now:

* It creates its output in `bin/PR-Trigger`, but that output is not
  used (and wouldn't work because it needs to be with the rest of the
  azure function stuffs) -- I'd disable generating it if it was
  possible.

* In the future, it should switch to an `index.ts`, which would make it
  possible to use its own directory for the js file.