### PR TITLE
Revise the ready-to-merge message to be a bit less celebratory

### DIFF
--- a/src/_tests/fixtures/43144/mutations.json
+++ b/src/_tests/fixtures/43144/mutations.json
@@ -33,7 +33,7 @@
     "variables": {
       "input": {
         "subjectId": "MDExOlB1bGxSZXF1ZXN0Mzg4NDkxOTI2",
-        "body": "@jeffreymeng Everything looks good here. Great job! I am ready to merge this PR (at f1f5c4b) on your behalf.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n\n(@pocesar: you can do this too.)\n<!--typescript_bot_merge-offer-->"
+        "body": "@jeffreymeng: Everything looks good here. I am ready to merge this PR (at f1f5c4b) on your behalf whenever you think it's ready.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n\n(@pocesar: you can do this too.)\n<!--typescript_bot_merge-offer-->"
       }
     }
   }

--- a/src/_tests/fixtures/43144/result.json
+++ b/src/_tests/fixtures/43144/result.json
@@ -11,7 +11,7 @@
     },
     {
       "tag": "merge-offer",
-      "status": "@jeffreymeng Everything looks good here. Great job! I am ready to merge this PR (at f1f5c4b) on your behalf.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n\n(@pocesar: you can do this too.)"
+      "status": "@jeffreymeng: Everything looks good here. I am ready to merge this PR (at f1f5c4b) on your behalf whenever you think it's ready.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n\n(@pocesar: you can do this too.)"
     }
   ],
   "shouldClose": false,

--- a/src/_tests/fixtures/44402/mutations.json
+++ b/src/_tests/fixtures/44402/mutations.json
@@ -34,7 +34,7 @@
     "variables": {
       "input": {
         "id": "MDEyOklzc3VlQ29tbWVudDYyMjE3NTQ3NA==",
-        "body": "@sandersn Everything looks good here. Great job! I am ready to merge this PR (at 5dfb994) on your behalf.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n\n<!--typescript_bot_merge-offer-->"
+        "body": "@sandersn: Everything looks good here. I am ready to merge this PR (at 5dfb994) on your behalf whenever you think it's ready.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n\n<!--typescript_bot_merge-offer-->"
       }
     }
   }

--- a/src/_tests/fixtures/44402/result.json
+++ b/src/_tests/fixtures/44402/result.json
@@ -13,7 +13,7 @@
     },
     {
       "tag": "merge-offer",
-      "status": "@sandersn Everything looks good here. Great job! I am ready to merge this PR (at 5dfb994) on your behalf.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n"
+      "status": "@sandersn: Everything looks good here. I am ready to merge this PR (at 5dfb994) on your behalf whenever you think it's ready.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n"
     }
   ],
   "shouldClose": false,

--- a/src/_tests/fixtures/44437/mutations.json
+++ b/src/_tests/fixtures/44437/mutations.json
@@ -24,7 +24,7 @@
     "variables": {
       "input": {
         "id": "MDEyOklzc3VlQ29tbWVudDYyMjk0NTA1NA==",
-        "body": "@johnnyreilly Everything looks good here. Great job! I am ready to merge this PR (at eb92456) on your behalf.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n\n(@Berkays, @unindented, @kamontat, @theweirdone, @whoaa512: you can do this too.)\n<!--typescript_bot_merge-offer-->"
+        "body": "@johnnyreilly: Everything looks good here. I am ready to merge this PR (at eb92456) on your behalf whenever you think it's ready.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n\n(@Berkays, @unindented, @kamontat, @theweirdone, @whoaa512: you can do this too.)\n<!--typescript_bot_merge-offer-->"
       }
     }
   }

--- a/src/_tests/fixtures/44437/result.json
+++ b/src/_tests/fixtures/44437/result.json
@@ -13,7 +13,7 @@
     },
     {
       "tag": "merge-offer",
-      "status": "@johnnyreilly Everything looks good here. Great job! I am ready to merge this PR (at eb92456) on your behalf.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n\n(@Berkays, @unindented, @kamontat, @theweirdone, @whoaa512: you can do this too.)"
+      "status": "@johnnyreilly: Everything looks good here. I am ready to merge this PR (at eb92456) on your behalf whenever you think it's ready.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n\n(@Berkays, @unindented, @kamontat, @theweirdone, @whoaa512: you can do this too.)"
     }
   ],
   "shouldClose": false,

