### PR TITLE
Call Day.js directly

### DIFF
--- a/src/compute-pr-actions.ts
+++ b/src/compute-pr-actions.ts
@@ -2,7 +2,7 @@ import * as Comments from "./comments";
 import * as urls from "./urls";
 import { PrInfo, BotResult, FileInfo } from "./pr-info";
 import { ReviewInfo } from "./pr-info";
-import { noNullish, flatten, unique, sameUser, daysSince, min, sha256, abbrOid } from "./util/util";
+import { noNullish, flatten, unique, sameUser, min, sha256, abbrOid } from "./util/util";
 import * as dayjs from "dayjs";
 import * as advancedFormat from "dayjs/plugin/advancedFormat";
 dayjs.extend(advancedFormat);
@@ -373,7 +373,7 @@ function makeStaleness(now: string, author: string, otherOwners: string[]) { // 
     return (kind: StalenessKind, since: Date,
             freshDays: number, attnDays: number, nearDays: number,
             doneColumn: ColumnName | "CLOSE") => {
-        const days = daysSince(since, now);
+        const days = dayjs(now).diff(since, "days");
         const state = days <= freshDays ? "fresh" : days <= attnDays ? "attention" : days <= nearDays ? "nearly" : "done";
         const kindAndState = `${kind}:${state}`;
         const explanation = Comments.StalenessExplanations[kindAndState];

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -1,5 +1,4 @@
 import * as crypto from "crypto";
-import * as dayjs from "dayjs";
 
 export function noNullish<T>(arr: ReadonlyArray<T | null | undefined> | null | undefined): T[] {
     if (arr == null) return [];
@@ -45,10 +44,6 @@ export function max<T>(arr: readonly T[], compare?: (a: T, b: T) => number): T |
 export function max<T>(arr: readonly T[], compare?: (a: T, b: T) => number) {
     return arr.length === 0 ? undefined : arr.reduce((res, x) =>
         (compare ? compare(x, res) > 0 : x > res) ? x : res);
-}
-
-export function daysSince(date: Date, now: Date | string): number {
-    return Math.floor(dayjs(now).diff(dayjs(date), "days"));
 }
 
 export function sameUser(u1: string, u2: string) {


### PR DESCRIPTION
- Day.js/Moment.js `.diff()` already truncates the result (since Moment.js 2.0.0), no need for `Math.floor()`
- `.diff()` accepts a `Date`