### PR TITLE
Combine dependent actions

### DIFF
--- a/src/_tests/fixtures/38979/result.json
+++ b/src/_tests/fixtures/38979/result.json
@@ -1,5 +1,5 @@
 {
-  "targetColumn": "Needs Maintainer Action",
+  "projectColumn": "Needs Maintainer Action",
   "labels": [
     "Critical package",
     "Other Approved",
@@ -25,7 +25,5 @@
   ],
   "shouldClose": false,
   "shouldMerge": false,
-  "shouldUpdateLabels": true,
-  "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false
+  "shouldUpdateLabels": true
 }

--- a/src/_tests/fixtures/43136/result.json
+++ b/src/_tests/fixtures/43136/result.json
@@ -1,5 +1,5 @@
 {
-  "targetColumn": "Needs Maintainer Review",
+  "projectColumn": "Needs Maintainer Review",
   "labels": [
     "Critical package"
   ],
@@ -19,7 +19,5 @@
   ],
   "shouldClose": false,
   "shouldMerge": false,
-  "shouldUpdateLabels": true,
-  "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false
+  "shouldUpdateLabels": true
 }

--- a/src/_tests/fixtures/43144/result.json
+++ b/src/_tests/fixtures/43144/result.json
@@ -1,5 +1,5 @@
 {
-  "targetColumn": "Waiting for Author to Merge",
+  "projectColumn": "Waiting for Author to Merge",
   "labels": [
     "Owner Approved",
     "Self Merge"
@@ -16,7 +16,5 @@
   ],
   "shouldClose": false,
   "shouldMerge": false,
-  "shouldUpdateLabels": true,
-  "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false
+  "shouldUpdateLabels": true
 }

--- a/src/_tests/fixtures/43151/result.json
+++ b/src/_tests/fixtures/43151/result.json
@@ -1,5 +1,5 @@
 {
-  "targetColumn": "Needs Maintainer Action",
+  "projectColumn": "Needs Maintainer Action",
   "labels": [
     "New Definition"
   ],
@@ -15,7 +15,5 @@
   ],
   "shouldClose": false,
   "shouldMerge": false,
-  "shouldUpdateLabels": true,
-  "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false
+  "shouldUpdateLabels": true
 }

--- a/src/_tests/fixtures/43160/result.json
+++ b/src/_tests/fixtures/43160/result.json
@@ -1,5 +1,5 @@
 {
-  "targetColumn": "Needs Author Action",
+  "projectColumn": "Needs Author Action",
   "labels": [
     "The CI failed",
     "Owner Approved",
@@ -21,7 +21,5 @@
   ],
   "shouldClose": false,
   "shouldMerge": false,
-  "shouldUpdateLabels": true,
-  "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false
+  "shouldUpdateLabels": true
 }

--- a/src/_tests/fixtures/43175/result.json
+++ b/src/_tests/fixtures/43175/result.json
@@ -1,5 +1,5 @@
 {
-  "targetColumn": "Needs Maintainer Review",
+  "projectColumn": "Needs Maintainer Review",
   "labels": [
     "Popular package",
     "Untested Change"
@@ -24,7 +24,5 @@
   ],
   "shouldClose": false,
   "shouldMerge": false,
-  "shouldUpdateLabels": true,
-  "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false
+  "shouldUpdateLabels": true
 }

--- a/src/_tests/fixtures/43235/result.json
+++ b/src/_tests/fixtures/43235/result.json
@@ -1,5 +1,5 @@
 {
-  "targetColumn": "Waiting for Code Reviews",
+  "projectColumn": "Waiting for Code Reviews",
   "labels": [],
   "responseComments": [
     {
@@ -13,7 +13,5 @@
   ],
   "shouldClose": false,
   "shouldMerge": false,
-  "shouldUpdateLabels": true,
-  "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false
+  "shouldUpdateLabels": true
 }

--- a/src/_tests/fixtures/43314/result.json
+++ b/src/_tests/fixtures/43314/result.json
@@ -1,5 +1,5 @@
 {
-  "targetColumn": "Needs Maintainer Action",
+  "projectColumn": "Needs Maintainer Action",
   "labels": [
     "New Definition"
   ],
@@ -15,7 +15,5 @@
   ],
   "shouldClose": false,
   "shouldMerge": false,
-  "shouldUpdateLabels": true,
-  "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false
+  "shouldUpdateLabels": true
 }

--- a/src/_tests/fixtures/43695-duplicate-comment/result.json
+++ b/src/_tests/fixtures/43695-duplicate-comment/result.json
@@ -1,5 +1,5 @@
 {
-  "targetColumn": "Needs Maintainer Action",
+  "projectColumn": "Needs Maintainer Action",
   "labels": [
     "New Definition",
     "Unreviewed"
@@ -24,7 +24,5 @@
   ],
   "shouldClose": false,
   "shouldMerge": false,
-  "shouldUpdateLabels": true,
-  "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false
+  "shouldUpdateLabels": true
 }

