### PR TITLE
Do not enforce compilerOptions `module`

### DIFF
--- a/src/pr-info.ts
+++ b/src/pr-info.ts
@@ -389,7 +389,6 @@ configSuspicious["tslint.json"] = makeChecker(
 configSuspicious["tsconfig.json"] = makeChecker(
     {
         compilerOptions: {
-            module: "commonjs",
             lib: ["es6"],
             noImplicitAny: true,
             noImplicitThis: true,

--- a/src/pr-info.ts
+++ b/src/pr-info.ts
@@ -405,7 +405,7 @@ configSuspicious["tsconfig.json"] = makeChecker(
             data.compilerOptions.lib = data.compilerOptions.lib.filter((value: unknown) =>
                 !(typeof value === "string" && value.toLowerCase() === "dom"));
         }
-        ["baseUrl", "typeRoots", "paths", "jsx"].forEach(k => delete data.compilerOptions[k]);
+        ["baseUrl", "typeRoots", "paths", "jsx", "module"].forEach(k => delete data.compilerOptions[k]);
         if (typeof data.compilerOptions?.target === "string" && data.compilerOptions.target.toLowerCase() === "es6") {
             delete data.compilerOptions.target;
         }


### PR DESCRIPTION
...so we can start migrating to `node16`. Once everything is migrated, we can put this back, enforcing `node16`.