### PR TITLE
Change the daily workflow to be dispatched manually

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -1,12 +1,7 @@
 name: Daily Open PR Sync
 
-# For testing
-# on: push
-
-# For prod
 on:
-  schedule:
-    - cron: "37 */6 * * *"
+  workflow_dispatch: ~
 
 jobs:
   build:


### PR DESCRIPTION
The dispatch will be done from a scheduled workflow running in the main DT repository because scheduled workflows deactivate themselves automatically when the repo has not recent activity.

Refs #452 