--- a/src/_tests/fixtures/43695-post-review/result.json
+++ b/src/_tests/fixtures/43695-post-review/result.json
@@ -1,5 +1,5 @@
 {
-  "targetColumn": "Needs Author Action",
+  "projectColumn": "Needs Author Action",
   "labels": [
     "Revision needed",
     "New Definition"
@@ -16,7 +16,5 @@
   ],
   "shouldClose": false,
   "shouldMerge": false,
-  "shouldUpdateLabels": true,
-  "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false
+  "shouldUpdateLabels": true
 }

--- a/src/_tests/fixtures/43695/result.json
+++ b/src/_tests/fixtures/43695/result.json
@@ -1,5 +1,5 @@
 {
-  "targetColumn": "Needs Author Action",
+  "projectColumn": "Needs Author Action",
   "labels": [
     "Revision needed",
     "New Definition"
@@ -16,7 +16,5 @@
   ],
   "shouldClose": false,
   "shouldMerge": false,
-  "shouldUpdateLabels": true,
-  "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false
+  "shouldUpdateLabels": true
 }

--- a/src/_tests/fixtures/43960-post-close/result.json
+++ b/src/_tests/fixtures/43960-post-close/result.json
@@ -4,6 +4,5 @@
   "shouldClose": false,
   "shouldMerge": false,
   "shouldUpdateLabels": false,
-  "shouldUpdateProjectColumn": false,
-  "shouldRemoveFromActiveColumns": true
+  "projectColumn": "*REMOVE*"
 }

--- a/src/_tests/fixtures/43960/result.json
+++ b/src/_tests/fixtures/43960/result.json
@@ -1,5 +1,5 @@
 {
-  "targetColumn": "Needs Author Action",
+  "projectColumn": "Needs Author Action",
   "labels": [
     "Revision needed",
     "Popular package"
@@ -16,7 +16,5 @@
   ],
   "shouldClose": false,
   "shouldMerge": false,
-  "shouldUpdateLabels": true,
-  "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false
+  "shouldUpdateLabels": true
 }

--- a/src/_tests/fixtures/44105/result.json
+++ b/src/_tests/fixtures/44105/result.json
@@ -4,6 +4,5 @@
   "shouldClose": false,
   "shouldMerge": false,
   "shouldUpdateLabels": false,
-  "shouldUpdateProjectColumn": false,
-  "shouldRemoveFromActiveColumns": true
+  "projectColumn": "*REMOVE*"
 }

--- a/src/_tests/fixtures/44256/result.json
+++ b/src/_tests/fixtures/44256/result.json
@@ -4,6 +4,5 @@
   "shouldClose": false,
   "shouldMerge": false,
   "shouldUpdateLabels": false,
-  "shouldUpdateProjectColumn": false,
-  "shouldRemoveFromActiveColumns": true
+  "projectColumn": "*REMOVE*"
 }

--- a/src/_tests/fixtures/44267/result.json
+++ b/src/_tests/fixtures/44267/result.json
@@ -1,5 +1,5 @@
 {
-  "targetColumn": "Needs Maintainer Review",
+  "projectColumn": "Needs Maintainer Review",
   "labels": [
     "Owner Approved",
     "Untested Change"
@@ -16,7 +16,5 @@
   ],
   "shouldClose": false,
   "shouldMerge": false,
-  "shouldUpdateLabels": true,
-  "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false
+  "shouldUpdateLabels": true
 }

--- a/src/_tests/fixtures/44282/result.json
+++ b/src/_tests/fixtures/44282/result.json
@@ -1,5 +1,5 @@
 {
-  "targetColumn": "Waiting for Code Reviews",
+  "projectColumn": "Waiting for Code Reviews",
   "labels": [
     "Edits Owners",
     "No Other Owners"
@@ -16,7 +16,5 @@
   ],
   "shouldClose": false,
   "shouldMerge": false,
-  "shouldUpdateLabels": true,
-  "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false
+  "shouldUpdateLabels": true
 }

--- a/src/_tests/fixtures/44288/result.json
+++ b/src/_tests/fixtures/44288/result.json
@@ -1,5 +1,5 @@
 {
-  "targetColumn": "Waiting for Code Reviews",
+  "projectColumn": "Waiting for Code Reviews",
   "labels": [],
   "responseComments": [
     {
@@ -13,7 +13,5 @@
   ],
   "shouldClose": false,
   "shouldMerge": false,
-  "shouldUpdateLabels": true,
-  "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false
+  "shouldUpdateLabels": true
 }

--- a/src/_tests/fixtures/44290/result.json
+++ b/src/_tests/fixtures/44290/result.json
@@ -4,7 +4,5 @@
   "shouldClose": false,
   "shouldMerge": false,
   "shouldUpdateLabels": false,
-  "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false,
-  "targetColumn": "Needs Author Action"
+  "projectColumn": "Needs Author Action"
 }

