### PR TITLE
Downgrade functions back to 4.0.0-alpha.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@apollo/client": "^3.10.3",
-        "@azure/functions": "^4.4.0",
+        "@azure/functions": "4.0.0-alpha.10",
         "@definitelytyped/old-header-parser": "npm:@definitelytyped/header-parser@0.0.178",
         "@definitelytyped/utils": "^0.1.6",
         "dayjs": "^1.11.11",
@@ -207,11 +207,10 @@
       }
     },
     "node_modules/@azure/functions": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.4.0.tgz",
-      "integrity": "sha512-debidWolFTsfapsK53ftzLtXJc3dbYYPc9UqJoEm1GAj1lS7jFMARQnbfTQPDqBIhuJxLZ9D8WVvhIEV7Hifzw==",
+      "version": "4.0.0-alpha.10",
+      "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.0.0-alpha.10.tgz",
+      "integrity": "sha512-gxPDBHlF4+KUqy790REYp9Cqkg2ieaeJDUrw795OFVCBYBJP/QHTdMmtJ1UwNdHSmaJmdFmz7Sp124y3VMuclA==",
       "dependencies": {
-        "cookie": "^0.6.0",
         "long": "^4.0.0",
         "undici": "^5.13.0"
       },
@@ -4691,14 +4690,6 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true
-    },
-    "node_modules/cookie": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
-      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
-      "engines": {
-        "node": ">= 0.6"
-      }
     },
     "node_modules/core-js": {
       "version": "3.37.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@apollo/client": "^3.10.3",
-    "@azure/functions": "^4.4.0",
+    "@azure/functions": "4.0.0-alpha.10",
     "@definitelytyped/old-header-parser": "npm:@definitelytyped/header-parser@0.0.178",
     "@definitelytyped/utils": "^0.1.6",
     "dayjs": "^1.11.11",


### PR DESCRIPTION
Not sure why but the newer version of functions doesn't register any of the endpoints. Rolling that back for now.