### PR TITLE
Adds a new webhook which returns the JSON data for a PR

### DIFF
--- a/Playground-Info/function.json
+++ b/Playground-Info/function.json
@@ -1,0 +1,20 @@
+{
+  "bindings": [
+    {
+      "authLevel": "function",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req",
+      "methods": [
+        "get",
+        "post"
+      ]
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "res"
+    }
+  ],
+  "scriptFile": "./index.mjs"
+}

--- a/Playground-Info/index.mjs
+++ b/Playground-Info/index.mjs
@@ -4,8 +4,16 @@ import { getPRInfo } from "../bin/queries/pr-query.js";
 
 /** @type {import("@azure/functions").AzureFunction} */
 const httpTrigger = async function (context) {
-    const prNumber = context.req.query.number;
-    const info = await getPRInfo(prNumber);
+    const prNumber = Number(context.req.query.number);
+    if (!prNumber || prNumber === NaN)  {
+        context.res = {
+            status: 404,
+            body: "PR not found"
+        };
+        return;
+    }
+
+    const info = await getPRInfo(prNumber)
     const prInfo = info.data.repository?.pullRequest;
 
     if (!prInfo) {
@@ -15,8 +23,8 @@ const httpTrigger = async function (context) {
         };
         return;
     }
-    const state = await deriveStateForPR(prInfo);
 
+    const state = await deriveStateForPR(prInfo);
     if (!context.res) throw new Error("No Res");
 
     // Allow all others to access this,  we can 

--- a/Playground-Info/index.mjs
+++ b/Playground-Info/index.mjs
@@ -1,0 +1,33 @@
+// @ts-check
+import { deriveStateForPR } from "../bin/pr-info.js";
+import { getPRInfo } from "../bin/queries/pr-query.js";
+
+/** @type {import("@azure/functions").AzureFunction} */
+const httpTrigger = async function (context) {
+    const prNumber = context.req.query.number;
+    const info = await getPRInfo(prNumber);
+    const prInfo = info.data.repository?.pullRequest;
+
+    if (!prInfo) {
+        context.res = {
+            status: 404,
+            body: "PR not found"
+        };
+        return;
+    }
+    const state = await deriveStateForPR(prInfo);
+
+    if (!context.res) throw new Error("No Res");
+
+    // Allow all others to access this,  we can 
+    // tighten this down to the TS URLs if the route is abused
+    const headers = {
+        "Content-Type": "text/json",
+        "Access-Control-Allow-Methods": "GET",
+        "Access-Control-Allow-Origin": "*",
+    }
+
+    context.res = { status: 200, headers, body: { state, info } };
+};
+
+export default httpTrigger;


### PR DESCRIPTION
Adds a new API end-point which allows anyone to grab the bot's opinion on an arbitrary PR number. You should rightly be wondering what the goal is, well I'm exploring a playground for reviewing DT PRs and I need data from GitHub - specifically a bunch of PR metadata.

To get useful metadata _reliably_ you need an access token etc, so I thought about re-using an existing API - then I wondered, well, I have to re-create _some_ of the logic from the state from the bot. Why not just have the bot fix both issues? So, now you can make an API call to get the PR state for an arbitrary PR.