--- a/src/_tests/fixtures/44299-with-files/result.json
+++ b/src/_tests/fixtures/44299-with-files/result.json
@@ -1,5 +1,5 @@
 {
-  "targetColumn": "Needs Maintainer Action",
+  "projectColumn": "Needs Maintainer Action",
   "labels": [
     "New Definition"
   ],
@@ -15,7 +15,5 @@
   ],
   "shouldClose": false,
   "shouldMerge": false,
-  "shouldUpdateLabels": true,
-  "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false
+  "shouldUpdateLabels": true
 }

--- a/src/_tests/fixtures/44299/result.json
+++ b/src/_tests/fixtures/44299/result.json
@@ -1,5 +1,5 @@
 {
-  "targetColumn": "Needs Maintainer Action",
+  "projectColumn": "Needs Maintainer Action",
   "labels": [
     "New Definition"
   ],
@@ -15,7 +15,5 @@
   ],
   "shouldClose": false,
   "shouldMerge": false,
-  "shouldUpdateLabels": true,
-  "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false
+  "shouldUpdateLabels": true
 }

--- a/src/_tests/fixtures/44316/result.json
+++ b/src/_tests/fixtures/44316/result.json
@@ -1,5 +1,5 @@
 {
-  "targetColumn": "Waiting for Code Reviews",
+  "projectColumn": "Waiting for Code Reviews",
   "labels": [
     "Author is Owner",
     "No Other Owners"
@@ -16,7 +16,5 @@
   ],
   "shouldClose": false,
   "shouldMerge": false,
-  "shouldUpdateLabels": true,
-  "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false
+  "shouldUpdateLabels": true
 }

--- a/src/_tests/fixtures/44343-pending-travis/result.json
+++ b/src/_tests/fixtures/44343-pending-travis/result.json
@@ -1,5 +1,5 @@
 {
-  "targetColumn": "Waiting for Code Reviews",
+  "projectColumn": "Waiting for Code Reviews",
   "labels": [],
   "responseComments": [
     {
@@ -13,7 +13,5 @@
   ],
   "shouldClose": false,
   "shouldMerge": false,
-  "shouldUpdateLabels": true,
-  "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false
+  "shouldUpdateLabels": true
 }

--- a/src/_tests/fixtures/44343-pre-travis/result.json
+++ b/src/_tests/fixtures/44343-pre-travis/result.json
@@ -1,5 +1,5 @@
 {
-  "targetColumn": "Waiting for Code Reviews",
+  "projectColumn": "Waiting for Code Reviews",
   "labels": [],
   "responseComments": [
     {
@@ -13,7 +13,5 @@
   ],
   "shouldClose": false,
   "shouldMerge": false,
-  "shouldUpdateLabels": true,
-  "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false
+  "shouldUpdateLabels": true
 }

--- a/src/_tests/fixtures/44343/result.json
+++ b/src/_tests/fixtures/44343/result.json
@@ -1,5 +1,5 @@
 {
-  "targetColumn": "Waiting for Code Reviews",
+  "projectColumn": "Waiting for Code Reviews",
   "labels": [],
   "responseComments": [
     {
@@ -13,7 +13,5 @@
   ],
   "shouldClose": false,
   "shouldMerge": false,
-  "shouldUpdateLabels": true,
-  "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false
+  "shouldUpdateLabels": true
 }

--- a/src/_tests/fixtures/44402/result.json
+++ b/src/_tests/fixtures/44402/result.json
@@ -1,5 +1,5 @@
 {
-  "targetColumn": "Waiting for Author to Merge",
+  "projectColumn": "Waiting for Author to Merge",
   "labels": [
     "Other Approved",
     "Maintainer Approved",
@@ -18,7 +18,5 @@
   ],
   "shouldClose": false,
   "shouldMerge": false,
-  "shouldUpdateLabels": true,
-  "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false
+  "shouldUpdateLabels": true
 }

--- a/src/_tests/fixtures/44411/result.json
+++ b/src/_tests/fixtures/44411/result.json
@@ -1,5 +1,5 @@
 {
-  "targetColumn": "Waiting for Code Reviews",
+  "projectColumn": "Waiting for Code Reviews",
   "labels": [
     "Edits Owners"
   ],
@@ -15,7 +15,5 @@
   ],
   "shouldClose": false,
   "shouldMerge": false,
-  "shouldUpdateLabels": true,
-  "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false
+  "shouldUpdateLabels": true
 }

--- a/src/_tests/fixtures/44424-1-travis-instantly-finished/result.json
+++ b/src/_tests/fixtures/44424-1-travis-instantly-finished/result.json
@@ -1,5 +1,5 @@
 {
-  "targetColumn": "Waiting for Code Reviews",
+  "projectColumn": "Waiting for Code Reviews",
   "labels": [
     "Author is Owner"
   ],
@@ -15,7 +15,5 @@
   ],
   "shouldClose": false,
   "shouldMerge": false,
-  "shouldUpdateLabels": true,
-  "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false
+  "shouldUpdateLabels": true
 }

--- a/src/_tests/fixtures/44424-2-after-travis-second/result.json
+++ b/src/_tests/fixtures/44424-2-after-travis-second/result.json
@@ -1,5 +1,5 @@
 {
-  "targetColumn": "Waiting for Code Reviews",
+  "projectColumn": "Waiting for Code Reviews",
   "labels": [
     "Author is Owner"
   ],
@@ -15,7 +15,5 @@
   ],
   "shouldClose": false,
   "shouldMerge": false,
-  "shouldUpdateLabels": true,
-  "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false
+  "shouldUpdateLabels": true
 }