--- a/src/_tests/fixtures/44989-14days/mutations.json
+++ b/src/_tests/fixtures/44989-14days/mutations.json
@@ -24,7 +24,7 @@
     "variables": {
       "input": {
         "id": "MDEyOklzc3VlQ29tbWVudDYzMzAxODkyMw==",
-        "body": "@petr-motejlek Everything looks good here. Great job! I am ready to merge this PR (at 9ca6086) on your behalf.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n\n(@TheHandsomeCoder, @donnut, @mdekrey, @sbking, @afharo, @teves-castro, @1M0reBug, @hojberg, @samsonkeung, @angeloocana, @raynerd, @moshensky, @ethanresnick, @deftomat, @blimusiek, @biern, @rayhaneh, @rgm, @drewwyatt, @jottenlips, @minitesh, @krantisinh, @pirix-gh, @brekk, @nemo108, @jituanlin, @Philippe-mills, @Saul-Mirone, @Nicholaiii: you can do this too.)\n<!--typescript_bot_merge-offer-->"
+        "body": "@petr-motejlek: Everything looks good here. I am ready to merge this PR (at 9ca6086) on your behalf whenever you think it's ready.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n\n(@TheHandsomeCoder, @donnut, @mdekrey, @sbking, @afharo, @teves-castro, @1M0reBug, @hojberg, @samsonkeung, @angeloocana, @raynerd, @moshensky, @ethanresnick, @deftomat, @blimusiek, @biern, @rayhaneh, @rgm, @drewwyatt, @jottenlips, @minitesh, @krantisinh, @pirix-gh, @brekk, @nemo108, @jituanlin, @Philippe-mills, @Saul-Mirone, @Nicholaiii: you can do this too.)\n<!--typescript_bot_merge-offer-->"
       }
     }
   },

--- a/src/_tests/fixtures/44989-14days/result.json
+++ b/src/_tests/fixtures/44989-14days/result.json
@@ -13,7 +13,7 @@
     },
     {
       "tag": "merge-offer",
-      "status": "@petr-motejlek Everything looks good here. Great job! I am ready to merge this PR (at 9ca6086) on your behalf.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n\n(@TheHandsomeCoder, @donnut, @mdekrey, @sbking, @afharo, @teves-castro, @1M0reBug, @hojberg, @samsonkeung, @angeloocana, @raynerd, @moshensky, @ethanresnick, @deftomat, @blimusiek, @biern, @rayhaneh, @rgm, @drewwyatt, @jottenlips, @minitesh, @krantisinh, @pirix-gh, @brekk, @nemo108, @jituanlin, @Philippe-mills, @Saul-Mirone, @Nicholaiii: you can do this too.)"
+      "status": "@petr-motejlek: Everything looks good here. I am ready to merge this PR (at 9ca6086) on your behalf whenever you think it's ready.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n\n(@TheHandsomeCoder, @donnut, @mdekrey, @sbking, @afharo, @teves-castro, @1M0reBug, @hojberg, @samsonkeung, @angeloocana, @raynerd, @moshensky, @ethanresnick, @deftomat, @blimusiek, @biern, @rayhaneh, @rgm, @drewwyatt, @jottenlips, @minitesh, @krantisinh, @pirix-gh, @brekk, @nemo108, @jituanlin, @Philippe-mills, @Saul-Mirone, @Nicholaiii: you can do this too.)"
     },
     {
       "tag": "Unmerged:nearly:2020-05-23",

--- a/src/_tests/fixtures/44989-32days/mutations.json
+++ b/src/_tests/fixtures/44989-32days/mutations.json
@@ -40,7 +40,7 @@
     "variables": {
       "input": {
         "id": "MDEyOklzc3VlQ29tbWVudDYzMzAxODkyMw==",
-        "body": "@petr-motejlek Everything looks good here. Great job! I am ready to merge this PR (at 9ca6086) on your behalf.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n\n(@TheHandsomeCoder, @donnut, @mdekrey, @sbking, @afharo, @teves-castro, @1M0reBug, @hojberg, @samsonkeung, @angeloocana, @raynerd, @moshensky, @ethanresnick, @deftomat, @blimusiek, @biern, @rayhaneh, @rgm, @drewwyatt, @jottenlips, @minitesh, @krantisinh, @pirix-gh, @brekk, @nemo108, @jituanlin, @Philippe-mills, @Saul-Mirone, @Nicholaiii: you can do this too.)\n<!--typescript_bot_merge-offer-->"
+        "body": "@petr-motejlek: Everything looks good here. I am ready to merge this PR (at 9ca6086) on your behalf whenever you think it's ready.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n\n(@TheHandsomeCoder, @donnut, @mdekrey, @sbking, @afharo, @teves-castro, @1M0reBug, @hojberg, @samsonkeung, @angeloocana, @raynerd, @moshensky, @ethanresnick, @deftomat, @blimusiek, @biern, @rayhaneh, @rgm, @drewwyatt, @jottenlips, @minitesh, @krantisinh, @pirix-gh, @brekk, @nemo108, @jituanlin, @Philippe-mills, @Saul-Mirone, @Nicholaiii: you can do this too.)\n<!--typescript_bot_merge-offer-->"
       }
     }
   },

