### PR TITLE
Replace fetch policy network-only -> no-cache

### DIFF
--- a/src/pr-info.ts
+++ b/src/pr-info.ts
@@ -158,7 +158,7 @@ export async function queryPRInfo(prNumber: number) {
         const info = await client.query({
             query: GetPRInfo,
             variables: { pr_number: prNumber },
-            fetchPolicy: "network-only",
+            fetchPolicy: "no-cache",
         });
         const prInfo = info.data.repository?.pullRequest;
         if (!prInfo) return info; // let `deriveStateForPR` handle the missing result

--- a/src/queries/SHA1-to-PR-query.ts
+++ b/src/queries/SHA1-to-PR-query.ts
@@ -6,7 +6,7 @@ export const runQueryToGetPRMetadataForSHA1 = async (owner: string, repo: string
     const info = await client.query({
         query: GetPRForSHA1Query,
         variables: { query: `${sha1} type:pr repo:${owner}/${repo}` },
-        fetchPolicy: "network-only",
+        fetchPolicy: "no-cache",
     });
     const pr = info.data.search.nodes?.[0];
     return pr?.__typename === "PullRequest" ? pr : undefined;

--- a/src/queries/all-open-prs-query.ts
+++ b/src/queries/all-open-prs-query.ts
@@ -26,7 +26,7 @@ export async function getAllOpenPRsAndCardIDs() {
     while (true) {
         const results = await client.query({
             query: getAllOpenPRsAndCardIDsQuery,
-            fetchPolicy: "network-only",
+            fetchPolicy: "no-cache",
             variables: { after }
         });
 

--- a/src/queries/card-id-to-pr-query.ts
+++ b/src/queries/card-id-to-pr-query.ts
@@ -17,7 +17,7 @@ export const runQueryToGetPRForCardId = async (id: string): Promise<CardPRInfo |
                 }
             }` as TypedDocumentNode<CardIdToPr, CardIdToPrVariables>,
         variables: { id },
-        fetchPolicy: "network-only",
+        fetchPolicy: "no-cache",
     });
     const node = info.data.node;
     return (node?.__typename === "ProjectCard" && node.content?.__typename === "PullRequest")

--- a/src/queries/projectboard-cards.ts
+++ b/src/queries/projectboard-cards.ts
@@ -38,7 +38,7 @@ interface ColumnInfo {
 export async function getProjectBoardCards() {
     const results = await client.query({
         query: GetProjectBoardCardsQuery,
-        fetchPolicy: "network-only",
+        fetchPolicy: "no-cache",
     });
 
     const project = results.data.repository?.project;


### PR DESCRIPTION
If we're never going to consult the cache (`fetchPolicy: "network-only"`) then don't waste memory storing results (`fetchPolicy: "no-cache"`)?

I don't expect this is a lot of memory -- I expect the number of objects is on the order of the number of active PRs? IDs should keep us from storing multiple copies. On the other hand the serverless function can run for long periods?