--- a/src/_tests/fixtures/44437/result.json
+++ b/src/_tests/fixtures/44437/result.json
@@ -1,5 +1,5 @@
 {
-  "targetColumn": "Waiting for Author to Merge",
+  "projectColumn": "Waiting for Author to Merge",
   "labels": [
     "Popular package",
     "Owner Approved",
@@ -18,7 +18,5 @@
   ],
   "shouldClose": false,
   "shouldMerge": false,
-  "shouldUpdateLabels": true,
-  "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false
+  "shouldUpdateLabels": true
 }

--- a/src/_tests/fixtures/44439/result.json
+++ b/src/_tests/fixtures/44439/result.json
@@ -1,5 +1,5 @@
 {
-  "targetColumn": "Needs Maintainer Action",
+  "projectColumn": "Needs Maintainer Action",
   "labels": [
     "Edits Owners",
     "Edits Infrastructure"
@@ -16,7 +16,5 @@
   ],
   "shouldClose": false,
   "shouldMerge": false,
-  "shouldUpdateLabels": true,
-  "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false
+  "shouldUpdateLabels": true
 }

--- a/src/_tests/fixtures/44631/result.json
+++ b/src/_tests/fixtures/44631/result.json
@@ -1,5 +1,5 @@
 {
-  "targetColumn": "Needs Author Action",
+  "projectColumn": "Needs Author Action",
   "labels": [
     "Has Merge Conflict",
     "Maintainer Approved"
@@ -16,7 +16,5 @@
   ],
   "shouldClose": false,
   "shouldMerge": false,
-  "shouldUpdateLabels": true,
-  "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false
+  "shouldUpdateLabels": true
 }

--- a/src/_tests/fixtures/44857/result.json
+++ b/src/_tests/fixtures/44857/result.json
@@ -1,5 +1,5 @@
 {
-  "targetColumn": "Needs Maintainer Action",
+  "projectColumn": "Needs Maintainer Action",
   "labels": [
     "Critical package",
     "Author is Owner",
@@ -25,7 +25,5 @@
   ],
   "shouldClose": false,
   "shouldMerge": false,
-  "shouldUpdateLabels": true,
-  "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false
+  "shouldUpdateLabels": true
 }

--- a/src/_tests/fixtures/44989-14days/result.json
+++ b/src/_tests/fixtures/44989-14days/result.json
@@ -1,5 +1,5 @@
 {
-  "targetColumn": "Waiting for Author to Merge",
+  "projectColumn": "Waiting for Author to Merge",
   "labels": [
     "Popular package",
     "Owner Approved",
@@ -22,7 +22,5 @@
   ],
   "shouldClose": false,
   "shouldMerge": false,
-  "shouldUpdateLabels": true,
-  "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false
+  "shouldUpdateLabels": true
 }

--- a/src/_tests/fixtures/44989-32days/result.json
+++ b/src/_tests/fixtures/44989-32days/result.json
@@ -1,5 +1,5 @@
 {
-  "targetColumn": "Waiting for Author to Merge",
+  "projectColumn": "*REMOVE*",
   "labels": [
     "Popular package",
     "Owner Approved",
@@ -22,7 +22,5 @@
   ],
   "shouldClose": true,
   "shouldMerge": false,
-  "shouldUpdateLabels": true,
-  "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": true
+  "shouldUpdateLabels": true
 }

--- a/src/_tests/fixtures/44989-3days/result.json
+++ b/src/_tests/fixtures/44989-3days/result.json
@@ -1,5 +1,5 @@
 {
-  "targetColumn": "Waiting for Author to Merge",
+  "projectColumn": "Waiting for Author to Merge",
   "labels": [
     "Popular package",
     "Owner Approved",
@@ -17,7 +17,5 @@
   ],
   "shouldClose": false,
   "shouldMerge": false,
-  "shouldUpdateLabels": true,
-  "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false
+  "shouldUpdateLabels": true
 }

--- a/src/_tests/fixtures/44989-7days/result.json
+++ b/src/_tests/fixtures/44989-7days/result.json
@@ -1,5 +1,5 @@
 {
-  "targetColumn": "Waiting for Author to Merge",
+  "projectColumn": "Waiting for Author to Merge",
   "labels": [
     "Popular package",
     "Owner Approved",
@@ -17,7 +17,5 @@
   ],
   "shouldClose": false,
   "shouldMerge": false,
-  "shouldUpdateLabels": true,
-  "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false
+  "shouldUpdateLabels": true
 }

