### PR TITLE
More cleanups

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -18,6 +18,20 @@
         "unicorn"
     ],
     "rules": {
+        "no-trailing-spaces": "error",
+        "eol-last": "error",
+        "semi": "error",
+        "quotes": ["error", "double", { "allowTemplateLiterals": true }],
+        "arrow-body-style": "error",
+        "indent": ["error", 4, {
+          "CallExpression": { "arguments": "first" },
+          "FunctionDeclaration": {"parameters": "first"},
+          "FunctionExpression": {"parameters": "first"},
+          "SwitchCase": 1,
+          "ImportDeclaration": "first",
+          "ArrayExpression": "first",
+          "ignoredNodes": ["ConditionalExpression", "TemplateLiteral > *"]
+        }],
         "no-constant-condition": ["error", { "checkLoops": false }],
         "no-useless-escape": "off",
         "@typescript-eslint/explicit-module-boundary-types": "off",

--- a/src/_tests/fixturedActions.test.ts
+++ b/src/_tests/fixturedActions.test.ts
@@ -8,8 +8,8 @@ import { PR } from "../queries/schema/PR";
 import { scrubDiagnosticDetails } from "../util/util";
 import * as cachedQueries from "./cachedQueries.json";
 jest.mock("../util/cachedQueries", () => ({
-  getProjectBoardColumns: jest.fn(() => cachedQueries.getProjectBoardColumns),
-  getLabels: jest.fn(() => cachedQueries.getLabels)
+    getProjectBoardColumns: jest.fn(() => cachedQueries.getProjectBoardColumns),
+    getLabels: jest.fn(() => cachedQueries.getLabels)
 }));
 import { executePrActions } from "../execute-pr-actions";
 
@@ -21,44 +21,44 @@ expect.extend({ toMatchFile });
  */
 
 async function testFixture(dir: string) {
-  // _foo.json are input files, except for Date.now from derived.json
-  const responsePath = join(dir, "_response.json");
-  const filesPath = join(dir, "_files.json");
-  const downloadsPath = join(dir, "_downloads.json");
-  const derivedPath = join(dir, "derived.json");
-  const resultPath = join(dir, "result.json");
-  const mutationsPath = join(dir, "mutations.json");
+    // _foo.json are input files, except for Date.now from derived.json
+    const responsePath = join(dir, "_response.json");
+    const filesPath = join(dir, "_files.json");
+    const downloadsPath = join(dir, "_downloads.json");
+    const derivedPath = join(dir, "derived.json");
+    const resultPath = join(dir, "result.json");
+    const mutationsPath = join(dir, "mutations.json");
 
-  const JSONString = (value: any) => scrubDiagnosticDetails(JSON.stringify(value, null, "  ") + "\n");
+    const JSONString = (value: any) => scrubDiagnosticDetails(JSON.stringify(value, null, "  ") + "\n");
 
-  const response: ApolloQueryResult<PR> = readJsonSync(responsePath);
-  const files = readJsonSync(filesPath);
-  const downloads = readJsonSync(downloadsPath);
+    const response: ApolloQueryResult<PR> = readJsonSync(responsePath);
+    const files = readJsonSync(filesPath);
+    const downloads = readJsonSync(downloadsPath);
 
-  const prInfo = response.data.repository?.pullRequest;
-  if (!prInfo) throw new Error("Should never happen");
+    const prInfo = response.data.repository?.pullRequest;
+    if (!prInfo) throw new Error("Should never happen");
 
-  const derived = await deriveStateForPR(
-    prInfo,
-    (expr: string) => Promise.resolve(files[expr] as string),
-    (name: string, _until?: Date) => name in downloads ? downloads[name] : 0,
-    (readJsonSync(derivedPath) as BotResult).now
-  );
+    const derived = await deriveStateForPR(
+        prInfo,
+        (expr: string) => Promise.resolve(files[expr] as string),
+        (name: string, _until?: Date) => name in downloads ? downloads[name] : 0,
+        (readJsonSync(derivedPath) as BotResult).now
+    );
 
-  const action = process(derived);
+    const action = process(derived);
 
-  expect(JSONString(action)).toMatchFile(resultPath);
-  expect(JSONString(derived)).toMatchFile(derivedPath);
+    expect(JSONString(action)).toMatchFile(resultPath);
+    expect(JSONString(derived)).toMatchFile(derivedPath);
 
-  const mutations = await executePrActions(action, prInfo, /*dry*/ true);
-  expect(JSONString(mutations)).toMatchFile(mutationsPath);
+    const mutations = await executePrActions(action, prInfo, /*dry*/ true);
+    expect(JSONString(mutations)).toMatchFile(mutationsPath);
 }
 
 describe("Test fixtures", () => {
-  const fixturesFolder = join(__dirname, "fixtures");
-  readdirSync(fixturesFolder, { withFileTypes: true }).forEach(dirent => {
-    if (dirent.isDirectory()) {
-      it(`Fixture: ${dirent.name}`, async () => testFixture(join(fixturesFolder, dirent.name)));
-    }
-  });
+    const fixturesFolder = join(__dirname, "fixtures");
+    readdirSync(fixturesFolder, { withFileTypes: true }).forEach(dirent => {
+        if (dirent.isDirectory()) {
+            it(`Fixture: ${dirent.name}`, async () => testFixture(join(fixturesFolder, dirent.name)));
+        }
+    });
 });

--- a/src/commands/create-fixture.ts
+++ b/src/commands/create-fixture.ts
@@ -10,95 +10,95 @@ import { scrubDiagnosticDetails } from "../util/util";
 import { executePrActions } from "../execute-pr-actions";
 
 export default async function main(directory: string, overwriteInfo: boolean) {
-  const writeJsonSync = (file: string, json: unknown) =>
-      writeFileSync(file, scrubDiagnosticDetails(JSON.stringify(json, undefined, 2) + "\n"));
+    const writeJsonSync = (file: string, json: unknown) =>
+        writeFileSync(file, scrubDiagnosticDetails(JSON.stringify(json, undefined, 2) + "\n"));
 
-  const fixturePath = join("src", "_tests", "fixtures", directory);
-  const prNumber = parseInt(directory, 10);
-  if (isNaN(prNumber)) throw new Error(`Expected ${directory} to be parseable as a PR number`);
+    const fixturePath = join("src", "_tests", "fixtures", directory);
+    const prNumber = parseInt(directory, 10);
+    if (isNaN(prNumber)) throw new Error(`Expected ${directory} to be parseable as a PR number`);
 
-  if (!existsSync(fixturePath)) mkdirSync(fixturePath);
+    if (!existsSync(fixturePath)) mkdirSync(fixturePath);
 
-  const jsonFixturePath = join(fixturePath, "_response.json");
-  if (overwriteInfo || !existsSync(jsonFixturePath)) {
-    writeJsonSync(jsonFixturePath, await queryPRInfo(prNumber));
-  }
-  const response: ApolloQueryResult<PR> = readJsonSync(jsonFixturePath);
+    const jsonFixturePath = join(fixturePath, "_response.json");
+    if (overwriteInfo || !existsSync(jsonFixturePath)) {
+        writeJsonSync(jsonFixturePath, await queryPRInfo(prNumber));
+    }
+    const response: ApolloQueryResult<PR> = readJsonSync(jsonFixturePath);
 
-  const filesJSONPath = join(fixturePath, "_files.json");
-  const filesFetched: {[expr: string]: string | undefined} = {};
-  const downloadsJSONPath = join(fixturePath, "_downloads.json");
-  const downloadsFetched: {[packageName: string]: number} = {};
-  const derivedFixturePath = join(fixturePath, "derived.json");
+    const filesJSONPath = join(fixturePath, "_files.json");
+    const filesFetched: {[expr: string]: string | undefined} = {};
+    const downloadsJSONPath = join(fixturePath, "_downloads.json");
+    const downloadsFetched: {[packageName: string]: number} = {};
+    const derivedFixturePath = join(fixturePath, "derived.json");
 
-  const shouldOverwrite = (file: string) => overwriteInfo || !existsSync(file);
+    const shouldOverwrite = (file: string) => overwriteInfo || !existsSync(file);
 
-  const prInfo = response.data.repository?.pullRequest;
-  if (!prInfo) {
-    console.error(`Could not get PR info for ${directory}, is the number correct?`);
-    return;
-  }
+    const prInfo = response.data.repository?.pullRequest;
+    if (!prInfo) {
+        console.error(`Could not get PR info for ${directory}, is the number correct?`);
+        return;
+    }
 
-  const derivedInfo = await deriveStateForPR(
-    prInfo,
-    shouldOverwrite(filesJSONPath) ? initFetchFilesAndWriteToFile() : getFilesFromFile,
-    shouldOverwrite(downloadsJSONPath) ? initGetDownloadsAndWriteToFile() : getDownloadsFromFile,
-    shouldOverwrite(derivedFixturePath) ? undefined : getTimeFromFile(),
-  );
+    const derivedInfo = await deriveStateForPR(
+        prInfo,
+        shouldOverwrite(filesJSONPath) ? initFetchFilesAndWriteToFile() : getFilesFromFile,
+        shouldOverwrite(downloadsJSONPath) ? initGetDownloadsAndWriteToFile() : getDownloadsFromFile,
+        shouldOverwrite(derivedFixturePath) ? undefined : getTimeFromFile(),
+    );
 
-  writeJsonSync(derivedFixturePath, derivedInfo);
+    writeJsonSync(derivedFixturePath, derivedInfo);
 
-  const resultFixturePath = join(fixturePath, "result.json");
-  const actions = computeActions.process(derivedInfo);
-  writeJsonSync(resultFixturePath, actions);
+    const resultFixturePath = join(fixturePath, "result.json");
+    const actions = computeActions.process(derivedInfo);
+    writeJsonSync(resultFixturePath, actions);
 
-  const mutationsFixturePath = join(fixturePath, "mutations.json");
-  const mutations = await executePrActions(actions, prInfo, /*dry*/ true);
-  writeJsonSync(mutationsFixturePath, mutations);
+    const mutationsFixturePath = join(fixturePath, "mutations.json");
+    const mutations = await executePrActions(actions, prInfo, /*dry*/ true);
+    writeJsonSync(mutationsFixturePath, mutations);
 
-  console.log(`Recorded`);
+    console.log("Recorded");
 
-  function initFetchFilesAndWriteToFile() {
-    writeJsonSync(filesJSONPath, {}); // one-time initialization of an empty storage
-    return fetchFilesAndWriteToFile;
-  }
-  async function fetchFilesAndWriteToFile(expr: string, limit?: number) {
-    filesFetched[expr] = await fetchFile(expr, limit);
-    writeJsonSync(filesJSONPath, filesFetched);
-    return filesFetched[expr];
-  }
-  function getFilesFromFile(expr: string) {
-    return readJsonSync(filesJSONPath)[expr];
-  }
+    function initFetchFilesAndWriteToFile() {
+        writeJsonSync(filesJSONPath, {}); // one-time initialization of an empty storage
+        return fetchFilesAndWriteToFile;
+    }
+    async function fetchFilesAndWriteToFile(expr: string, limit?: number) {
+        filesFetched[expr] = await fetchFile(expr, limit);
+        writeJsonSync(filesJSONPath, filesFetched);
+        return filesFetched[expr];
+    }
+    function getFilesFromFile(expr: string) {
+        return readJsonSync(filesJSONPath)[expr];
+    }
 
-  function initGetDownloadsAndWriteToFile() {
-    writeJsonSync(downloadsJSONPath, {}); // one-time initialization of an empty storage
-    return getDownloadsAndWriteToFile;
-  }
-  async function getDownloadsAndWriteToFile(packageName: string, until?: Date) {
-    const downloads = await getMonthlyDownloadCount(packageName, until)
-    downloadsFetched[packageName] = downloads;
-    writeJsonSync(downloadsJSONPath, downloadsFetched);
-    return downloads;
-  }
-  function getDownloadsFromFile(packageName: string) {
-    return readJsonSync(downloadsJSONPath)[packageName];
-  }
+    function initGetDownloadsAndWriteToFile() {
+        writeJsonSync(downloadsJSONPath, {}); // one-time initialization of an empty storage
+        return getDownloadsAndWriteToFile;
+    }
+    async function getDownloadsAndWriteToFile(packageName: string, until?: Date) {
+        const downloads = await getMonthlyDownloadCount(packageName, until);
+        downloadsFetched[packageName] = downloads;
+        writeJsonSync(downloadsJSONPath, downloadsFetched);
+        return downloads;
+    }
+    function getDownloadsFromFile(packageName: string) {
+        return readJsonSync(downloadsJSONPath)[packageName];
+    }
 
-  function getTimeFromFile() {
-    return (readJsonSync(derivedFixturePath) as BotResult).now;
-  }
+    function getTimeFromFile() {
+        return (readJsonSync(derivedFixturePath) as BotResult).now;
+    }
 }
 
 
 if (!module.parent) {
-  const num = process.argv[2];
-  if (!num) {
-    console.error("expecting a PR number");
-    process.exit(1);
-  }
-  const overwriteInfo = process.argv.slice(2).includes("--overwrite-info")
-  main(num, overwriteInfo).then(() => {
-    process.exit(0);
-  });
+    const num = process.argv[2];
+    if (!num) {
+        console.error("expecting a PR number");
+        process.exit(1);
+    }
+    const overwriteInfo = process.argv.slice(2).includes("--overwrite-info");
+    main(num, overwriteInfo).then(() => {
+        process.exit(0);
+    });
 }

--- a/src/commands/update-all-fixtures.ts
+++ b/src/commands/update-all-fixtures.ts
@@ -3,24 +3,24 @@ import * as path from "path";
 import * as fs from "fs";
 
 async function main() {
-  const overwriteInfo = process.argv.slice(2).includes('--overwrite-info');
-  const fixturesDir = path.join(__dirname, "../../src/_tests/fixtures");
-  const fixtures = await fs.promises.readdir(fixturesDir, { withFileTypes: true });
-  for (const dir of fixtures) {
-    if (!dir.isDirectory()) continue;
-    console.log(`Updating ${dir.name}, ${overwriteInfo ? 'overwriting' : 'preserving'} the existing PR info...`);
-    await createFixture(dir.name, overwriteInfo);
-  }
+    const overwriteInfo = process.argv.slice(2).includes("--overwrite-info");
+    const fixturesDir = path.join(__dirname, "../../src/_tests/fixtures");
+    const fixtures = await fs.promises.readdir(fixturesDir, { withFileTypes: true });
+    for (const dir of fixtures) {
+        if (!dir.isDirectory()) continue;
+        console.log(`Updating ${dir.name}, ${overwriteInfo ? "overwriting" : "preserving"} the existing PR info...`);
+        await createFixture(dir.name, overwriteInfo);
+    }
 }
 
 main().then(() => {
-  console.log("Done!");
-  process.exit(0);
+    console.log("Done!");
+    process.exit(0);
 }, err => {
-  if (err?.stack) {
-      console.error(err.stack);
-  } else {
-      console.error(err);
-  }
-  process.exit(1);
+    if (err?.stack) {
+        console.error(err.stack);
+    } else {
+        console.error(err);
+    }
+    process.exit(1);
 });

--- a/src/commands/update-test-data.ts
+++ b/src/commands/update-test-data.ts
@@ -3,34 +3,35 @@ import * as path from "path";
 import * as cachedQueries from "../util/cachedQueries";
 
 async function main() {
-  let base = __dirname, dataPath = "";
-  while (!fs.existsSync(dataPath = path.join(base, "src", "_tests", "cachedQueries.json"))) {
-    const up = path.dirname(base);
-    if (up === base) throw new Error("Couldn't find cachedQueries.json");
-    base = up;
-  }
+    let base = __dirname, dataPath = "";
+    while (!fs.existsSync(dataPath = path.join(base, "src", "_tests", "cachedQueries.json"))) {
+        const up = path.dirname(base);
+        if (up === base) throw new Error("Couldn't find cachedQueries.json");
+        base = up;
+    }
 
-  const data: any = {};
+    const data: any = {};
 
-  for (const query in cachedQueries) {
-    data[query] = await cachedQueries[query as keyof typeof cachedQueries]();
-  }
+    for (const query in cachedQueries) {
+        data[query] = await cachedQueries[query as keyof typeof cachedQueries]();
+    }
 
-  await fs.promises.writeFile(
-      dataPath,
-      JSON.stringify({comment: "Generate & update with `npm run update-test-data`", ...data},
-                     undefined, 2), 'utf8');
+    await fs.promises.writeFile(
+        dataPath,
+        JSON.stringify({ comment: "Generate & update with `npm run update-test-data`", ...data },
+                       undefined, 2),
+        "utf8");
 }
 
 
 main().then(() => {
-  console.log("Done!");
-  process.exit(0);
+    console.log("Done!");
+    process.exit(0);
 }, err => {
-  if (err?.stack) {
-      console.error(err.stack);
-  } else {
-      console.error(err);
-  }
-  process.exit(1);
+    if (err?.stack) {
+        console.error(err.stack);
+    } else {
+        console.error(err);
+    }
+    process.exit(1);
 });

--- a/src/execute-pr-actions.ts
+++ b/src/execute-pr-actions.ts
@@ -29,7 +29,7 @@ export async function executePrActions(actions: Actions, pr: PR_repository_pullR
 }
 
 async function getMutationsForLabels(actions: Actions, pr: PR_repository_pullRequest) {
-    if (!actions.shouldUpdateLabels) return []
+    if (!actions.shouldUpdateLabels) return [];
     const labels = noNullish(pr.labels?.nodes).map(l => l.name);
     const makeMutations = async (pred: (l: LabelName) => boolean, query: keyof schema.Mutation) => {
         const labels = LabelNames.filter(pred);
@@ -64,12 +64,13 @@ async function getMutationsForProjectChanges(actions: Actions, pr: PR_repository
 type ParsedComment = { id: string, body: string, tag: string, status: string };
 
 function getBotComments(pr: PR_repository_pullRequest): ParsedComment[] {
-    return noNullish((pr.comments.nodes ?? [])
-                   .filter(comment => comment?.author?.login === "typescript-bot")
-                   .map(c => {
-                       const { id, body } = c!, parsed = comment.parse(body);
-                       return parsed && { id, body, ...parsed };
-                   }));
+    return noNullish(
+        (pr.comments.nodes ?? [])
+            .filter(comment => comment?.author?.login === "typescript-bot")
+            .map(c => {
+                const { id, body } = c!, parsed = comment.parse(body);
+                return parsed && { id, body, ...parsed };
+            }));
 }
 
 function getMutationsForComments(actions: Actions, prId: string, botComments: ParsedComment[]) {

--- a/src/graphql-client.ts
+++ b/src/graphql-client.ts
@@ -31,7 +31,7 @@ function getAuthToken() {
     if (process.env.JEST_WORKER_ID) return "FAKE_TOKEN";
 
     const result = process.env["BOT_AUTH_TOKEN"] || process.env["AUTH_TOKEN"];
-    if (typeof result !== 'string') {
+    if (typeof result !== "string") {
         throw new Error("Set either BOT_AUTH_TOKEN or AUTH_TOKEN to a valid auth token");
     }
     return result.trim();

--- a/src/pr-trigger.ts
+++ b/src/pr-trigger.ts
@@ -28,11 +28,11 @@ export async function httpTrigger(context: Context, req: HttpRequest) {
     // For process.env.GITHUB_WEBHOOK_SECRET see
     // https://ms.portal.azure.com/#blade/WebsitesExtension/FunctionsIFrameBlade/id/%2Fsubscriptions%2F57bfeeed-c34a-4ffd-a06b-ccff27ac91b8%2FresourceGroups%2Fdtmergebot%2Fproviders%2FMicrosoft.Web%2Fsites%2FDTMergeBot
     if (!isDev && !webhooks.verify(req.body, webhooks.sign(req.body))) {
-      context.res = {
-        status: 500,
-        body: "This webhook did not come from GitHub"
-      };
-      return;
+        context.res = {
+            status: 500,
+            body: "This webhook did not come from GitHub"
+        };
+        return;
     }
 
     // Allow the bot to run side-effects which are not the 'core' function
@@ -79,7 +79,7 @@ export async function httpTrigger(context: Context, req: HttpRequest) {
         context.res = {
             status: 204,
             body: `NOOPing due to not supporting ${action} on ${event}`
-        }
+        };
         return;
     }
 
@@ -96,7 +96,7 @@ export async function httpTrigger(context: Context, req: HttpRequest) {
         const cardURL = webhook.project_card.content_url;
         const numberInURL = cardURL.match(/\/\d+$/);
         if (!numberInURL) throw new Error(`Could not get PR for project card URL: ${cardURL}`);
-        prNumber = +numberInURL[0].substring(1)
+        prNumber = +numberInURL[0].substring(1);
     } else if ("check_suite" in webhook) {
         // See https://github.com/maintainers/early-access-feedback/issues/114 for more context on getting a PR from a SHA
         // TLDR: it's not in the API, and this search hack has been in used on Peril for the last ~3 years

--- a/src/queries/SHA1-to-PR-query.ts
+++ b/src/queries/SHA1-to-PR-query.ts
@@ -3,13 +3,13 @@ import { client } from "../graphql-client";
 import { GetPRForSHA1, GetPRForSHA1Variables } from "./schema/GetPRForSHA1";
 
 export const runQueryToGetPRMetadataForSHA1 = async (owner: string, repo: string, sha1: string) => {
-  const info = await client.query({
-      query: GetPRForSHA1Query,
-      variables: { query: `${sha1} type:pr repo:${owner}/${repo}` },
-      fetchPolicy: "network-only",
-  });
-  const pr = info.data.search.nodes?.[0];
-  return pr?.__typename === "PullRequest" ? pr : undefined;
+    const info = await client.query({
+        query: GetPRForSHA1Query,
+        variables: { query: `${sha1} type:pr repo:${owner}/${repo}` },
+        fetchPolicy: "network-only",
+    });
+    const pr = info.data.search.nodes?.[0];
+    return pr?.__typename === "PullRequest" ? pr : undefined;
 };
 
 export const GetPRForSHA1Query: TypedDocumentNode<GetPRForSHA1, GetPRForSHA1Variables> = gql`

--- a/src/queries/all-open-prs-query.ts
+++ b/src/queries/all-open-prs-query.ts
@@ -20,28 +20,28 @@ query GetAllOpenPRsAndCardIDs($after: String) {
 }`;
 
 export async function getAllOpenPRsAndCardIDs() {
-  const prNumbers: number[] = [];
-  const cardIDs: string[] = [];
-  let after: string | undefined;
-  while (true) {
-    const results = await client.query({
-      query: getAllOpenPRsAndCardIDsQuery,
-      fetchPolicy: "network-only",
-      variables: { after }
-    });
+    const prNumbers: number[] = [];
+    const cardIDs: string[] = [];
+    let after: string | undefined;
+    while (true) {
+        const results = await client.query({
+            query: getAllOpenPRsAndCardIDsQuery,
+            fetchPolicy: "network-only",
+            variables: { after }
+        });
 
-    if (!results.data.repository?.pullRequests.edges?.length) {
-        return { prNumbers, cardIDs };
+        if (!results.data.repository?.pullRequests.edges?.length) {
+            return { prNumbers, cardIDs };
+        }
+
+        for (const edge of results.data.repository.pullRequests.edges) {
+            if (!edge) continue;
+            const { node, cursor } = edge;
+            after = cursor;
+            if (!node) continue;
+
+            prNumbers.push(node.number);
+            node.projectCards.nodes?.forEach(n => n && cardIDs.push(n.id));
+        }
     }
-
-    for (const edge of results.data.repository.pullRequests.edges) {
-      if (!edge) continue;
-      const { node, cursor } = edge;
-      after = cursor;
-      if (!node) continue;
-
-      prNumbers.push(node.number);
-      node.projectCards.nodes?.forEach(n => n && cardIDs.push(n.id));
-    }
-  }
 }

--- a/src/queries/card-id-to-pr-query.ts
+++ b/src/queries/card-id-to-pr-query.ts
@@ -23,4 +23,4 @@ export const runQueryToGetPRForCardId = async (id: string): Promise<CardPRInfo |
     return (node?.__typename === "ProjectCard" && node.content?.__typename === "PullRequest")
         ? { number: node.content.number, state: node.content.state }
         : undefined;
-}
+};

--- a/src/run.ts
+++ b/src/run.ts
@@ -47,7 +47,7 @@ const xform = (x: unknown, xlate: (s: string) => string): unknown => {
     if (Array.isArray(x)) return x.map(e => xform(e, xlate));
     const o = x as { [k: string]: unknown };
     return Object.fromEntries(Object.keys(o).map(k => [k, xform(o[k], xlate)]));
-}
+};
 
 const show = (name: string, value: unknown) => {
     console.log(`  === ${name} ===`);
@@ -102,7 +102,7 @@ const start = async function () {
         }
         const mutation = createMutation<schema.DeleteProjectCardInput>("deleteProjectCard", { cardId: id });
         await client.mutate(mutation);
-    }
+    };
     // Reduce "Recently Merged"
     {
         const recentlyMerged = columns.find(c => c.name === "Recently Merged");
@@ -110,8 +110,7 @@ const start = async function () {
             throw new Error(`Could not find the 'Recently Merged' column in ${columns.map(n => n.name)}`);
         }
         const { cards, totalCount } = recentlyMerged;
-        const afterFirst50 = cards.sort((l, r) => l.updatedAt.localeCompare(r.updatedAt))
-                                  .slice(50);
+        const afterFirst50 = cards.sort((l, r) => l.updatedAt.localeCompare(r.updatedAt)).slice(50);
         if (afterFirst50.length > 0) {
             console.log(`Cutting "Recently Merged" projects to the last 50`);
             if (cards.length < totalCount) {

--- a/src/scripts/updateJSONFixtures.ts
+++ b/src/scripts/updateJSONFixtures.ts
@@ -1,5 +1,5 @@
-import {readdirSync, readFileSync, writeFileSync} from "fs"
-import { join } from "path"
+import {readdirSync, readFileSync, writeFileSync} from "fs";
+import { join } from "path";
 
 // Converts Travis response to GH Actions response, left
 // around so that someone whio needs to edit fixtures can start from
@@ -7,32 +7,32 @@ import { join } from "path"
 
 //  yarn ts-node src/scripts/updateJSONFixtures.ts
 
-const fixtureRoot = join(__dirname, "..",  "_tests", "fixtures")
-const fixtureNames = readdirSync(fixtureRoot)
+const fixtureRoot = join(__dirname, "..",  "_tests", "fixtures");
+const fixtureNames = readdirSync(fixtureRoot);
 
 fixtureNames.forEach(fixture => {
-  const responsePath = join(fixtureRoot, fixture, "_response.json")
-  const response = JSON.parse(readFileSync(responsePath, "utf8"))
-  const pr = response.data.repository.pullRequest
-  const headSha =  pr.headRefOid
-  
-  if (!pr.commits) return
+    const responsePath = join(fixtureRoot, fixture, "_response.json");
+    const response = JSON.parse(readFileSync(responsePath, "utf8"));
+    const pr = response.data.repository.pullRequest;
+    const headSha =  pr.headRefOid;
 
-  const headCommit = pr.commits.nodes.find((c: any) => c.commit.oid === headSha).commit
-  const status = headCommit.status && headCommit.status.state || "MISSING"
+    if (!pr.commits) return;
 
-  if (!headCommit.checkSuites) headCommit.checkSuites = { nodes: [] }
-  headCommit.checkSuites.nodes.push({
-    "app": {
-      "name": "GitHub Actions",
-      "__typename": "App"
-    },
-    "conclusion": status,
-    "resourcePath": "/DefinitelyTyped/DefinitelyTyped/commit/22c73c88cc9c09efd4c2998ec360607dd4c36c2e/checks?check_suite_id=731664306",
-    "status": status,
-    "url": "https://github.com/DefinitelyTyped/DefinitelyTyped/commit/22c73c88cc9c09efd4c2998ec360607dd4c36c2e/checks?check_suite_id=731664306",
-    "__typename": "CheckSuite"
-  })
+    const headCommit = pr.commits.nodes.find((c: any) => c.commit.oid === headSha).commit;
+    const status = headCommit.status && headCommit.status.state || "MISSING";
 
-  writeFileSync(responsePath, JSON.stringify(response, null, "  ") + "\n", "utf8")
+    if (!headCommit.checkSuites) headCommit.checkSuites = { nodes: [] };
+    headCommit.checkSuites.nodes.push({
+        "app": {
+            "name": "GitHub Actions",
+            "__typename": "App"
+        },
+        "conclusion": status,
+        "resourcePath": "/DefinitelyTyped/DefinitelyTyped/commit/22c73c88cc9c09efd4c2998ec360607dd4c36c2e/checks?check_suite_id=731664306",
+        "status": status,
+        "url": "https://github.com/DefinitelyTyped/DefinitelyTyped/commit/22c73c88cc9c09efd4c2998ec360607dd4c36c2e/checks?check_suite_id=731664306",
+        "__typename": "CheckSuite"
+    });
+
+    writeFileSync(responsePath, JSON.stringify(response, null, "  ") + "\n", "utf8");
 });

--- a/src/util/CIResult.ts
+++ b/src/util/CIResult.ts
@@ -1,6 +1,0 @@
-export enum CIResult {
-    Pending = "unknown",
-    Pass = "pass",
-    Fail = "fail",
-    Missing = "missing",
-}

--- a/src/util/cachedQueries.ts
+++ b/src/util/cachedQueries.ts
@@ -7,25 +7,25 @@ import { noNullish } from "./util";
 const cache = createCache();
 
 export async function getProjectBoardColumns() {
-  return cache.getAsync("project board colum names", Infinity, async () => {
-      const res = noNullish((await query(GetProjectColumns))
-          .repository?.project?.columns.nodes);
-      return res.sort((a,b) => a.name.localeCompare(b.name));
-  });
+    return cache.getAsync("project board colum names", Infinity, async () => {
+        const res = noNullish((await query(GetProjectColumns))
+            .repository?.project?.columns.nodes);
+        return res.sort((a,b) => a.name.localeCompare(b.name));
+    });
 }
 
 export async function getLabels() {
-  return await cache.getAsync("label ids", Infinity, async () => {
-      const res = noNullish((await query(GetLabels))
-          .repository?.labels?.nodes);
-      return res.sort((a,b) => a.name.localeCompare(b.name));
-  });
+    return await cache.getAsync("label ids", Infinity, async () => {
+        const res = noNullish((await query(GetLabels))
+            .repository?.labels?.nodes);
+        return res.sort((a,b) => a.name.localeCompare(b.name));
+    });
 }
 
 async function query<T>(gql: TypedDocumentNode<T>): Promise<T> {
-  const res = await client.query({
-      query: gql,
-      fetchPolicy: "network-only",
-  });
-  return res.data;
+    const res = await client.query({
+        query: gql,
+        fetchPolicy: "network-only",
+    });
+    return res.data;
 }

--- a/src/util/comment.ts
+++ b/src/util/comment.ts
@@ -4,15 +4,15 @@ export const prefix = "\n<!--typescript_bot_";
 export const suffix = "-->";
 
 export function parse(body: string): Comment | undefined {
-  const start = body.lastIndexOf(prefix);
-  const end = body.lastIndexOf(suffix);
-  return start < 0 || end < 0 || end + suffix.length != body.length
-    ? undefined
-    : { status: body.substr(0, start),
-        tag: body.substr(start + prefix.length, end - start - prefix.length),
-      };
+    const start = body.lastIndexOf(prefix);
+    const end = body.lastIndexOf(suffix);
+    return start < 0 || end < 0 || end + suffix.length != body.length
+        ? undefined
+        : { status: body.substr(0, start),
+            tag: body.substr(start + prefix.length, end - start - prefix.length),
+        };
 }
 
 export function make({ status, tag }: Comment) {
-  return `${status}${prefix}${tag}${suffix}`;
+    return `${status}${prefix}${tag}${suffix}`;
 }

--- a/src/util/fetchFile.ts
+++ b/src/util/fetchFile.ts
@@ -2,21 +2,21 @@ import { client } from "../graphql-client";
 import { GetFileContent } from "../queries/file-query";
 
 export async function fetchFile(expr: string, limit?: number): Promise<string | undefined> {
-  const info = await client.query({
-      query: GetFileContent,
-      variables: {
-          name: "DefinitelyTyped",
-          owner: "DefinitelyTyped",
-          expr: `${expr}`
-      }
-  });
-  const obj = info.data.repository?.object;
-  if (!obj || obj.__typename !== "Blob") return undefined;
-  if (obj.text && limit && obj.text.length > limit) {
-    return obj.text.substring(0, limit);
-  } else if (obj.byteSize > 3_000_000 && !obj.text) {
-    throw new Error(`Blob too big to fetch: ${expr}`);
-  } else {
-    return obj.text ?? undefined;
-  }
+    const info = await client.query({
+        query: GetFileContent,
+        variables: {
+            name: "DefinitelyTyped",
+            owner: "DefinitelyTyped",
+            expr: `${expr}`
+        }
+    });
+    const obj = info.data.repository?.object;
+    if (!obj || obj.__typename !== "Blob") return undefined;
+    if (obj.text && limit && obj.text.length > limit) {
+        return obj.text.substring(0, limit);
+    } else if (obj.byteSize > 3_000_000 && !obj.text) {
+        throw new Error(`Blob too big to fetch: ${expr}`);
+    } else {
+        return obj.text ?? undefined;
+    }
 }

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -66,7 +66,7 @@ export function scrubDiagnosticDetails(s: string) {
 }
 
 export function sha256(s: string) {
-    return crypto.createHash("sha256").update(s).digest("hex")
+    return crypto.createHash("sha256").update(s).digest("hex");
 }
 
 export function abbrOid(s: string) {


### PR DESCRIPTION
* Indentation, semicolons, quotes, etc.

* Eslint rules to check these (ignoring some things that I couldn't
  figure out a way to sensible-ize).

* Drop the `CIResult` enum and use the strings directly instead.