### PR TITLE
Check for failure before deriveStateForPR() vs. after

### DIFF
--- a/src/compute-pr-actions.ts
+++ b/src/compute-pr-actions.ts
@@ -1,6 +1,6 @@
 import * as Comments from "./comments";
 import * as urls from "./urls";
-import { PrInfo, BotNotFail, FileInfo } from "./pr-info";
+import { PrInfo, BotResult, FileInfo } from "./pr-info";
 import { CIResult } from "./util/CIResult";
 import { ReviewInfo } from "./pr-info";
 import { noNullish, flatten, unique, sameUser, daysSince, min, sha256, abbrOid } from "./util/util";
@@ -231,7 +231,7 @@ function extendPrInfo(info: PrInfo): ExtendedPrInfo {
 
 }
 
-export function process(prInfo: BotNotFail,
+export function process(prInfo: BotResult,
                         extendedCallback: (info: ExtendedPrInfo) => void = _i => {}): Actions {
     if (prInfo.type === "remove") {
         if (prInfo.isDraft) {

--- a/src/execute-pr-actions.ts
+++ b/src/execute-pr-actions.ts
@@ -1,6 +1,6 @@
 import { MutationOptions } from "@apollo/client/core";
 import * as schema from "@octokit/graphql-schema/schema";
-import { PR as PRQueryResult, PR_repository_pullRequest } from "./queries/schema/PR";
+import { PR_repository_pullRequest } from "./queries/schema/PR";
 import { Actions, LabelNames, LabelName } from "./compute-pr-actions";
 import { createMutation, client } from "./graphql-client";
 import { getProjectBoardColumns, getLabels } from "./util/cachedQueries";
@@ -11,8 +11,7 @@ import * as comment from "./util/comment";
 // https://github.com/DefinitelyTyped/DefinitelyTyped/projects/5
 const ProjectBoardNumber = 5;
 
-export async function executePrActions(actions: Actions, info: PRQueryResult, dry?: boolean) {
-    const pr = info.repository!.pullRequest!;
+export async function executePrActions(actions: Actions, pr: PR_repository_pullRequest, dry?: boolean) {
     const botComments: ParsedComment[] = getBotComments(pr);
     const mutations = noNullish([
         ...await getMutationsForLabels(actions, pr),


### PR DESCRIPTION
What do you think about factoring `BotFail` out of `BotResult`?

Instead of checking for `!prInfo` in `deriveStateForPR()` and also checking `state.type === "fail"` immediately afterwards (to narrow `BotResult` -> `BotNotFail`), replace the second check (`state.type === "fail"`) with `!prInfo`, move it ahead of `deriveStateForPR()` and call `deriveStateForPR()` on the non-null `prInfo`?

Also, instead of passing the whole GraphQL result to `executePrActions()` and then non-null asserting `info.repository!.pullRequest!`, just pass the non-null pull request data, like `deriveStateForPR()`.

No change in behavior, just cleave `BotFail` from `BotNotFail` and handle them separately, before and after `deriveStateForPR()`. Also makes the `executePrActions()` signature (slightly) stricter.