--- a/src/_tests/fixtures/45137/result.json
+++ b/src/_tests/fixtures/45137/result.json
@@ -1,5 +1,5 @@
 {
-  "targetColumn": "Needs Maintainer Review",
+  "projectColumn": "Needs Maintainer Review",
   "labels": [
     "Popular package",
     "Owner Approved",
@@ -19,7 +19,5 @@
   ],
   "shouldClose": false,
   "shouldMerge": false,
-  "shouldUpdateLabels": true,
-  "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false
+  "shouldUpdateLabels": true
 }

--- a/src/_tests/fixtures/45627/result.json
+++ b/src/_tests/fixtures/45627/result.json
@@ -1,5 +1,5 @@
 {
-  "targetColumn": "Recently Merged",
+  "projectColumn": "*REMOVE*",
   "labels": [
     "Critical package",
     "Owner Approved",
@@ -28,7 +28,5 @@
   ],
   "shouldClose": true,
   "shouldMerge": true,
-  "shouldUpdateLabels": true,
-  "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": true
+  "shouldUpdateLabels": true
 }

--- a/src/_tests/fixtures/45836/result.json
+++ b/src/_tests/fixtures/45836/result.json
@@ -1,5 +1,5 @@
 {
-  "targetColumn": "Needs Maintainer Review",
+  "projectColumn": "Needs Maintainer Review",
   "labels": [
     "Owner Approved",
     "Edits Owners",
@@ -17,7 +17,5 @@
   ],
   "shouldClose": false,
   "shouldMerge": false,
-  "shouldUpdateLabels": true,
-  "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false
+  "shouldUpdateLabels": true
 }

--- a/src/_tests/fixtures/45884/result.json
+++ b/src/_tests/fixtures/45884/result.json
@@ -1,5 +1,5 @@
 {
-  "targetColumn": "Waiting for Author to Merge",
+  "projectColumn": "Waiting for Author to Merge",
   "labels": [
     "Owner Approved",
     "Untested Change",
@@ -21,7 +21,5 @@
   ],
   "shouldClose": false,
   "shouldMerge": false,
-  "shouldUpdateLabels": true,
-  "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false
+  "shouldUpdateLabels": true
 }

--- a/src/_tests/fixtures/45888/result.json
+++ b/src/_tests/fixtures/45888/result.json
@@ -1,5 +1,5 @@
 {
-  "targetColumn": "Waiting for Code Reviews",
+  "projectColumn": "Waiting for Code Reviews",
   "labels": [
     "Other Approved",
     "Untested Change"
@@ -20,7 +20,5 @@
   ],
   "shouldClose": false,
   "shouldMerge": false,
-  "shouldUpdateLabels": true,
-  "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false
+  "shouldUpdateLabels": true
 }

--- a/src/_tests/fixtures/45890/result.json
+++ b/src/_tests/fixtures/45890/result.json
@@ -1,5 +1,5 @@
 {
-  "targetColumn": "Needs Maintainer Action",
+  "projectColumn": "Needs Maintainer Action",
   "labels": [
     "Other Approved",
     "New Definition"
@@ -16,7 +16,5 @@
   ],
   "shouldClose": false,
   "shouldMerge": false,
-  "shouldUpdateLabels": true,
-  "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false
+  "shouldUpdateLabels": true
 }

--- a/src/_tests/fixtures/45946/result.json
+++ b/src/_tests/fixtures/45946/result.json
@@ -1,5 +1,5 @@
 {
-  "targetColumn": "Needs Maintainer Action",
+  "projectColumn": "Needs Maintainer Action",
   "labels": [
     "Edits Infrastructure",
     "No Other Owners"
@@ -16,7 +16,5 @@
   ],
   "shouldClose": false,
   "shouldMerge": false,
-  "shouldUpdateLabels": true,
-  "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false
+  "shouldUpdateLabels": true
 }

--- a/src/_tests/fixtures/45982/result.json
+++ b/src/_tests/fixtures/45982/result.json
@@ -1,5 +1,5 @@
 {
-  "targetColumn": "Other",
+  "projectColumn": "Other",
   "labels": [
     "Mergebot Error"
   ],
@@ -11,7 +11,5 @@
   ],
   "shouldClose": false,
   "shouldMerge": false,
-  "shouldUpdateLabels": true,
-  "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false
+  "shouldUpdateLabels": true
 }

--- a/src/_tests/fixtures/45999/result.json
+++ b/src/_tests/fixtures/45999/result.json
@@ -1,5 +1,5 @@
 {
-  "targetColumn": "Waiting for Author to Merge",
+  "projectColumn": "Waiting for Author to Merge",
   "labels": [
     "Critical package",
     "Owner Approved",
@@ -17,7 +17,5 @@
   ],
   "shouldClose": false,
   "shouldMerge": false,
-  "shouldUpdateLabels": true,
-  "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false
+  "shouldUpdateLabels": true
 }

