### PR TITLE
Non-GitHub requests throwing errors

### DIFF
--- a/src/pr-trigger.ts
+++ b/src/pr-trigger.ts
@@ -44,9 +44,9 @@ export async function httpTrigger(context: Context, req: HttpRequest) {
     const evName = headers["x-github-event"], evAction = body.action;
 
     if (evName === "check_run" && evAction === "completed") {
-        context.log(`>>>>>> name: ${body?.check_run?.name}, sha: ${body?.check_run?.head_sha}`);
-        if (body?.check_run?.head_sha && body?.repository?.full_name === "DefinitelyTyped/DefinitelyTyped") {
-            const pr = await runQueryToGetPRMetadataForSHA1("DefinitelyTyped", "DefinitelyTyped", body?.check_run?.head_sha);
+        context.log(`>>>>>> name: ${body.check_run?.name}, sha: ${body.check_run?.head_sha}`);
+        if (body.check_run?.head_sha && body.repository?.full_name === "DefinitelyTyped/DefinitelyTyped") {
+            const pr = await runQueryToGetPRMetadataForSHA1("DefinitelyTyped", "DefinitelyTyped", body.check_run?.head_sha);
             if (pr) {
                 context.log(`>>>>>>>>> pr => num: ${pr.number}, title: "${pr.title}" closed: ${pr.closed}`);
             } else {

--- a/src/pr-trigger.ts
+++ b/src/pr-trigger.ts
@@ -36,12 +36,12 @@ class IgnoredBecause {
 
 export async function httpTrigger(context: Context, req: HttpRequest) {
     httpLog(context, req);
-    const { headers, body } = req, githubId = headers["x-github-delivery"];
-    const evName = headers["x-github-event"], evAction = body.action;
-
     if (!(await shouldRunRequest(context, req))) {
         return reply(context, 204, "Can't handle this request");
     }
+
+    const { headers, body } = req, githubId = headers["x-github-delivery"];
+    const evName = headers["x-github-event"], evAction = body.action;
 
     if (evName === "check_run" && evAction === "completed") {
         context.log(`>>>>>> name: ${body?.check_run?.name}, sha: ${body?.check_run?.head_sha}`);

--- a/src/util/verify.ts
+++ b/src/util/verify.ts
@@ -5,7 +5,7 @@ export async function httpLog(context: Context, req: HttpRequest) {
     const { headers, body } = req;
     const githubId = headers["x-github-delivery"];
     const event = headers["x-github-event"]!;
-    const action = body.action;
+    const action = body?.action;
     context.log(`>>> HTTP Trigger ${context.executionContext.functionName} [${
                   event}.${action
                   }; gh: ${githubId
@@ -15,11 +15,6 @@ export async function httpLog(context: Context, req: HttpRequest) {
 
 export async function shouldRunRequest(context: Context, req: HttpRequest, canHandleRequest?: (event: string, action: string) => boolean) {
     const isDev = process.env.AZURE_FUNCTIONS_ENVIRONMENT === "Development";
-    const { headers, body } = req;
-
-    const event = headers["x-github-event"]!;
-    const action = body.action;
-
     // For process.env.GITHUB_WEBHOOK_SECRET see
     // https://ms.portal.azure.com/#blade/WebsitesExtension/FunctionsIFrameBlade/id/%2Fsubscriptions%2F57bfeeed-c34a-4ffd-a06b-ccff27ac91b8%2FresourceGroups%2Fdtmergebot%2Fproviders%2FMicrosoft.Web%2Fsites%2FDTMergeBot
     const fromGitHub = await verifyIsFromGitHub(req);
@@ -27,6 +22,10 @@ export async function shouldRunRequest(context: Context, req: HttpRequest, canHa
         context.log("Request did not come from GitHub");
         return false;
     }
+
+    const { headers, body } = req;
+    const event = headers["x-github-event"]!;
+    const action = body.action;
 
     // Optional function for early bailing if it returns false
     if (canHandleRequest && !canHandleRequest(event, action)) {
@@ -39,10 +38,11 @@ export async function shouldRunRequest(context: Context, req: HttpRequest, canHa
 
 
 export async function verifyIsFromGitHub(req: HttpRequest) {
+    if (!req.headers["x-hub-signature-256"] || !req.rawBody) return false;
     const secret = process.env.GITHUB_WEBHOOK_SECRET;
 
     // For process.env.GITHUB_WEBHOOK_SECRET see
     // https://ms.portal.azure.com/#blade/WebsitesExtension/FunctionsIFrameBlade/id/%2Fsubscriptions%2F57bfeeed-c34a-4ffd-a06b-ccff27ac91b8%2FresourceGroups%2Fdtmergebot%2Fproviders%2FMicrosoft.Web%2Fsites%2FDTMergeBot
-    return await verify(secret!, req.rawBody, req.headers["x-hub-signature-256"]!);
+    return await verify(secret!, req.rawBody, req.headers["x-hub-signature-256"]);
 }
 


### PR DESCRIPTION
Miscellaneous requests to triggers will no longer throw an error.  
Fixes optional chaining consistency error.