--- a/src/_tests/fixtures/44989-32days/result.json
+++ b/src/_tests/fixtures/44989-32days/result.json
@@ -13,7 +13,7 @@
     },
     {
       "tag": "merge-offer",
-      "status": "@petr-motejlek Everything looks good here. Great job! I am ready to merge this PR (at 9ca6086) on your behalf.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n\n(@TheHandsomeCoder, @donnut, @mdekrey, @sbking, @afharo, @teves-castro, @1M0reBug, @hojberg, @samsonkeung, @angeloocana, @raynerd, @moshensky, @ethanresnick, @deftomat, @blimusiek, @biern, @rayhaneh, @rgm, @drewwyatt, @jottenlips, @minitesh, @krantisinh, @pirix-gh, @brekk, @nemo108, @jituanlin, @Philippe-mills, @Saul-Mirone, @Nicholaiii: you can do this too.)"
+      "status": "@petr-motejlek: Everything looks good here. I am ready to merge this PR (at 9ca6086) on your behalf whenever you think it's ready.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n\n(@TheHandsomeCoder, @donnut, @mdekrey, @sbking, @afharo, @teves-castro, @1M0reBug, @hojberg, @samsonkeung, @angeloocana, @raynerd, @moshensky, @ethanresnick, @deftomat, @blimusiek, @biern, @rayhaneh, @rgm, @drewwyatt, @jottenlips, @minitesh, @krantisinh, @pirix-gh, @brekk, @nemo108, @jituanlin, @Philippe-mills, @Saul-Mirone, @Nicholaiii: you can do this too.)"
     },
     {
       "tag": "Unmerged:done",

--- a/src/_tests/fixtures/44989-3days/mutations.json
+++ b/src/_tests/fixtures/44989-3days/mutations.json
@@ -13,7 +13,7 @@
     "variables": {
       "input": {
         "id": "MDEyOklzc3VlQ29tbWVudDYzMzAxODkyMw==",
-        "body": "@petr-motejlek Everything looks good here. Great job! I am ready to merge this PR (at 9ca6086) on your behalf.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n\n(@TheHandsomeCoder, @donnut, @mdekrey, @sbking, @afharo, @teves-castro, @1M0reBug, @hojberg, @samsonkeung, @angeloocana, @raynerd, @moshensky, @ethanresnick, @deftomat, @blimusiek, @biern, @rayhaneh, @rgm, @drewwyatt, @jottenlips, @minitesh, @krantisinh, @pirix-gh, @brekk, @nemo108, @jituanlin, @Philippe-mills, @Saul-Mirone, @Nicholaiii: you can do this too.)\n<!--typescript_bot_merge-offer-->"
+        "body": "@petr-motejlek: Everything looks good here. I am ready to merge this PR (at 9ca6086) on your behalf whenever you think it's ready.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n\n(@TheHandsomeCoder, @donnut, @mdekrey, @sbking, @afharo, @teves-castro, @1M0reBug, @hojberg, @samsonkeung, @angeloocana, @raynerd, @moshensky, @ethanresnick, @deftomat, @blimusiek, @biern, @rayhaneh, @rgm, @drewwyatt, @jottenlips, @minitesh, @krantisinh, @pirix-gh, @brekk, @nemo108, @jituanlin, @Philippe-mills, @Saul-Mirone, @Nicholaiii: you can do this too.)\n<!--typescript_bot_merge-offer-->"
       }
     }
   }

--- a/src/_tests/fixtures/44989-3days/result.json
+++ b/src/_tests/fixtures/44989-3days/result.json
@@ -12,7 +12,7 @@
     },
     {
       "tag": "merge-offer",
-      "status": "@petr-motejlek Everything looks good here. Great job! I am ready to merge this PR (at 9ca6086) on your behalf.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n\n(@TheHandsomeCoder, @donnut, @mdekrey, @sbking, @afharo, @teves-castro, @1M0reBug, @hojberg, @samsonkeung, @angeloocana, @raynerd, @moshensky, @ethanresnick, @deftomat, @blimusiek, @biern, @rayhaneh, @rgm, @drewwyatt, @jottenlips, @minitesh, @krantisinh, @pirix-gh, @brekk, @nemo108, @jituanlin, @Philippe-mills, @Saul-Mirone, @Nicholaiii: you can do this too.)"
+      "status": "@petr-motejlek: Everything looks good here. I am ready to merge this PR (at 9ca6086) on your behalf whenever you think it's ready.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n\n(@TheHandsomeCoder, @donnut, @mdekrey, @sbking, @afharo, @teves-castro, @1M0reBug, @hojberg, @samsonkeung, @angeloocana, @raynerd, @moshensky, @ethanresnick, @deftomat, @blimusiek, @biern, @rayhaneh, @rgm, @drewwyatt, @jottenlips, @minitesh, @krantisinh, @pirix-gh, @brekk, @nemo108, @jituanlin, @Philippe-mills, @Saul-Mirone, @Nicholaiii: you can do this too.)"
     }
   ],
   "shouldClose": false,

--- a/src/_tests/fixtures/44989-7days/mutations.json
+++ b/src/_tests/fixtures/44989-7days/mutations.json
@@ -13,7 +13,7 @@
     "variables": {
       "input": {
         "id": "MDEyOklzc3VlQ29tbWVudDYzMzAxODkyMw==",
-        "body": "@petr-motejlek Everything looks good here. Great job! I am ready to merge this PR (at 9ca6086) on your behalf.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n\n(@TheHandsomeCoder, @donnut, @mdekrey, @sbking, @afharo, @teves-castro, @1M0reBug, @hojberg, @samsonkeung, @angeloocana, @raynerd, @moshensky, @ethanresnick, @deftomat, @blimusiek, @biern, @rayhaneh, @rgm, @drewwyatt, @jottenlips, @minitesh, @krantisinh, @pirix-gh, @brekk, @nemo108, @jituanlin, @Philippe-mills, @Saul-Mirone, @Nicholaiii: you can do this too.)\n<!--typescript_bot_merge-offer-->"
+        "body": "@petr-motejlek: Everything looks good here. I am ready to merge this PR (at 9ca6086) on your behalf whenever you think it's ready.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n\n(@TheHandsomeCoder, @donnut, @mdekrey, @sbking, @afharo, @teves-castro, @1M0reBug, @hojberg, @samsonkeung, @angeloocana, @raynerd, @moshensky, @ethanresnick, @deftomat, @blimusiek, @biern, @rayhaneh, @rgm, @drewwyatt, @jottenlips, @minitesh, @krantisinh, @pirix-gh, @brekk, @nemo108, @jituanlin, @Philippe-mills, @Saul-Mirone, @Nicholaiii: you can do this too.)\n<!--typescript_bot_merge-offer-->"
       }
     }
   }