--- a/src/_tests/fixtures/46008/result.json
+++ b/src/_tests/fixtures/46008/result.json
@@ -1,5 +1,5 @@
 {
-  "targetColumn": "Waiting for Author to Merge",
+  "projectColumn": "Waiting for Author to Merge",
   "labels": [
     "Owner Approved",
     "Untested Change",
@@ -21,7 +21,5 @@
   ],
   "shouldClose": false,
   "shouldMerge": false,
-  "shouldUpdateLabels": true,
-  "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false
+  "shouldUpdateLabels": true
 }

--- a/src/_tests/fixtures/46019/result.json
+++ b/src/_tests/fixtures/46019/result.json
@@ -1,5 +1,5 @@
 {
-  "targetColumn": "Waiting for Author to Merge",
+  "projectColumn": "Waiting for Author to Merge",
   "labels": [
     "Maintainer Approved",
     "New Definition",
@@ -17,7 +17,5 @@
   ],
   "shouldClose": false,
   "shouldMerge": false,
-  "shouldUpdateLabels": true,
-  "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false
+  "shouldUpdateLabels": true
 }

--- a/src/_tests/fixtures/46120/result.json
+++ b/src/_tests/fixtures/46120/result.json
@@ -1,5 +1,5 @@
 {
-  "targetColumn": "Waiting for Author to Merge",
+  "projectColumn": "Waiting for Author to Merge",
   "labels": [
     "Popular package",
     "Owner Approved",
@@ -22,7 +22,5 @@
   ],
   "shouldClose": false,
   "shouldMerge": false,
-  "shouldUpdateLabels": true,
-  "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false
+  "shouldUpdateLabels": true
 }

--- a/src/_tests/fixtures/46191/result.json
+++ b/src/_tests/fixtures/46191/result.json
@@ -1,5 +1,5 @@
 {
-  "targetColumn": "Needs Author Action",
+  "projectColumn": "Needs Author Action",
   "labels": [
     "The CI failed",
     "Edits Owners",
@@ -25,7 +25,5 @@
   ],
   "shouldClose": false,
   "shouldMerge": false,
-  "shouldUpdateLabels": true,
-  "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false
+  "shouldUpdateLabels": true
 }

--- a/src/_tests/fixtures/46196/result.json
+++ b/src/_tests/fixtures/46196/result.json
@@ -1,5 +1,5 @@
 {
-  "targetColumn": "Waiting for Code Reviews",
+  "projectColumn": "Waiting for Code Reviews",
   "labels": [],
   "responseComments": [
     {
@@ -13,7 +13,5 @@
   ],
   "shouldClose": false,
   "shouldMerge": false,
-  "shouldUpdateLabels": true,
-  "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false
+  "shouldUpdateLabels": true
 }

--- a/src/_tests/fixtures/46279/result.json
+++ b/src/_tests/fixtures/46279/result.json
@@ -1,5 +1,5 @@
 {
-  "targetColumn": "Needs Maintainer Action",
+  "projectColumn": "Needs Maintainer Action",
   "labels": [
     "Author is Owner",
     "No Other Owners",
@@ -21,7 +21,5 @@
   ],
   "shouldClose": false,
   "shouldMerge": false,
-  "shouldUpdateLabels": true,
-  "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false
+  "shouldUpdateLabels": true
 }

--- a/src/_tests/fixtures/46804/result.json
+++ b/src/_tests/fixtures/46804/result.json
@@ -1,5 +1,5 @@
 {
-  "targetColumn": "Waiting for Code Reviews",
+  "projectColumn": "Waiting for Code Reviews",
   "labels": [
     "Untested Change"
   ],
@@ -19,7 +19,5 @@
   ],
   "shouldClose": false,
   "shouldMerge": false,
-  "shouldUpdateLabels": true,
-  "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false
+  "shouldUpdateLabels": true
 }

--- a/src/_tests/fixtures/46879/result.json
+++ b/src/_tests/fixtures/46879/result.json
@@ -1,5 +1,5 @@
 {
-  "targetColumn": "Waiting for Code Reviews",
+  "projectColumn": "Waiting for Code Reviews",
   "labels": [
     "Popular package"
   ],
@@ -15,7 +15,5 @@
   ],
   "shouldClose": false,
   "shouldMerge": false,
-  "shouldUpdateLabels": true,
-  "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false
+  "shouldUpdateLabels": true
 }

--- a/src/_tests/fixtures/47017-blessed-and-one-owner/result.json
+++ b/src/_tests/fixtures/47017-blessed-and-one-owner/result.json
@@ -1,5 +1,5 @@
 {
-  "targetColumn": "Waiting for Code Reviews",
+  "projectColumn": "Waiting for Code Reviews",
   "labels": [
     "Critical package",
     "Edits multiple packages"
@@ -12,7 +12,5 @@
   ],
   "shouldClose": false,
   "shouldMerge": false,
-  "shouldUpdateLabels": true,
-  "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false
+  "shouldUpdateLabels": true
 }

