### PR TITLE
If there are over 500 files changed, don't fetch more than that

### DIFF
--- a/src/_tests/cachedQueries.json
+++ b/src/_tests/cachedQueries.json
@@ -54,6 +54,11 @@
       "__typename": "Label"
     },
     {
+      "id": "LA_kwDOAFz6BM7QXorW",
+      "name": "Blocked upstream",
+      "__typename": "Label"
+    },
+    {
       "id": "MDU6TGFiZWwyMTU0ODE2NTQ5",
       "name": "Check Config",
       "__typename": "Label"
@@ -121,6 +126,11 @@
     {
       "id": "MDU6TGFiZWwyNDk1OTc2ODI5",
       "name": "Edits Owners",
+      "__typename": "Label"
+    },
+    {
+      "id": "LA_kwDOAFz6BM71Jg4R",
+      "name": "github_actions",
       "__typename": "Label"
     },
     {
@@ -256,6 +266,11 @@
     {
       "id": "MDU6TGFiZWwyOTUzOTk2NDAx",
       "name": "The CI is blocked",
+      "__typename": "Label"
+    },
+    {
+      "id": "LA_kwDOAFz6BM8AAAABEGgY4Q",
+      "name": "Too Many Files",
       "__typename": "Label"
     },
     {

--- a/src/_tests/fixtures/44424-1-travis-instantly-finished/mutations.json
+++ b/src/_tests/fixtures/44424-1-travis-instantly-finished/mutations.json
@@ -13,7 +13,8 @@
     "variables": {
       "input": {
         "labelIds": [
-          "MDU6TGFiZWwyOTUzOTk4NzE4"
+          "MDU6TGFiZWwyOTUzOTk4NzE4",
+          "LA_kwDOAFz6BM8AAAABEGgY4Q"
         ],
         "labelableId": "MDExOlB1bGxSZXF1ZXN0NDEyMjY1MDE2"
       }

--- a/src/_tests/fixtures/44424-1-travis-instantly-finished/result.json
+++ b/src/_tests/fixtures/44424-1-travis-instantly-finished/result.json
@@ -2,7 +2,8 @@
   "projectColumn": "Needs Maintainer Action",
   "labels": [
     "Possibly Edits Infrastructure",
-    "Author is Owner"
+    "Author is Owner",
+    "Too Many Files"
   ],
   "responseComments": [
     {

--- a/src/_tests/fixtures/44424-2-after-travis-second/mutations.json
+++ b/src/_tests/fixtures/44424-2-after-travis-second/mutations.json
@@ -13,7 +13,8 @@
     "variables": {
       "input": {
         "labelIds": [
-          "MDU6TGFiZWwyOTUzOTk4NzE4"
+          "MDU6TGFiZWwyOTUzOTk4NzE4",
+          "LA_kwDOAFz6BM8AAAABEGgY4Q"
         ],
         "labelableId": "MDExOlB1bGxSZXF1ZXN0NDEyMjY1MDE2"
       }

--- a/src/_tests/fixtures/44424-2-after-travis-second/result.json
+++ b/src/_tests/fixtures/44424-2-after-travis-second/result.json
@@ -2,7 +2,8 @@
   "projectColumn": "Waiting for Code Reviews",
   "labels": [
     "Possibly Edits Infrastructure",
-    "Author is Owner"
+    "Author is Owner",
+    "Too Many Files"
   ],
   "responseComments": [
     {

--- a/src/basic.ts
+++ b/src/basic.ts
@@ -44,6 +44,7 @@ export const LabelNames = [
     "Too Many Owners",
     "Untested Change",
     "Check Config",
+    "Too Many Files",
     "Huge Change",
     "Needs Actions Permission",
     ...StalenessKinds,

--- a/src/compute-pr-actions.ts
+++ b/src/compute-pr-actions.ts
@@ -252,6 +252,7 @@ export function process(prInfo: BotResult,
     label("Too Many Owners", info.tooManyOwners);
     label("Check Config", info.checkConfig);
     label("Untested Change", info.isUntested);
+    label("Too Many Files", info.tooManyFiles);
     label("Huge Change", info.hugeChange);
     if (info.staleness?.state === "nearly" || info.staleness?.state === "done") label(info.staleness.kind);
 

--- a/src/queries/pr-query.ts
+++ b/src/queries/pr-query.ts
@@ -4,6 +4,8 @@ import { PR, PRVariables, PR_repository_pullRequest_files_nodes } from "./schema
 import { PRFiles, PRFilesVariables } from "./schema/PRFiles";
 import { noNullish } from "../util/util";
 
+export const TOO_MANY_FILES = 500;
+
 // Note: If you want to work on this in local a copy of GraphiQL:
 // - Download the electron app: https://github.com/skevy/graphiql-app/releases
 // - Then set the headers:
@@ -185,7 +187,7 @@ export async function getPRInfo(prNumber: number) {
     return info;
 }
 
-export async function getPRInfoFirst(prNumber: number) {
+async function getPRInfoFirst(prNumber: number) {
     // The query can return a mergeable value of `UNKNOWN`, and then it takes a
     // while to get the actual value while GH refreshes the state (verified
     // with GH that this is expected).  So implement a simple retry thing to
@@ -240,7 +242,7 @@ async function getPRInfoRest(prNumber: number, endCursor: string | null,
         const newFiles = result.data.repository?.pullRequest?.files;
         if (!newFiles) return;
         files.push(...noNullish(newFiles.nodes));
-        if (!newFiles.pageInfo.hasNextPage) return;
+        if (files.length >= TOO_MANY_FILES || !newFiles.pageInfo.hasNextPage) return;
         endCursor = newFiles.pageInfo.endCursor;
     }
 }

--- a/src/run.ts
+++ b/src/run.ts
@@ -63,7 +63,7 @@ const show = (name: string, value: unknown) => {
 
 const start = async function () {
     console.log(`Getting open PRs.`);
-    const { prs: prs, cardIDs } = await getAllOpenPRsAndCardIDs();
+    const { prs, cardIDs } = await getAllOpenPRsAndCardIDs();
     //
     for (const pr of prs) {
         if (!shouldRunOn(pr)) continue;


### PR DESCRIPTION
This should avoid [the problem seen in this PR](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/62106) ***BUT*** it means that when there are too many files, it should be taken more seriously, since the bot wouldn't go over any of the extra ones.

So I also added a "Too Many Files" label and made it use it (otherwise it would only show an easy-to-miss line at the bottom of the welcome message).

Fixes #447. Probably. Maybe.