### PR TITLE
Fetch *all* files

### DIFF
--- a/src/commands/create-fixture.ts
+++ b/src/commands/create-fixture.ts
@@ -1,5 +1,6 @@
 import * as computeActions from "../compute-pr-actions";
-import { deriveStateForPR, queryPRInfo } from "../pr-info";
+import { getPRInfo } from "../queries/pr-query";
+import { deriveStateForPR } from "../pr-info";
 import { ApolloQueryResult } from "@apollo/client/core";
 import { writeFileSync, mkdirSync, existsSync, readJsonSync } from "fs-extra";
 import { join } from "path";
@@ -21,7 +22,7 @@ export default async function main(directory: string, overwriteInfo: boolean) {
 
     const jsonFixturePath = join(fixturePath, "_response.json");
     if (overwriteInfo || !existsSync(jsonFixturePath)) {
-        writeJsonSync(jsonFixturePath, await queryPRInfo(prNumber));
+        writeJsonSync(jsonFixturePath, await getPRInfo(prNumber));
     }
     const response: ApolloQueryResult<PR> = readJsonSync(jsonFixturePath);
 

--- a/src/pr-trigger.ts
+++ b/src/pr-trigger.ts
@@ -1,6 +1,7 @@
 // GH webhook entry point
 
-import { queryPRInfo, deriveStateForPR } from "./pr-info";
+import { getPRInfo } from "./queries/pr-query";
+import { deriveStateForPR } from "./pr-info";
 import { process as computeActions } from "./compute-pr-actions";
 import { executePrActions } from "./execute-pr-actions";
 import { mergeCodeOwnersOnGreen } from "./side-effects/merge-codeowner-prs";
@@ -90,7 +91,7 @@ const handleTrigger = (context: Context) => async (event: EmitterWebhookEvent<ty
         return reply(context, 204, `Skipped webhook, superseded by a newer one for ${pr.number}`);
 
     context.log(`Getting info for PR ${pr.number} - ${pr.title || "(title not fetched)"}`);
-    const info = await queryPRInfo(pr.number);
+    const info = await getPRInfo(pr.number);
     const prInfo = info.data.repository?.pullRequest;
 
     // If it didn't work, bail early

--- a/src/queries/schema/PR.ts
+++ b/src/queries/schema/PR.ts
@@ -408,6 +408,18 @@ export interface PR_repository_pullRequest_files_nodes {
   deletions: number;
 }
 
+export interface PR_repository_pullRequest_files_pageInfo {
+  __typename: "PageInfo";
+  /**
+   * When paginating forwards, are there more items?
+   */
+  hasNextPage: boolean;
+  /**
+   * When paginating forwards, the cursor to continue.
+   */
+  endCursor: string | null;
+}
+
 export interface PR_repository_pullRequest_files {
   __typename: "PullRequestChangedFileConnection";
   /**
@@ -418,6 +430,10 @@ export interface PR_repository_pullRequest_files {
    * A list of nodes.
    */
   nodes: (PR_repository_pullRequest_files_nodes | null)[] | null;
+  /**
+   * Information to aid in pagination.
+   */
+  pageInfo: PR_repository_pullRequest_files_pageInfo;
 }
 
 export interface PR_repository_pullRequest_projectCards_nodes_project {
@@ -556,5 +572,5 @@ export interface PR {
 }
 
 export interface PRVariables {
-  pr_number: number;
+  prNumber: number;
 }

--- a/src/queries/schema/PRFiles.ts
+++ b/src/queries/schema/PRFiles.ts
@@ -1,0 +1,80 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL query operation: PRFiles
+// ====================================================
+
+export interface PRFiles_repository_pullRequest_files_nodes {
+  __typename: "PullRequestChangedFile";
+  /**
+   * The path of the file.
+   */
+  path: string;
+  /**
+   * The number of additions to the file.
+   */
+  additions: number;
+  /**
+   * The number of deletions to the file.
+   */
+  deletions: number;
+}
+
+export interface PRFiles_repository_pullRequest_files_pageInfo {
+  __typename: "PageInfo";
+  /**
+   * When paginating forwards, are there more items?
+   */
+  hasNextPage: boolean;
+  /**
+   * When paginating forwards, the cursor to continue.
+   */
+  endCursor: string | null;
+}
+
+export interface PRFiles_repository_pullRequest_files {
+  __typename: "PullRequestChangedFileConnection";
+  /**
+   * Identifies the total count of items in the connection.
+   */
+  totalCount: number;
+  /**
+   * A list of nodes.
+   */
+  nodes: (PRFiles_repository_pullRequest_files_nodes | null)[] | null;
+  /**
+   * Information to aid in pagination.
+   */
+  pageInfo: PRFiles_repository_pullRequest_files_pageInfo;
+}
+
+export interface PRFiles_repository_pullRequest {
+  __typename: "PullRequest";
+  /**
+   * Lists the files changed within this pull request.
+   */
+  files: PRFiles_repository_pullRequest_files | null;
+}
+
+export interface PRFiles_repository {
+  __typename: "Repository";
+  /**
+   * Returns a single pull request from the current repository by number.
+   */
+  pullRequest: PRFiles_repository_pullRequest | null;
+}
+
+export interface PRFiles {
+  /**
+   * Lookup a given repository by the owner and repository name.
+   */
+  repository: PRFiles_repository | null;
+}
+
+export interface PRFilesVariables {
+  prNumber: number;
+  endCursor?: string | null;
+}

--- a/src/run.ts
+++ b/src/run.ts
@@ -4,7 +4,8 @@ import * as schema from "@octokit/graphql-schema/schema";
 import * as yargs from "yargs";
 import { process as computeActions } from "./compute-pr-actions";
 import { getAllOpenPRsAndCardIDs } from "./queries/all-open-prs-query";
-import { queryPRInfo, deriveStateForPR } from "./pr-info";
+import { getPRInfo } from "./queries/pr-query";
+import { deriveStateForPR } from "./pr-info";
 import { executePrActions } from "./execute-pr-actions";
 import { getProjectBoardCards } from "./queries/projectboard-cards";
 import { runQueryToGetPRForCardId } from "./queries/card-id-to-pr-query";
@@ -68,7 +69,7 @@ const start = async function () {
         if (!shouldRunOn(pr)) continue;
         console.log(`Processing #${pr} (${prs.indexOf(pr) + 1} of ${prs.length})...`);
         // Generate the info for the PR from scratch
-        const info = await queryPRInfo(pr);
+        const info = await getPRInfo(pr);
         if (args["show-raw"]) show("Raw Query Result", info);
         const prInfo = info.data.repository?.pullRequest;
         // If it didn't work, bail early


### PR DESCRIPTION
This reduces maintainer load since there are less suspicious PRs, and
make it easier to see if the PR is well behaved.

Move the whole retry + fetch rest thing into `src/queries/pr-query`.

Leave the `tooManyFiles` bits in for now, but if this is stable enough
they should eventually be removed.