--- a/src/_tests/fixtures/47017-blessed-and-two-owner/result.json
+++ b/src/_tests/fixtures/47017-blessed-and-two-owner/result.json
@@ -1,5 +1,5 @@
 {
-  "targetColumn": "Waiting for Author to Merge",
+  "projectColumn": "Waiting for Author to Merge",
   "labels": [
     "Critical package",
     "Owner Approved",
@@ -18,7 +18,5 @@
   ],
   "shouldClose": false,
   "shouldMerge": false,
-  "shouldUpdateLabels": true,
-  "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false
+  "shouldUpdateLabels": true
 }

--- a/src/_tests/fixtures/47017-blessed/result.json
+++ b/src/_tests/fixtures/47017-blessed/result.json
@@ -1,5 +1,5 @@
 {
-  "targetColumn": "Waiting for Code Reviews",
+  "projectColumn": "Waiting for Code Reviews",
   "labels": [
     "Critical package",
     "Edits multiple packages"
@@ -16,7 +16,5 @@
   ],
   "shouldClose": false,
   "shouldMerge": false,
-  "shouldUpdateLabels": true,
-  "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false
+  "shouldUpdateLabels": true
 }

--- a/src/_tests/fixtures/47017/result.json
+++ b/src/_tests/fixtures/47017/result.json
@@ -1,5 +1,5 @@
 {
-  "targetColumn": "Needs Maintainer Review",
+  "projectColumn": "Needs Maintainer Review",
   "labels": [
     "Critical package",
     "Edits multiple packages"
@@ -16,7 +16,5 @@
   ],
   "shouldClose": false,
   "shouldMerge": false,
-  "shouldUpdateLabels": true,
-  "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false
+  "shouldUpdateLabels": true
 }