--- a/src/_tests/fixtures/44989-7days/result.json
+++ b/src/_tests/fixtures/44989-7days/result.json
@@ -12,7 +12,7 @@
     },
     {
       "tag": "merge-offer",
-      "status": "@petr-motejlek Everything looks good here. Great job! I am ready to merge this PR (at 9ca6086) on your behalf.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n\n(@TheHandsomeCoder, @donnut, @mdekrey, @sbking, @afharo, @teves-castro, @1M0reBug, @hojberg, @samsonkeung, @angeloocana, @raynerd, @moshensky, @ethanresnick, @deftomat, @blimusiek, @biern, @rayhaneh, @rgm, @drewwyatt, @jottenlips, @minitesh, @krantisinh, @pirix-gh, @brekk, @nemo108, @jituanlin, @Philippe-mills, @Saul-Mirone, @Nicholaiii: you can do this too.)"
+      "status": "@petr-motejlek: Everything looks good here. I am ready to merge this PR (at 9ca6086) on your behalf whenever you think it's ready.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n\n(@TheHandsomeCoder, @donnut, @mdekrey, @sbking, @afharo, @teves-castro, @1M0reBug, @hojberg, @samsonkeung, @angeloocana, @raynerd, @moshensky, @ethanresnick, @deftomat, @blimusiek, @biern, @rayhaneh, @rgm, @drewwyatt, @jottenlips, @minitesh, @krantisinh, @pirix-gh, @brekk, @nemo108, @jituanlin, @Philippe-mills, @Saul-Mirone, @Nicholaiii: you can do this too.)"
     }
   ],
   "shouldClose": false,

--- a/src/_tests/fixtures/45627/mutations.json
+++ b/src/_tests/fixtures/45627/mutations.json
@@ -62,7 +62,7 @@
     "variables": {
       "input": {
         "id": "MDEyOklzc3VlQ29tbWVudDYyMTU1OTExNA==",
-        "body": "@spamshaker Everything looks good here. Great job! I am ready to merge this PR (at 15facc1) on your behalf.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n\n(@tkqubo, @bumbleblym, @bcherny, @tommytroylin, @mohsen1, @jcreamer898, @alan-agius4, @dennispg, @christophehurpeau, @ZSkycat, @johnnyreilly, @rwaskiewicz, @kuehlein, @grgur, @rubenspgcavalcante, @andersk, @ofhouse, @danielthank, @sasurau4, @dionshihk, @peterblazejewicz: you can do this too.)\n<!--typescript_bot_merge-offer-->"
+        "body": "@spamshaker: Everything looks good here. I am ready to merge this PR (at 15facc1) on your behalf whenever you think it's ready.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n\n(@tkqubo, @bumbleblym, @bcherny, @tommytroylin, @mohsen1, @jcreamer898, @alan-agius4, @dennispg, @christophehurpeau, @ZSkycat, @johnnyreilly, @rwaskiewicz, @kuehlein, @grgur, @rubenspgcavalcante, @andersk, @ofhouse, @danielthank, @sasurau4, @dionshihk, @peterblazejewicz: you can do this too.)\n<!--typescript_bot_merge-offer-->"
       }
     }
   },

--- a/src/_tests/fixtures/45627/result.json
+++ b/src/_tests/fixtures/45627/result.json
@@ -19,7 +19,7 @@
     },
     {
       "tag": "merge-offer",
-      "status": "@spamshaker Everything looks good here. Great job! I am ready to merge this PR (at 15facc1) on your behalf.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n\n(@tkqubo, @bumbleblym, @bcherny, @tommytroylin, @mohsen1, @jcreamer898, @alan-agius4, @dennispg, @christophehurpeau, @ZSkycat, @johnnyreilly, @rwaskiewicz, @kuehlein, @grgur, @rubenspgcavalcante, @andersk, @ofhouse, @danielthank, @sasurau4, @dionshihk, @peterblazejewicz: you can do this too.)"
+      "status": "@spamshaker: Everything looks good here. I am ready to merge this PR (at 15facc1) on your behalf whenever you think it's ready.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n\n(@tkqubo, @bumbleblym, @bcherny, @tommytroylin, @mohsen1, @jcreamer898, @alan-agius4, @dennispg, @christophehurpeau, @ZSkycat, @johnnyreilly, @rwaskiewicz, @kuehlein, @grgur, @rubenspgcavalcante, @andersk, @ofhouse, @danielthank, @sasurau4, @dionshihk, @peterblazejewicz: you can do this too.)"
     },
     {
       "tag": "Unmerged:done",

--- a/src/_tests/fixtures/45884/mutations.json
+++ b/src/_tests/fixtures/45884/mutations.json
@@ -22,7 +22,7 @@
     "variables": {
       "input": {
         "id": "MDEyOklzc3VlQ29tbWVudDY1NDA0ODc4NQ==",
-        "body": "@sgratzl Everything looks good here. Great job! I am ready to merge this PR (at 1dcf44a) on your behalf.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n\n(@phreed, @wy193777, @ypconstante, @janniclas, @cerberuser, @gsbelarus, @peterjferrarotto, @spaxe, @appleparan, @Veckodag: you can do this too.)\n<!--typescript_bot_merge-offer-->"
+        "body": "@sgratzl: Everything looks good here. I am ready to merge this PR (at 1dcf44a) on your behalf whenever you think it's ready.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n\n(@phreed, @wy193777, @ypconstante, @janniclas, @cerberuser, @gsbelarus, @peterjferrarotto, @spaxe, @appleparan, @Veckodag: you can do this too.)\n<!--typescript_bot_merge-offer-->"
       }
     }
   }

