### PR TITLE
Only delay if actually waiting for CI

### DIFF
--- a/src/_tests/fixtures/44343-pending-travis/mutations.json
+++ b/src/_tests/fixtures/44343-pending-travis/mutations.json
@@ -1,5 +1,16 @@
 [
   {
+    "mutation": "mutation ($input: RemoveLabelsFromLabelableInput!) {\n  removeLabelsFromLabelable(input: $input) {\n    __typename\n  }\n}\n",
+    "variables": {
+      "input": {
+        "labelIds": [
+          "MDU6TGFiZWwyMTU0ODU3ODAw"
+        ],
+        "labelableId": "MDExOlB1bGxSZXF1ZXN0NDEwODAzMTcz"
+      }
+    }
+  },
+  {
     "mutation": "mutation ($input: UpdateIssueCommentInput!) {\n  updateIssueComment(input: $input) {\n    __typename\n  }\n}\n",
     "variables": {
       "input": {

--- a/src/_tests/fixtures/44343-pending-travis/result.json
+++ b/src/_tests/fixtures/44343-pending-travis/result.json
@@ -13,7 +13,7 @@
   ],
   "shouldClose": false,
   "shouldMerge": false,
-  "shouldUpdateLabels": false,
-  "shouldUpdateProjectColumn": false,
+  "shouldUpdateLabels": true,
+  "shouldUpdateProjectColumn": true,
   "shouldRemoveFromActiveColumns": false
 }

--- a/src/_tests/fixtures/44343-pre-travis/mutations.json
+++ b/src/_tests/fixtures/44343-pre-travis/mutations.json
@@ -1,5 +1,16 @@
 [
   {
+    "mutation": "mutation ($input: RemoveLabelsFromLabelableInput!) {\n  removeLabelsFromLabelable(input: $input) {\n    __typename\n  }\n}\n",
+    "variables": {
+      "input": {
+        "labelIds": [
+          "MDU6TGFiZWwyMTU0ODU3ODAw"
+        ],
+        "labelableId": "MDExOlB1bGxSZXF1ZXN0NDEwODAzMTcz"
+      }
+    }
+  },
+  {
     "mutation": "mutation ($input: UpdateIssueCommentInput!) {\n  updateIssueComment(input: $input) {\n    __typename\n  }\n}\n",
     "variables": {
       "input": {

--- a/src/_tests/fixtures/44343-pre-travis/result.json
+++ b/src/_tests/fixtures/44343-pre-travis/result.json
@@ -13,7 +13,7 @@
   ],
   "shouldClose": false,
   "shouldMerge": false,
-  "shouldUpdateLabels": false,
-  "shouldUpdateProjectColumn": false,
+  "shouldUpdateLabels": true,
+  "shouldUpdateProjectColumn": true,
   "shouldRemoveFromActiveColumns": false
 }


### PR DESCRIPTION
Instead of waiting unconditionally for one minute after the last push, only wait if the CI result is actually "missing".