--- a/src/_tests/fixtures/48216/result.json
+++ b/src/_tests/fixtures/48216/result.json
@@ -1,5 +1,5 @@
 {
-  "targetColumn": "Waiting for Code Reviews",
+  "projectColumn": "Waiting for Code Reviews",
   "labels": [],
   "responseComments": [
     {
@@ -13,7 +13,5 @@
   ],
   "shouldClose": false,
   "shouldMerge": false,
-  "shouldUpdateLabels": true,
-  "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false
+  "shouldUpdateLabels": true
 }

--- a/src/_tests/fixtures/48236/result.json
+++ b/src/_tests/fixtures/48236/result.json
@@ -1,5 +1,5 @@
 {
-  "targetColumn": "Recently Merged",
+  "projectColumn": "Recently Merged",
   "labels": [
     "Other Approved",
     "Self Merge"
@@ -20,7 +20,5 @@
   ],
   "shouldClose": false,
   "shouldMerge": true,
-  "shouldUpdateLabels": true,
-  "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false
+  "shouldUpdateLabels": true
 }

--- a/src/_tests/fixtures/48652-merge-offer/result.json
+++ b/src/_tests/fixtures/48652-merge-offer/result.json
@@ -1,5 +1,5 @@
 {
-  "targetColumn": "Waiting for Author to Merge",
+  "projectColumn": "Waiting for Author to Merge",
   "labels": [
     "Owner Approved",
     "Maintainer Approved",
@@ -22,7 +22,5 @@
   ],
   "shouldClose": false,
   "shouldMerge": false,
-  "shouldUpdateLabels": true,
-  "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false
+  "shouldUpdateLabels": true
 }

--- a/src/_tests/fixtures/48652-prereq/result.json
+++ b/src/_tests/fixtures/48652-prereq/result.json
@@ -1,5 +1,5 @@
 {
-  "targetColumn": "Waiting for Author to Merge",
+  "projectColumn": "Waiting for Author to Merge",
   "labels": [
     "Owner Approved",
     "Maintainer Approved",
@@ -26,7 +26,5 @@
   ],
   "shouldClose": false,
   "shouldMerge": false,
-  "shouldUpdateLabels": true,
-  "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false
+  "shouldUpdateLabels": true
 }

--- a/src/_tests/fixtures/48652-retract-merge-offer-and-prerequest/result.json
+++ b/src/_tests/fixtures/48652-retract-merge-offer-and-prerequest/result.json
@@ -1,5 +1,5 @@
 {
-  "targetColumn": "Needs Author Action",
+  "projectColumn": "Needs Author Action",
   "labels": [
     "Revision needed",
     "Edits multiple packages"
@@ -20,7 +20,5 @@
   ],
   "shouldClose": false,
   "shouldMerge": false,
-  "shouldUpdateLabels": true,
-  "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false
+  "shouldUpdateLabels": true
 }

--- a/src/_tests/fixtures/48652-retract-merge-offer/result.json
+++ b/src/_tests/fixtures/48652-retract-merge-offer/result.json
@@ -1,5 +1,5 @@
 {
-  "targetColumn": "Needs Author Action",
+  "projectColumn": "Needs Author Action",
   "labels": [
     "Revision needed",
     "Edits multiple packages"
@@ -16,7 +16,5 @@
   ],
   "shouldClose": false,
   "shouldMerge": false,
-  "shouldUpdateLabels": true,
-  "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false
+  "shouldUpdateLabels": true
 }

--- a/src/_tests/fixtures/48708/result.json
+++ b/src/_tests/fixtures/48708/result.json
@@ -1,5 +1,5 @@
 {
-  "targetColumn": "Needs Author Action",
+  "projectColumn": "Needs Author Action",
   "labels": [
     "Revision needed",
     "Critical package",
@@ -22,7 +22,5 @@
   ],
   "shouldClose": false,
   "shouldMerge": false,
-  "shouldUpdateLabels": true,
-  "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false
+  "shouldUpdateLabels": true
 }

--- a/src/_tests/fixtures/48945/result.json
+++ b/src/_tests/fixtures/48945/result.json
@@ -1,5 +1,5 @@
 {
-  "targetColumn": "Needs Author Action",
+  "projectColumn": "Needs Author Action",
   "labels": [
     "Revision needed",
     "Author is Owner"
@@ -16,7 +16,5 @@
   ],
   "shouldClose": false,
   "shouldMerge": false,
-  "shouldUpdateLabels": true,
-  "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false
+  "shouldUpdateLabels": true
 }

--- a/src/_tests/fixtures/49417/result.json
+++ b/src/_tests/fixtures/49417/result.json
@@ -1,5 +1,5 @@
 {
-  "targetColumn": "Waiting for Author to Merge",
+  "projectColumn": "Waiting for Author to Merge",
   "labels": [
     "Owner Approved",
     "Author is Owner",
@@ -21,7 +21,5 @@
   ],
   "shouldClose": false,
   "shouldMerge": false,
-  "shouldUpdateLabels": true,
-  "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false
+  "shouldUpdateLabels": true
 }

--- a/src/_tests/fixtures/49548/result.json
+++ b/src/_tests/fixtures/49548/result.json
@@ -1,5 +1,5 @@
 {
-  "targetColumn": "Waiting for Code Reviews",
+  "projectColumn": "Waiting for Code Reviews",
   "labels": [
     "Edits Owners",
     "No Other Owners",
@@ -21,7 +21,5 @@
   ],
   "shouldClose": false,
   "shouldMerge": false,
-  "shouldUpdateLabels": true,
-  "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false
+  "shouldUpdateLabels": true
 }

--- a/src/_tests/fixtures/49575/result.json
+++ b/src/_tests/fixtures/49575/result.json
@@ -1,5 +1,5 @@
 {
-  "targetColumn": "Needs Maintainer Action",
+  "projectColumn": "Needs Maintainer Action",
   "labels": [
     "Other Approved",
     "Edits Infrastructure"
@@ -20,7 +20,5 @@
   ],
   "shouldClose": false,
   "shouldMerge": false,
-  "shouldUpdateLabels": true,
-  "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false
+  "shouldUpdateLabels": true
 }

--- a/src/_tests/fixtures/49841/result.json
+++ b/src/_tests/fixtures/49841/result.json
@@ -1,5 +1,5 @@
 {
-  "targetColumn": "Needs Author Action",
+  "projectColumn": "Needs Author Action",
   "labels": [
     "The CI failed",
     "New Definition",
@@ -21,7 +21,5 @@
   ],
   "shouldClose": false,
   "shouldMerge": false,
-  "shouldUpdateLabels": true,
-  "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false
+  "shouldUpdateLabels": true
 }

--- a/src/_tests/fixtures/50429/result.json
+++ b/src/_tests/fixtures/50429/result.json
@@ -1,5 +1,5 @@
 {
-  "targetColumn": "Needs Author Action",
+  "projectColumn": "Needs Author Action",
   "labels": [
     "The CI failed",
     "New Definition",
@@ -21,7 +21,5 @@
   ],
   "shouldClose": false,
   "shouldMerge": false,
-  "shouldUpdateLabels": true,
-  "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false
+  "shouldUpdateLabels": true
 }

--- a/src/_tests/fixtures/50443/result.json
+++ b/src/_tests/fixtures/50443/result.json
@@ -1,5 +1,5 @@
 {
-  "targetColumn": "Recently Merged",
+  "projectColumn": "Recently Merged",
   "labels": [
     "Maintainer Approved",
     "New Definition",
@@ -17,7 +17,5 @@
   ],
   "shouldClose": false,
   "shouldMerge": true,
-  "shouldUpdateLabels": true,
-  "shouldUpdateProjectColumn": true,
-  "shouldRemoveFromActiveColumns": false
+  "shouldUpdateLabels": true
 }


### PR DESCRIPTION
Minor detail but it could be more obvious, when we set `targetColumn`, `shouldUpdateProjectColumn` and `shouldRemoveFromActiveColumns` independently, what the result will be. What do you think about combining these three and replacing `shouldRemoveFromActiveColumns` with "REMOVE"?

Also I replaced "context" with "actions" in `compute-pr-actions.ts`, to match `execute-pr-actions.ts`, etc.