--- a/src/_tests/fixtures/45884/result.json
+++ b/src/_tests/fixtures/45884/result.json
@@ -16,7 +16,7 @@
     },
     {
       "tag": "merge-offer",
-      "status": "@sgratzl Everything looks good here. Great job! I am ready to merge this PR (at 1dcf44a) on your behalf.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n\n(@phreed, @wy193777, @ypconstante, @janniclas, @cerberuser, @gsbelarus, @peterjferrarotto, @spaxe, @appleparan, @Veckodag: you can do this too.)"
+      "status": "@sgratzl: Everything looks good here. I am ready to merge this PR (at 1dcf44a) on your behalf whenever you think it's ready.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n\n(@phreed, @wy193777, @ypconstante, @janniclas, @cerberuser, @gsbelarus, @peterjferrarotto, @spaxe, @appleparan, @Veckodag: you can do this too.)"
     }
   ],
   "shouldClose": false,

--- a/src/_tests/fixtures/45999/mutations.json
+++ b/src/_tests/fixtures/45999/mutations.json
@@ -33,7 +33,7 @@
     "variables": {
       "input": {
         "subjectId": "MDExOlB1bGxSZXF1ZXN0NDQ3Mzc2MjE3",
-        "body": "@alexpyzhianov Everything looks good here. Great job! I am ready to merge this PR (at 381a2a9) on your behalf.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n\n(@johnnyreilly, @bbenezech, @pzavolinsky, @digiguru, @ericanderson, @DovydasNavickas, @theruther4d, @guilhermehubner, @ferdaber, @jrakotoharisoa, @pascaloliv, @hotell, @franklixuefei, @Jessidhia, @saranshkataria, @lukyth, @eps1lon, @zieka, @dancerphil, @dimitropoulos, @disjukr, @vhfmag, @hellatan: you can do this too.)\n<!--typescript_bot_merge-offer-->"
+        "body": "@alexpyzhianov: Everything looks good here. I am ready to merge this PR (at 381a2a9) on your behalf whenever you think it's ready.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n\n(@johnnyreilly, @bbenezech, @pzavolinsky, @digiguru, @ericanderson, @DovydasNavickas, @theruther4d, @guilhermehubner, @ferdaber, @jrakotoharisoa, @pascaloliv, @hotell, @franklixuefei, @Jessidhia, @saranshkataria, @lukyth, @eps1lon, @zieka, @dancerphil, @dimitropoulos, @disjukr, @vhfmag, @hellatan: you can do this too.)\n<!--typescript_bot_merge-offer-->"
       }
     }
   }

--- a/src/_tests/fixtures/45999/result.json
+++ b/src/_tests/fixtures/45999/result.json
@@ -12,7 +12,7 @@
     },
     {
       "tag": "merge-offer",
-      "status": "@alexpyzhianov Everything looks good here. Great job! I am ready to merge this PR (at 381a2a9) on your behalf.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n\n(@johnnyreilly, @bbenezech, @pzavolinsky, @digiguru, @ericanderson, @DovydasNavickas, @theruther4d, @guilhermehubner, @ferdaber, @jrakotoharisoa, @pascaloliv, @hotell, @franklixuefei, @Jessidhia, @saranshkataria, @lukyth, @eps1lon, @zieka, @dancerphil, @dimitropoulos, @disjukr, @vhfmag, @hellatan: you can do this too.)"
+      "status": "@alexpyzhianov: Everything looks good here. I am ready to merge this PR (at 381a2a9) on your behalf whenever you think it's ready.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n\n(@johnnyreilly, @bbenezech, @pzavolinsky, @digiguru, @ericanderson, @DovydasNavickas, @theruther4d, @guilhermehubner, @ferdaber, @jrakotoharisoa, @pascaloliv, @hotell, @franklixuefei, @Jessidhia, @saranshkataria, @lukyth, @eps1lon, @zieka, @dancerphil, @dimitropoulos, @disjukr, @vhfmag, @hellatan: you can do this too.)"
     }
   ],
   "shouldClose": false,

