### PR TITLE
Make now a Date

### DIFF
--- a/src/_tests/fixturedActions.test.ts
+++ b/src/_tests/fixturedActions.test.ts
@@ -3,7 +3,7 @@ import { readdirSync, readJsonSync } from "fs-extra";
 import { join } from "path";
 import { toMatchFile } from "jest-file-snapshot";
 import { process } from "../compute-pr-actions";
-import { deriveStateForPR, BotResult } from "../pr-info";
+import { deriveStateForPR } from "../pr-info";
 import { PR } from "../queries/schema/PR";
 import { scrubDiagnosticDetails } from "../util/util";
 import * as cachedQueries from "./cachedQueries.json";
@@ -42,7 +42,7 @@ async function testFixture(dir: string) {
         prInfo,
         (expr: string) => Promise.resolve(files[expr] as string),
         (name: string, _until?: Date) => name in downloads ? downloads[name] : 0,
-        (readJsonSync(derivedPath) as BotResult).now
+        new Date(readJsonSync(derivedPath).now)
     );
 
     const action = process(derived);

--- a/src/_tests/fixtures/43960-post-close/derived.json
+++ b/src/_tests/fixtures/43960-post-close/derived.json
@@ -1,6 +1,6 @@
 {
   "type": "remove",
-  "now": "2020-04-30T12:01:56-07:00",
+  "now": "2020-04-30T19:01:56.000Z",
   "pr_number": 43960,
   "message": "PR is not active",
   "isDraft": false

--- a/src/_tests/fixtures/44105/derived.json
+++ b/src/_tests/fixtures/44105/derived.json
@@ -1,6 +1,6 @@
 {
   "type": "remove",
-  "now": "2020-04-28T15:49:39-07:00",
+  "now": "2020-04-28T22:49:39.000Z",
   "pr_number": 44105,
   "message": "PR is not active",
   "isDraft": false

--- a/src/_tests/fixtures/44256/derived.json
+++ b/src/_tests/fixtures/44256/derived.json
@@ -1,6 +1,6 @@
 {
   "type": "remove",
-  "now": "2020-04-30T12:07:55-07:00",
+  "now": "2020-04-30T19:07:55.000Z",
   "pr_number": 44256,
   "message": "PR is not active",
   "isDraft": false

--- a/src/_tests/fixtures/44290/derived.json
+++ b/src/_tests/fixtures/44290/derived.json
@@ -1,6 +1,6 @@
 {
   "type": "remove",
-  "now": "2020-04-28T12:41:44-04:00",
+  "now": "2020-04-28T16:41:44.000Z",
   "pr_number": 44290,
   "message": "PR is a draft",
   "isDraft": true

--- a/src/commands/create-fixture.ts
+++ b/src/commands/create-fixture.ts
@@ -1,5 +1,5 @@
 import * as computeActions from "../compute-pr-actions";
-import { deriveStateForPR, BotResult, queryPRInfo } from "../pr-info";
+import { deriveStateForPR, queryPRInfo } from "../pr-info";
 import { ApolloQueryResult } from "@apollo/client/core";
 import { writeFileSync, mkdirSync, existsSync, readJsonSync } from "fs-extra";
 import { join } from "path";
@@ -86,7 +86,7 @@ export default async function main(directory: string, overwriteInfo: boolean) {
     }
 
     function getTimeFromFile() {
-        return (readJsonSync(derivedFixturePath) as BotResult).now;
+        return new Date(readJsonSync(derivedFixturePath).now);
     }
 }
 

--- a/src/compute-pr-actions.ts
+++ b/src/compute-pr-actions.ts
@@ -361,15 +361,14 @@ export function process(prInfo: BotResult,
     // This bot is faster than CI in coming back to give a response, and so the bot starts flipping between
     // a 'where is CI'-ish state and a 'got CI deets' state. To work around this, we wait a
     // minute since the last timeline push action before label/project states can be updated
-    const oneMinute = 60 * 1000;
-    const tooEarlyForLabelsOrProjects = info.lastPushDate.getTime() + oneMinute < (new Date(prInfo.now)).getTime();
-    context.shouldUpdateLabels = tooEarlyForLabelsOrProjects;
-    context.shouldUpdateProjectColumn = tooEarlyForLabelsOrProjects;
+    const tooEarlyForLabelsOrProjects = dayjs(info.now).diff(info.lastPushDate, "minutes") < 1;
+    context.shouldUpdateLabels = !tooEarlyForLabelsOrProjects;
+    context.shouldUpdateProjectColumn = !tooEarlyForLabelsOrProjects;
 
     return context;
 }
 
-function makeStaleness(now: string, author: string, otherOwners: string[]) { // curried for convenience
+function makeStaleness(now: Date, author: string, otherOwners: string[]) { // curried for convenience
     return (kind: StalenessKind, since: Date,
             freshDays: number, attnDays: number, nearDays: number,
             doneColumn: ColumnName | "CLOSE") => {

--- a/src/pr-info.ts
+++ b/src/pr-info.ts
@@ -29,7 +29,7 @@ export type PopularityLevel =
 // Some error found, will be passed to `process` to report in a comment
 interface BotError {
     readonly type: "error";
-    readonly now: string;
+    readonly now: Date;
     readonly pr_number: number;
     readonly message: string;
     readonly author: string | undefined;
@@ -37,7 +37,7 @@ interface BotError {
 
 interface BotEnsureRemovedFromProject {
     readonly type: "remove";
-    readonly now: string;
+    readonly now: Date;
     readonly pr_number: number;
     readonly message: string;
     readonly isDraft: boolean;
@@ -77,7 +77,7 @@ export interface PrInfo {
     readonly type: "info";
 
     /** ISO8601 date string for the time the PR info was created at */
-    readonly now: string;
+    readonly now: Date;
 
     readonly pr_number: number;
 
@@ -183,7 +183,7 @@ export async function deriveStateForPR(
     prInfo: PR_repository_pullRequest,
     fetchFile = defaultFetchFile,
     getDownloads = getMonthlyDownloadCount,
-    now = new Date().toISOString(),
+    now = new Date(),
 ): Promise<BotResult>  {
     if (prInfo.author == null) return botError(prInfo.number, "PR author does not exist");
 


### PR DESCRIPTION
Slightly stricter than `string`. Consistent with the rest of `PrInfo` (`lastPushDate`, `lastActivityDate`, etc.).

Also, use Day.js for `tooEarlyForLabelsOrProjects`.

Cosmetic changes, no change in behavior.