### PR TITLE
Fix timeline expires math

### DIFF
--- a/src/_tests/fixtures/44989-14days/mutations.json
+++ b/src/_tests/fixtures/44989-14days/mutations.json
@@ -33,7 +33,7 @@
     "variables": {
       "input": {
         "subjectId": "MDExOlB1bGxSZXF1ZXN0NDIyMDc5Mjk3",
-        "body": "Re-ping @petr-motejlek / @TheHandsomeCoder, @donnut, @mdekrey, @sbking, @afharo, @teves-castro, @1M0reBug, @hojberg, @samsonkeung, @angeloocana, @raynerd, @moshensky, @ethanresnick, @deftomat, @blimusiek, @biern, @rayhaneh, @rgm, @drewwyatt, @jottenlips, @minitesh, @krantisinh, @pirix-gh, @brekk, @nemo108, @jituanlin, @Philippe-mills, @Saul-Mirone, @Nicholaiii:\n\nThis PR has been ready to merge for over a week, and I haven't seen any requests to merge it. I will close it on Jul 6th (in three weeks) if this doesn't happen.\n\n(If there's no reason to avoid merging it, please do so.  Otherwise, if it shouldn't be merged or if it needs more time, please close it or turn it into a draft.)\n<!--typescript_bot_Unmerged:nearly:2020-05-23-->"
+        "body": "Re-ping @petr-motejlek / @TheHandsomeCoder, @donnut, @mdekrey, @sbking, @afharo, @teves-castro, @1M0reBug, @hojberg, @samsonkeung, @angeloocana, @raynerd, @moshensky, @ethanresnick, @deftomat, @blimusiek, @biern, @rayhaneh, @rgm, @drewwyatt, @jottenlips, @minitesh, @krantisinh, @pirix-gh, @brekk, @nemo108, @jituanlin, @Philippe-mills, @Saul-Mirone, @Nicholaiii:\n\nThis PR has been ready to merge for over a week, and I haven't seen any requests to merge it. I will close it on Jun 22nd (in three weeks) if this doesn't happen.\n\n(If there's no reason to avoid merging it, please do so.  Otherwise, if it shouldn't be merged or if it needs more time, please close it or turn it into a draft.)\n<!--typescript_bot_Unmerged:nearly:2020-05-23-->"
       }
     }
   }

--- a/src/_tests/fixtures/44989-14days/result.json
+++ b/src/_tests/fixtures/44989-14days/result.json
@@ -17,7 +17,7 @@
     },
     {
       "tag": "Unmerged:nearly:2020-05-23",
-      "status": "Re-ping @petr-motejlek / @TheHandsomeCoder, @donnut, @mdekrey, @sbking, @afharo, @teves-castro, @1M0reBug, @hojberg, @samsonkeung, @angeloocana, @raynerd, @moshensky, @ethanresnick, @deftomat, @blimusiek, @biern, @rayhaneh, @rgm, @drewwyatt, @jottenlips, @minitesh, @krantisinh, @pirix-gh, @brekk, @nemo108, @jituanlin, @Philippe-mills, @Saul-Mirone, @Nicholaiii:\n\nThis PR has been ready to merge for over a week, and I haven't seen any requests to merge it. I will close it on Jul 6th (in three weeks) if this doesn't happen.\n\n(If there's no reason to avoid merging it, please do so.  Otherwise, if it shouldn't be merged or if it needs more time, please close it or turn it into a draft.)"
+      "status": "Re-ping @petr-motejlek / @TheHandsomeCoder, @donnut, @mdekrey, @sbking, @afharo, @teves-castro, @1M0reBug, @hojberg, @samsonkeung, @angeloocana, @raynerd, @moshensky, @ethanresnick, @deftomat, @blimusiek, @biern, @rayhaneh, @rgm, @drewwyatt, @jottenlips, @minitesh, @krantisinh, @pirix-gh, @brekk, @nemo108, @jituanlin, @Philippe-mills, @Saul-Mirone, @Nicholaiii:\n\nThis PR has been ready to merge for over a week, and I haven't seen any requests to merge it. I will close it on Jun 22nd (in three weeks) if this doesn't happen.\n\n(If there's no reason to avoid merging it, please do so.  Otherwise, if it shouldn't be merged or if it needs more time, please close it or turn it into a draft.)"
     }
   ],
   "shouldClose": false,

--- a/src/_tests/fixtures/48708/mutations.json
+++ b/src/_tests/fixtures/48708/mutations.json
@@ -25,7 +25,7 @@
     "variables": {
       "input": {
         "id": "MDEyOklzc3VlQ29tbWVudDcyNjMyMDI0OQ==",
-        "body": "@martin-badin I haven't seen any activity on this PR in more than three weeks, and it still has problems that prevent it from being merged. The PR will be closed on Dec 12th (in a week) if the issues aren't addressed.\n<!--typescript_bot_Abandoned:nearly:2020-10-15-->"
+        "body": "@martin-badin I haven't seen any activity on this PR in more than three weeks, and it still has problems that prevent it from being merged. The PR will be closed on Nov 14th (in a week) if the issues aren't addressed.\n<!--typescript_bot_Abandoned:nearly:2020-10-15-->"
       }
     }
   }

--- a/src/_tests/fixtures/48708/result.json
+++ b/src/_tests/fixtures/48708/result.json
@@ -17,7 +17,7 @@
     },
     {
       "tag": "Abandoned:nearly:2020-10-15",
-      "status": "@martin-badin I haven't seen any activity on this PR in more than three weeks, and it still has problems that prevent it from being merged. The PR will be closed on Dec 12th (in a week) if the issues aren't addressed."
+      "status": "@martin-badin I haven't seen any activity on this PR in more than three weeks, and it still has problems that prevent it from being merged. The PR will be closed on Nov 14th (in a week) if the issues aren't addressed."
     }
   ],
   "shouldClose": false,

--- a/src/compute-pr-actions.ts
+++ b/src/compute-pr-actions.ts
@@ -359,7 +359,7 @@ function makeStaleness(now: Date, author: string, otherOwners: string[]) { // cu
         const state = days <= freshDays ? "fresh" : days <= attnDays ? "attention" : days <= nearDays ? "nearly" : "done";
         const kindAndState = `${kind}:${state}`;
         const explanation = Comments.StalenessExplanations[kindAndState];
-        const expires = dayjs(now).add(nearDays, "days").format("MMM Do");
+        const expires = dayjs(since).add(nearDays, "days").format("MMM Do");
         const comment = Comments.StalenessComment(author, otherOwners, expires)[kindAndState];
         const doTimelineActions = (actions: Actions) => {
             if (comment !== undefined) {


### PR DESCRIPTION
The timelines expire on (`since` + the maximum staleness), not (`now` + the maximum staleness). I introduced this bug in #289, mea culpa!