### PR TITLE
Move some dependencies -> devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,26 +17,25 @@
   },
   "dependencies": {
     "@apollo/client": "^3.3.6",
-    "@azure/functions": "^1.2.2",
     "@definitelytyped/header-parser": "^0.0.64",
-    "@octokit/graphql-schema": "^10.11.0",
     "@octokit/webhooks": "^7.21.0",
-    "@types/node": "latest",
-    "@types/node-fetch": "^2.5.7",
-    "@types/prettyjson": "^0.0.29",
     "dayjs": "^1.10.3",
     "fast-json-patch": "^3.0.0-1",
     "fs-extra": "^9.0.1",
     "graphql": "^14.5.8",
     "node-fetch": "^2.6.1",
     "prettyjson": "^1.2.1",
-    "typescript": "^4.1.3",
     "yargs": "^16.2.0"
   },
   "devDependencies": {
+    "@azure/functions": "^1.2.2",
     "@endemolshinegroup/cosmiconfig-typescript-loader": "^3.0.2",
+    "@octokit/graphql-schema": "^10.11.0",
     "@types/fs-extra": "^4.0.11",
     "@types/jest": "^26.0.20",
+    "@types/node": "latest",
+    "@types/node-fetch": "^2.5.7",
+    "@types/prettyjson": "^0.0.29",
     "@typescript-eslint/eslint-plugin": "^4.9.0",
     "@typescript-eslint/parser": "^4.9.0",
     "apollo": "^2.32.0",
@@ -44,7 +43,8 @@
     "eslint-plugin-unicorn": "^26.0.1",
     "jest": "^26.4.4",
     "jest-file-snapshot": "^0.3.8",
-    "ts-jest": "^26.4.4"
+    "ts-jest": "^26.4.4",
+    "typescript": "^4.1.3"
   },
   "scripts": {
     "prepublishOnly": "npm run build",


### PR DESCRIPTION
We don't need types at runtime? Minor cleanup.