### PR TITLE
Verify webhook signatures

### DIFF
--- a/src/pr-trigger.ts
+++ b/src/pr-trigger.ts
@@ -27,7 +27,7 @@ export async function httpTrigger(context: Context, req: HttpRequest) {
 
     // For process.env.GITHUB_WEBHOOK_SECRET see
     // https://ms.portal.azure.com/#blade/WebsitesExtension/FunctionsIFrameBlade/id/%2Fsubscriptions%2F57bfeeed-c34a-4ffd-a06b-ccff27ac91b8%2FresourceGroups%2Fdtmergebot%2Fproviders%2FMicrosoft.Web%2Fsites%2FDTMergeBot
-    if (!isDev && !webhooks.verify(req.body, webhooks.sign(req.body))) {
+    if (!isDev && !webhooks.verify(req.body, req.headers["x-hub-signature-256"]!)) {
         context.res = {
             status: 500,
             body: "This webhook did not come from GitHub"


### PR DESCRIPTION
`verify(req.body, sign(req.body))` is true by definition. Verify the actual signature instead.