### PR TITLE
Move daily schedule to this repo, keepalive

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -2,6 +2,8 @@ name: Daily Open PR Sync
 
 on:
   workflow_dispatch: ~
+  schedule:
+    - cron: '37 */6 * * *'
 
 jobs:
   build:
@@ -19,3 +21,12 @@ jobs:
       - run: node ./dist/run.js
         env:
           BOT_AUTH_TOKEN: ${{ secrets.BOT_AUTH_TOKEN }}
+
+  keepalive-job:
+    name: Keepalive Workflow
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: gautamkrishnar/keepalive-workflow@14b7c72e9af14bddbbc1022a6f0bd20b1eac2619 # v2.0.0


### PR DESCRIPTION
Rather than using a token to trigger this from the DT repo, just do the schedule here, then use a nifty action to keep the workflow from being disabled.