### PR TITLE
Ignore case of entries in `compilerOptions.lib`

### DIFF
--- a/src/pr-info.ts
+++ b/src/pr-info.ts
@@ -397,7 +397,8 @@ configSuspicious["tsconfig.json"] = makeChecker(
     },
     urls.tsconfigJson,
     { ignore: data => {
-        data.compilerOptions.lib = data.compilerOptions.lib.filter((value: unknown) => value !== "dom");
+        data.compilerOptions.lib = data.compilerOptions.lib.filter((value: unknown) =>
+            !(typeof value === "string" && value.toLowerCase() === "dom"));
         delete data.compilerOptions.baseUrl;
         delete data.compilerOptions.typeRoots;
         delete data.compilerOptions.paths;


### PR DESCRIPTION
So there are no suspicious flags raised when using `dom` too.