--- a/src/_tests/fixtures/46008/mutations.json
+++ b/src/_tests/fixtures/46008/mutations.json
@@ -42,7 +42,7 @@
     "variables": {
       "input": {
         "subjectId": "MDExOlB1bGxSZXF1ZXN0NDQ3NTU0NTEw",
-        "body": "@risingBirdSong Everything looks good here. Great job! I am ready to merge this PR (at 3e19cb9) on your behalf.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n\n(@p5-types, @Zalastax: you can do this too.)\n<!--typescript_bot_merge-offer-->"
+        "body": "@risingBirdSong: Everything looks good here. I am ready to merge this PR (at 3e19cb9) on your behalf whenever you think it's ready.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n\n(@p5-types, @Zalastax: you can do this too.)\n<!--typescript_bot_merge-offer-->"
       }
     }
   }

--- a/src/_tests/fixtures/46008/result.json
+++ b/src/_tests/fixtures/46008/result.json
@@ -16,7 +16,7 @@
     },
     {
       "tag": "merge-offer",
-      "status": "@risingBirdSong Everything looks good here. Great job! I am ready to merge this PR (at 3e19cb9) on your behalf.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n\n(@p5-types, @Zalastax: you can do this too.)"
+      "status": "@risingBirdSong: Everything looks good here. I am ready to merge this PR (at 3e19cb9) on your behalf whenever you think it's ready.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n\n(@p5-types, @Zalastax: you can do this too.)"
     }
   ],
   "shouldClose": false,

--- a/src/_tests/fixtures/46019/mutations.json
+++ b/src/_tests/fixtures/46019/mutations.json
@@ -13,7 +13,7 @@
     "variables": {
       "input": {
         "id": "MDEyOklzc3VlQ29tbWVudDY1NzE3MjMxMA==",
-        "body": "@peterblazejewicz Everything looks good here. Great job! I am ready to merge this PR (at ceca9f7) on your behalf.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n\n<!--typescript_bot_merge-offer-->"
+        "body": "@peterblazejewicz: Everything looks good here. I am ready to merge this PR (at ceca9f7) on your behalf whenever you think it's ready.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n\n<!--typescript_bot_merge-offer-->"
       }
     }
   }

--- a/src/_tests/fixtures/46019/result.json
+++ b/src/_tests/fixtures/46019/result.json
@@ -12,7 +12,7 @@
     },
     {
       "tag": "merge-offer",
-      "status": "@peterblazejewicz Everything looks good here. Great job! I am ready to merge this PR (at ceca9f7) on your behalf.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n"
+      "status": "@peterblazejewicz: Everything looks good here. I am ready to merge this PR (at ceca9f7) on your behalf whenever you think it's ready.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n"
     }
   ],
   "shouldClose": false,

--- a/src/_tests/fixtures/46120/mutations.json
+++ b/src/_tests/fixtures/46120/mutations.json
@@ -22,7 +22,7 @@
     "variables": {
       "input": {
         "subjectId": "MDExOlB1bGxSZXF1ZXN0NDQ5ODI3NTQ3",
-        "body": "@reubenrybnik Everything looks good here. Great job! I am ready to merge this PR (at 5ef8fe2) on your behalf.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n\n(@borisyankov, @jbaldwin, @ccurrens, @confususs, @jgonggrijp, @ffflorian, @regevbr, @peterblazejewicz: you can do this too.)\n<!--typescript_bot_merge-offer-->"
+        "body": "@reubenrybnik: Everything looks good here. I am ready to merge this PR (at 5ef8fe2) on your behalf whenever you think it's ready.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n\n(@borisyankov, @jbaldwin, @ccurrens, @confususs, @jgonggrijp, @ffflorian, @regevbr, @peterblazejewicz: you can do this too.)\n<!--typescript_bot_merge-offer-->"
       }
     }
   },

--- a/src/_tests/fixtures/46120/result.json
+++ b/src/_tests/fixtures/46120/result.json
@@ -13,7 +13,7 @@
     },
     {
       "tag": "merge-offer",
-      "status": "@reubenrybnik Everything looks good here. Great job! I am ready to merge this PR (at 5ef8fe2) on your behalf.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n\n(@borisyankov, @jbaldwin, @ccurrens, @confususs, @jgonggrijp, @ffflorian, @regevbr, @peterblazejewicz: you can do this too.)"
+      "status": "@reubenrybnik: Everything looks good here. I am ready to merge this PR (at 5ef8fe2) on your behalf whenever you think it's ready.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n\n(@borisyankov, @jbaldwin, @ccurrens, @confususs, @jgonggrijp, @ffflorian, @regevbr, @peterblazejewicz: you can do this too.)"
     },
     {
       "tag": "wait-for-merge-offer-5ef8fe2",

--- a/src/_tests/fixtures/47017-blessed-and-two-owner/mutations.json
+++ b/src/_tests/fixtures/47017-blessed-and-two-owner/mutations.json
@@ -34,7 +34,7 @@
     "variables": {
       "input": {
         "subjectId": "MDExOlB1bGxSZXF1ZXN0NDcyOTQ5NjQ1",
-        "body": "@mastermatt Everything looks good here. Great job! I am ready to merge this PR (at dbe687d) on your behalf.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n\n<!--typescript_bot_merge-offer-->"
+        "body": "@mastermatt: Everything looks good here. I am ready to merge this PR (at dbe687d) on your behalf whenever you think it's ready.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n\n<!--typescript_bot_merge-offer-->"
       }
     }
   }

