### PR TITLE
fix: enable cors for api routes

### DIFF
--- a/src/functions/api.ts
+++ b/src/functions/api.ts
@@ -3,7 +3,8 @@ import { getPRInfo } from "../queries/pr-query";
 const headers = {
     "Content-Type": "text/json",
     "Access-Control-Allow-Methods": "GET",
-    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Origin": "https://www.typescriptlang.org",
+    "Vary": "Origin"
 };
 const notFound = (reason: string) => ({
     headers,
@@ -27,7 +28,7 @@ export async function httpTrigger(request: HttpRequest, context: InvocationConte
     // Extract the JSON from the comment
     const jsonText = welcomeComment.body.replace(/^[^]*```json\n([^]*)\n```[^]*$/, "$1");
     const response = { title: prInfo.title, ...JSON.parse(jsonText) };
-    return { status: 200, body: JSON.stringify(response) };
+    return { headers, status: 200, body: JSON.stringify(response) };
 }
 // Allow all others to access this, we can
 // tighten this down to the TS URLs if the route is abused

--- a/src/run.ts
+++ b/src/run.ts
@@ -94,7 +94,7 @@ const start = async function () {
             console.error(`  No PR with this number exists, (${JSON.stringify(info)})`);
             continue;
         }
-        let state: BotResult | undefined
+        let state: BotResult | undefined;
         try {
             state = await deriveStateForPR(prInfo);
         }


### PR DESCRIPTION
dtmergebot's API used to have CORS enabled. v2 broke [orta/playground-dt-review](https://github.com/orta/playground-dt-review/pull/6)

Considering that the plugin is still shown in comments on the dt repo, it'd be better to enable CORS. Currently that "You can test the changes of this PR in the Playground." thing doesn't work.

If abuse is a concern, we can limit it to just `typescriptlang.org`