--- a/src/_tests/fixtures/47017-blessed-and-two-owner/result.json
+++ b/src/_tests/fixtures/47017-blessed-and-two-owner/result.json
@@ -13,7 +13,7 @@
     },
     {
       "tag": "merge-offer",
-      "status": "@mastermatt Everything looks good here. Great job! I am ready to merge this PR (at dbe687d) on your behalf.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n"
+      "status": "@mastermatt: Everything looks good here. I am ready to merge this PR (at dbe687d) on your behalf whenever you think it's ready.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n"
     }
   ],
   "shouldClose": false,

--- a/src/_tests/fixtures/48236/mutations.json
+++ b/src/_tests/fixtures/48236/mutations.json
@@ -39,5 +39,14 @@
         "pullRequestId": "MDExOlB1bGxSZXF1ZXN0NDkzNjEyMTI3"
       }
     }
+  },
+  {
+    "mutation": "mutation ($input: UpdateIssueCommentInput!) {\n  updateIssueComment(input: $input) {\n    __typename\n  }\n}\n",
+    "variables": {
+      "input": {
+        "id": "MDEyOklzc3VlQ29tbWVudDcwMTA1ODc1Nw==",
+        "body": "@jablko: Everything looks good here. I am ready to merge this PR (at b4d71f6) on your behalf whenever you think it's ready.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n\n(@climba03003: you can do this too.)\n<!--typescript_bot_merge-offer-->"
+      }
+    }
   }
 ]

--- a/src/_tests/fixtures/48236/result.json
+++ b/src/_tests/fixtures/48236/result.json
@@ -15,7 +15,7 @@
     },
     {
       "tag": "merge-offer",
-      "status": "@jablko Everything looks good here. Great job! I am ready to merge this PR (at b4d71f6) on your behalf.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n\n(@climba03003: you can do this too.)"
+      "status": "@jablko: Everything looks good here. I am ready to merge this PR (at b4d71f6) on your behalf whenever you think it's ready.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n\n(@climba03003: you can do this too.)"
     }
   ],
   "shouldClose": false,

--- a/src/_tests/fixtures/48652-merge-offer/mutations.json
+++ b/src/_tests/fixtures/48652-merge-offer/mutations.json
@@ -33,7 +33,7 @@
     "variables": {
       "input": {
         "subjectId": "MDExOlB1bGxSZXF1ZXN0NTAwNjg4ODM0",
-        "body": "@mgol Everything looks good here. Great job! I am ready to merge this PR (at 06d8d67) on your behalf.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n\n<!--typescript_bot_merge-offer-->"
+        "body": "@mgol: Everything looks good here. I am ready to merge this PR (at 06d8d67) on your behalf whenever you think it's ready.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n\n<!--typescript_bot_merge-offer-->"
       }
     }
   },

--- a/src/_tests/fixtures/48652-merge-offer/result.json
+++ b/src/_tests/fixtures/48652-merge-offer/result.json
@@ -13,7 +13,7 @@
     },
     {
       "tag": "merge-offer",
-      "status": "@mgol Everything looks good here. Great job! I am ready to merge this PR (at 06d8d67) on your behalf.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n"
+      "status": "@mgol: Everything looks good here. I am ready to merge this PR (at 06d8d67) on your behalf whenever you think it's ready.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n"
     },
     {
       "tag": "stale-ping-024242-753cdb3",

--- a/src/_tests/fixtures/48652-prereq/mutations.json
+++ b/src/_tests/fixtures/48652-prereq/mutations.json
@@ -33,7 +33,7 @@
     "variables": {
       "input": {
         "subjectId": "MDExOlB1bGxSZXF1ZXN0NTAwNjg4ODM0",
-        "body": "@mgol Everything looks good here. Great job! I am ready to merge this PR (at 06d8d67) on your behalf.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n\n<!--typescript_bot_merge-offer-->"
+        "body": "@mgol: Everything looks good here. I am ready to merge this PR (at 06d8d67) on your behalf whenever you think it's ready.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n\n<!--typescript_bot_merge-offer-->"
       }
     }
   },

--- a/src/_tests/fixtures/48652-prereq/result.json
+++ b/src/_tests/fixtures/48652-prereq/result.json
@@ -13,7 +13,7 @@
     },
     {
       "tag": "merge-offer",
-      "status": "@mgol Everything looks good here. Great job! I am ready to merge this PR (at 06d8d67) on your behalf.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n"
+      "status": "@mgol: Everything looks good here. I am ready to merge this PR (at 06d8d67) on your behalf whenever you think it's ready.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n"
     },
     {
       "tag": "stale-ping-024242-753cdb3",

--- a/src/_tests/fixtures/49417/mutations.json
+++ b/src/_tests/fixtures/49417/mutations.json
@@ -37,7 +37,7 @@
     "variables": {
       "input": {
         "subjectId": "MDExOlB1bGxSZXF1ZXN0NTE3MTkwNTIz",
-        "body": "@Methuselah96 Everything looks good here. Great job! I am ready to merge this PR (at 2b9d098) on your behalf.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n\n(@gustavderdrache, @borisyankov, @tomwanzek, @denisname, @ledragon: you can do this too.)\n<!--typescript_bot_merge-offer-->"
+        "body": "@Methuselah96: Everything looks good here. I am ready to merge this PR (at 2b9d098) on your behalf whenever you think it's ready.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n\n(@gustavderdrache, @borisyankov, @tomwanzek, @denisname, @ledragon: you can do this too.)\n<!--typescript_bot_merge-offer-->"
       }
     }
   }

--- a/src/_tests/fixtures/49417/result.json
+++ b/src/_tests/fixtures/49417/result.json
@@ -12,7 +12,7 @@
     },
     {
       "tag": "merge-offer",
-      "status": "@Methuselah96 Everything looks good here. Great job! I am ready to merge this PR (at 2b9d098) on your behalf.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n\n(@gustavderdrache, @borisyankov, @tomwanzek, @denisname, @ledragon: you can do this too.)"
+      "status": "@Methuselah96: Everything looks good here. I am ready to merge this PR (at 2b9d098) on your behalf whenever you think it's ready.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n\n(@gustavderdrache, @borisyankov, @tomwanzek, @denisname, @ledragon: you can do this too.)"
     },
     {
       "tag": "stale-ping-98aca3-525f75c",

--- a/src/_tests/fixtures/50443/mutations.json
+++ b/src/_tests/fixtures/50443/mutations.json
@@ -29,5 +29,14 @@
         "pullRequestId": "MDExOlB1bGxSZXF1ZXN0NTUwNjA3Mzgw"
       }
     }
+  },
+  {
+    "mutation": "mutation ($input: UpdateIssueCommentInput!) {\n  updateIssueComment(input: $input) {\n    __typename\n  }\n}\n",
+    "variables": {
+      "input": {
+        "id": "MDEyOklzc3VlQ29tbWVudDc1NjM2ODA4NA==",
+        "body": "@shockdevv: Everything looks good here. I am ready to merge this PR (at 130c088) on your behalf whenever you think it's ready.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n\n<!--typescript_bot_merge-offer-->"
+      }
+    }
   }
 ]

--- a/src/_tests/fixtures/50443/result.json
+++ b/src/_tests/fixtures/50443/result.json
@@ -12,7 +12,7 @@
     },
     {
       "tag": "merge-offer",
-      "status": "@shockdevv Everything looks good here. Great job! I am ready to merge this PR (at 130c088) on your behalf.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n"
+      "status": "@shockdevv: Everything looks good here. I am ready to merge this PR (at 130c088) on your behalf whenever you think it's ready.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n"
     }
   ],
   "shouldClose": false,

--- a/src/_tests/fixtures/52848/mutations.json
+++ b/src/_tests/fixtures/52848/mutations.json
@@ -33,7 +33,7 @@
     "variables": {
       "input": {
         "subjectId": "MDExOlB1bGxSZXF1ZXN0NjM3MDk5NjE4",
-        "body": "@Runtu4378 Everything looks good here. Great job! I am ready to merge this PR (at 14499de) on your behalf.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n\n<!--typescript_bot_merge-offer-->"
+        "body": "@Runtu4378: Everything looks good here. I am ready to merge this PR (at 14499de) on your behalf whenever you think it's ready.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n\n<!--typescript_bot_merge-offer-->"
       }
     }
   }

--- a/src/_tests/fixtures/52848/result.json
+++ b/src/_tests/fixtures/52848/result.json
@@ -15,7 +15,7 @@
     },
     {
       "tag": "merge-offer",
-      "status": "@Runtu4378 Everything looks good here. Great job! I am ready to merge this PR (at 14499de) on your behalf.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n"
+      "status": "@Runtu4378: Everything looks good here. I am ready to merge this PR (at 14499de) on your behalf whenever you think it's ready.\n\nIf you'd like that to happen, please post a comment saying:\n\n> Ready to merge\n\nand I'll merge this PR almost instantly. Thanks for helping out! :heart:\n"
     }
   ],
   "shouldClose": false,

--- a/src/comments.ts
+++ b/src/comments.ts
@@ -96,8 +96,8 @@ export const OfferSelfMerge = deletedWhenNotPresent("merge-offer", tag =>
     (user: string, otherOwners: string[], abbrOid: string) => ({
         // Note: pr-info.ts searches for the `(at ${abbrOid})`
         tag, status: txt`
-            |@${user} Everything looks good here. Great job! I am ready to merge this PR
-             (at ${abbrOid}) on your behalf.
+            |@${user}: Everything looks good here. I am ready to merge this PR
+             (at ${abbrOid}) on your behalf whenever you think it's ready.
             |
             |If you'd like that to happen, please post a comment saying:
             |


### PR DESCRIPTION
Since I think that the "great job" part can be confusingly read as an
approving review for people who don't realize that it's not a human who
said it.  I also realized that it's what was making me accompany a PR
blessing with my own comment clarifying that I'm making it possible to
merge "if you're actually done" -- so I added the "whenever you think
it's ready".

Also, revise the comment on the `tooManyFiles` thing: I verified that
not only does this affect GQL queries too, but it also lies in the
resulting `totalCount` field.